### PR TITLE
Few fixes in testcases

### DIFF
--- a/robot/testsuites/integration/acl/acl_basic_public_container.robot
+++ b/robot/testsuites/integration/acl/acl_basic_public_container.robot
@@ -58,7 +58,7 @@ Check Public Container
                             Get Range Hash    ${SYSTEM_KEY_SN}    ${PUBLIC_CID}    ${S_OID_USER}    ${EMPTY}    0:256
 
     # Search
-    @{S_OBJ_PRIV} =	        Create List	      ${S_OID_USER}       ${S_OID_OTHER}    ${S_OID_SYS_SN}    ${S_OID_SYS_IR}
+    @{S_OBJ_PRIV} =	    Create List	      ${S_OID_USER}       ${S_OID_OTHER}    ${S_OID_SYS_SN}    ${S_OID_SYS_IR}
                             Search object     ${USER_KEY}         ${PUBLIC_CID}     --root    ${EMPTY}    ${EMPTY}    ${S_OBJ_PRIV}
                             Search object     ${OTHER_KEY}        ${PUBLIC_CID}     --root    ${EMPTY}    ${EMPTY}    ${S_OBJ_PRIV}
                             Search object     ${SYSTEM_KEY_IR}    ${PUBLIC_CID}     --root    ${EMPTY}    ${EMPTY}    ${S_OBJ_PRIV}

--- a/robot/testsuites/integration/acl/common_steps_acl_basic.robot
+++ b/robot/testsuites/integration/acl/common_steps_acl_basic.robot
@@ -44,10 +44,7 @@ Payment Operations
                             ...  Transaction accepted in block  ${TX_DEPOSIT}
                             Get Transaction                     ${TX_DEPOSIT}
 
-
 Create Containers
-    # Create containers:
-
                             Log	                   Create Private Container
     ${PRIV_CID_GEN} =       Create container       ${USER_KEY}        0x18888888              ${RULE_FOR_ALL}
                             Container Existing     ${USER_KEY}        ${PRIV_CID_GEN}
@@ -63,7 +60,6 @@ Create Containers
                             Set Global Variable    ${PRIV_CID}        ${PRIV_CID_GEN}
                             Set Global Variable    ${PUBLIC_CID}      ${PUBLIC_CID_GEN}
                             Set Global Variable    ${READONLY_CID}    ${READONLY_CID_GEN}
-
 
 Generate file
     [Arguments]             ${SIZE}

--- a/robot/testsuites/integration/acl/common_steps_acl_bearer.robot
+++ b/robot/testsuites/integration/acl/common_steps_acl_bearer.robot
@@ -14,8 +14,8 @@ ${RULE_FOR_ALL} =           REP 2 IN X CBF 1 SELECT 4 FROM * AS X
 
 Generate Keys
     # Generate new wallets
-    ${WALLET}       ${ADDR}         ${USER_KEY_GEN}  =   Init Wallet with Address    ${TEMP_DIR}
-    ${WALLET_OTH}   ${ADDR_OTH}     ${OTHER_KEY_GEN} =   Init Wallet with Address    ${TEMP_DIR}
+    ${WALLET}       ${ADDR}         ${USER_KEY_GEN} =   Init Wallet with Address    ${TEMP_DIR}
+    ${WALLET_OTH}   ${ADDR_OTH}     ${OTHER_KEY_GEN} =  Init Wallet with Address    ${TEMP_DIR}
 
     # Get pre-defined keys
     ${EACL_KEY_GEN} =	    Form WIF from String    782676b81a35c5f07325ec523e8521ee4946b6e5d4c6cd652dd0c3ba51ce03de
@@ -52,13 +52,13 @@ Payment Operations
 
 Create Container Public
                             Log	                  Create Public Container
-    ${PUBLIC_CID_GEN} =     Create container      ${USER_KEY}    0x0FFFFFFF
+    ${PUBLIC_CID_GEN} =     Create container      ${USER_KEY}    0x0FFFFFFF     ${COMMON_PLACEMENT_RULE}
     [Return]                ${PUBLIC_CID_GEN}
 
 
 Create Container Inaccessible
                             Log	                  Create Inaccessible Container
-    ${PUBLIC_CID_GEN} =     Create container      ${USER_KEY}     0x40000000
+    ${PUBLIC_CID_GEN} =     Create container      ${USER_KEY}     0x40000000     ${COMMON_PLACEMENT_RULE}
     [Return]                ${PUBLIC_CID_GEN}
 
 

--- a/robot/testsuites/integration/network/replication.robot
+++ b/robot/testsuites/integration/network/replication.robot
@@ -6,6 +6,9 @@ Library     ../${RESOURCES}/payment_neogo.py
 Library     ${KEYWORDS}/wallet.py
 Library     ../${RESOURCES}/utility_keywords.py
 
+*** Variables ***
+${PLACEMENT_RULE} = "REP 2 IN X CBF 1 SELECT 4 FROM * AS X"
+
 *** Test cases ***
 NeoFS Object Replication
     [Documentation]         Testcase to validate NeoFS object replication.
@@ -28,7 +31,7 @@ NeoFS Object Replication
                             ...  Transaction accepted in block    ${TX_DEPOSIT}
                             Get Transaction                       ${TX_DEPOSIT}
 
-    ${CID} =                Create container                      ${PRIV_KEY}    ${EMPTY}    REP 2 IN X CBF 1 SELECT 4 FROM * AS X
+    ${CID} =                Create container                      ${PRIV_KEY}    ${EMPTY}   ${PLACEMENT_RULE}
                             Container Existing                    ${PRIV_KEY}    ${CID}
 
 

--- a/robot/testsuites/integration/object/common_steps_object.robot
+++ b/robot/testsuites/integration/object/common_steps_object.robot
@@ -6,9 +6,10 @@ Library     ${KEYWORDS}/wallet.py
 *** Variables ***
 ${FILE_USR_HEADER} =    key1=1,key2=abc
 ${FILE_USR_HEADER_OTH} =    key1=2
-${UNEXIST_OID} =    B2DKvkHnLnPvapbDgfpU1oVUPuXQo5LTfKVxmNDZXQff
+${UNEXIST_OID} =        B2DKvkHnLnPvapbDgfpU1oVUPuXQo5LTfKVxmNDZXQff
 ${TRANSFER_AMOUNT} =    15
-${DEPOSIT_AMOUNT} =    10
+${DEPOSIT_AMOUNT} =     10
+${EMPTY_ACL} =          ""
 
 *** Keywords ***
 
@@ -34,13 +35,11 @@ Payment operations
                         Set Global Variable                   ${PRIV_KEY}    ${PRIV_KEY}
                         Set Global Variable                   ${ADDR}    ${ADDR}
 
-
 Prepare container
-    ${CID} =            Create container                      ${PRIV_KEY}
-                        Container Existing                    ${PRIV_KEY}    ${CID}
+    ${CID} =            Create container                      ${PRIV_KEY}   ${EMPTY_ACL}     ${COMMON_PLACEMENT_RULE}
+                        Container Existing                    ${PRIV_KEY}   ${CID}
 
                         Wait Until Keyword Succeeds           ${NEOFS_EPOCH_TIMEOUT}    ${MORPH_BLOCK_TIME}
                         ...  Expected Balance                 ${PRIV_KEY}    ${DEPOSIT_AMOUNT}    ${NEOFS_CREATE_CONTAINER_GAS_FEE}
 
                         Set Global Variable                   ${CID}    ${CID}
-

--- a/robot/testsuites/integration/object/object_storagegroup_complex.robot
+++ b/robot/testsuites/integration/object/object_storagegroup_complex.robot
@@ -6,7 +6,6 @@ Library     ../${RESOURCES}/payment_neogo.py
 Library     ../${RESOURCES}/utility_keywords.py
 Resource    common_steps_object.robot
 
-
 *** Test cases ***
 NeoFS Complex Storagegroup
     [Documentation]     Testcase to validate NeoFS operations with Storagegroup.
@@ -16,17 +15,16 @@ NeoFS Complex Storagegroup
     [Setup]             Create Temporary Directory
 
                         Payment operations
-                        Create container
+                        Prepare container
 
     ${FILE_S} =         Generate file of bytes            ${COMPLEX_OBJ_SIZE}
     ${FILE_HASH_S} =    Get file hash                     ${FILE_S}
-
 
     # Put two Simple Object
     ${S_OID_1} =        Put object    ${PRIV_KEY}    ${FILE_S}    ${CID}    ${EMPTY}    ${EMPTY}
     ${S_OID_2} =        Put object    ${PRIV_KEY}    ${FILE_S}    ${CID}    ${EMPTY}    ${FILE_USR_HEADER}
 
-    @{S_OBJ_ALL} =	    Create List    ${S_OID_1}    ${S_OID_2}
+    @{S_OBJ_ALL} =	Create List    ${S_OID_1}    ${S_OID_2}
 
                         Log    Storage group with 1 object
     ${SG_OID_1} =       Put Storagegroup    ${PRIV_KEY}    ${CID}   ${EMPTY}    ${S_OID_1}
@@ -38,7 +36,6 @@ NeoFS Complex Storagegroup
                         Run Keyword And Expect Error    *
                         ...  Get Storagegroup    ${PRIV_KEY}    ${CID}    ${SG_OID_1}   ${EMPTY}    ${COMPLEX_OBJ_SIZE}    @{SPLIT_OBJ_1}
                         List Storagegroup    ${PRIV_KEY}    ${CID}   ${EMPTY}    @{EMPTY}
-
 
                         Log    Storage group with 2 objects
     ${SG_OID_2} =       Put Storagegroup    ${PRIV_KEY}    ${CID}    ${EMPTY}    @{S_OBJ_ALL}

--- a/robot/testsuites/integration/object/object_storagegroup_simple.robot
+++ b/robot/testsuites/integration/object/object_storagegroup_simple.robot
@@ -16,7 +16,7 @@ NeoFS Simple Storagegroup
     [Setup]             Create Temporary Directory
 
                         Payment operations
-                        Create container
+                        Prepare container
 
     ${FILE_S} =         Generate file of bytes            ${SIMPLE_OBJ_SIZE}
     ${FILE_HASH_S} =    Get file hash                     ${FILE_S}

--- a/robot/testsuites/integration/services/http_gate.robot
+++ b/robot/testsuites/integration/services/http_gate.robot
@@ -1,6 +1,5 @@
 *** Settings ***
 Variables   ../../../variables/common.py
-<<<<<<< HEAD
 
 Library     ../${RESOURCES}/neofs.py
 Library     ../${RESOURCES}/payment_neogo.py
@@ -8,6 +7,8 @@ Library     ../${RESOURCES}/gates.py
 Library     ${KEYWORDS}/wallet.py
 Library     ../${RESOURCES}/utility_keywords.py
 
+*** Variables ***
+${PLACEMENT_RULE} = "REP 1 IN X CBF 1 SELECT 1 FROM * AS X"
 
 *** Test cases ***
 
@@ -31,7 +32,7 @@ NeoFS HTTP Gateway
                         ...  Transaction accepted in block  ${TX_DEPOSIT}
                         Get Transaction                     ${TX_DEPOSIT}
 
-    ${CID} =            Create container                    ${PRIV_KEY}    public    REP 1 IN X CBF 1 SELECT 1 FROM * AS X
+    ${CID} =            Create container                    ${PRIV_KEY}    public   ${PLACEMENT_RULE}
                         Wait Until Keyword Succeeds         2 min          30 sec
                         ...  Container Existing             ${PRIV_KEY}    ${CID}
 

--- a/robot/variables/common.py
+++ b/robot/variables/common.py
@@ -53,4 +53,6 @@ GAS_HASH = os.getenv("GAS_HASH", '0xd2a4cff31913016155e38e474a2c06d08be276cf')
 NEOFS_CONTRACT = (os.getenv("NEOFS_CONTRACT") if os.getenv("NEOFS_CONTRACT")
              else os.getenv("NEOFS_IR_CONTRACTS_NEOFS", 'cfe89912c457754b7eb1f89781dc74bb3e0070bf'))
 
+COMMON_PLACEMENT_RULE = "REP 2 IN X CBF 1 SELECT 2 FROM * AS X"
+
 TEMP_DIR = os.getenv("TEMP_DIR", "TemporaryDir/")


### PR DESCRIPTION
- `Create container` -> `Prepare container` misprint fixed
- removed default placement rule from `Create container` keyword
- common placement rule added to variables and is used explicitly in testsuites
- retrieving CID and OID from cli output is done using `str.split()` instead of using regular expressions
- alignments, removed blank lines and comments