### PR TITLE
TEMP_DIR -> ASSETS_DIR

### DIFF
--- a/robot/resources/lib/neofs.py
+++ b/robot/resources/lib/neofs.py
@@ -193,7 +193,7 @@ def get_epoch(private_key: str):
 
 @keyword('Set eACL')
 def set_eacl(private_key: str, cid: str, eacl: str, add_keys: str = ""):
-    file_path = TEMP_DIR + eacl
+    file_path = f"{ASSETS_DIR}/{eacl}"
     cmd = (
         f'{NEOFS_CLI_EXEC} --rpc-endpoint {NEOFS_ENDPOINT} --key {private_key} '
         f'container set-eacl --cid {cid} --table {file_path} {add_keys}'
@@ -214,7 +214,7 @@ def form_bearertoken_file(private_key: str, cid: str, file_name: str, eacl_oper_
     cid_base64 = base64.b64encode(cid_base58_b).decode("utf-8")
     eacl = get_eacl(private_key, cid)
     json_eacl = {}
-    file_path = TEMP_DIR + file_name
+    file_path = f"{ASSETS_DIR}/{file_name}"
 
     if eacl:
         res_json = re.split(r'[\s\n]+Signature:', eacl)
@@ -267,7 +267,7 @@ def form_bearertoken_file(private_key: str, cid: str, file_name: str, eacl_oper_
 @keyword('Form eACL json common file')
 def form_eacl_json_common_file(file_name, eacl_oper_list ):
     # Input role can be Role (USER, SYSTEM, OTHERS) or public key.
-    file_path = TEMP_DIR + file_name
+    file_path = f"{ASSETS_DIR}/{file_name}"
     eacl = {"records":[]}
 
     logger.info(eacl_oper_list)
@@ -299,12 +299,12 @@ def get_range(private_key: str, cid: str, oid: str, range_file: str, bearer: str
         range_cut: str, options:str=""):
     bearer_token = ""
     if bearer:
-        bearer_token = f"--bearer {TEMP_DIR}{bearer}"
+        bearer_token = f"--bearer {ASSETS_DIR}/{bearer}"
 
     Cmd = (
         f'{NEOFS_CLI_EXEC} --rpc-endpoint {NEOFS_ENDPOINT} --key {private_key} '
         f'object range --cid {cid} --oid {oid} {bearer_token} --range {range_cut} '
-        f'--file {TEMP_DIR}{range_file} {options}'
+        f'--file {ASSETS_DIR}/{range_file} {options}'
     )
     logger.info("Cmd: %s" % Cmd)
 
@@ -374,7 +374,7 @@ def search_object(private_key: str, cid: str, keys: str, bearer: str, filters: s
     filters_result = ""
 
     if bearer:
-        bearer_token = f"--bearer {TEMP_DIR}{bearer}"
+        bearer_token = f"--bearer {ASSETS_DIR}/{bearer}"
     if filters:
         for filter_item in filters.split(','):
             filter_item = re.sub(r'=', ' EQ ', filter_item)
@@ -625,7 +625,7 @@ def head_object(private_key: str, cid: str, oid: str, bearer_token: str="",
     user_headers:str="", options:str="", endpoint: str="", ignore_failure: bool = False):
 
     if bearer_token:
-        bearer_token = f"--bearer {TEMP_DIR}{bearer_token}"
+        bearer_token = f"--bearer {ASSETS_DIR}/{bearer_token}"
     if endpoint == "":
         endpoint = NEOFS_ENDPOINT
 
@@ -762,7 +762,7 @@ def parse_object_system_header(header: str):
 def delete_object(private_key: str, cid: str, oid: str, bearer: str, options: str=""):
     bearer_token = ""
     if bearer:
-        bearer_token = f"--bearer {TEMP_DIR}{bearer}"
+        bearer_token = f"--bearer {ASSETS_DIR}/{bearer}"
 
     object_cmd = (
         f'{NEOFS_CLI_EXEC} --rpc-endpoint {NEOFS_ENDPOINT} --key {private_key} '
@@ -809,7 +809,7 @@ def put_object(private_key: str, path: str, cid: str, bearer: str, user_headers:
         user_headers = f"--attributes {user_headers}"
 
     if bearer:
-        bearer = f"--bearer {TEMP_DIR}{bearer}"
+        bearer = f"--bearer {ASSETS_DIR}/{bearer}"
 
     putobject_cmd = (
         f'{NEOFS_CLI_EXEC} --rpc-endpoint {endpoint} --key {private_key} object '
@@ -892,7 +892,7 @@ def find_in_nodes_Log(line: str, nodes_logs_time: dict):
 def get_range_hash(private_key: str, cid: str, oid: str, bearer_token: str,
         range_cut: str, options: str=""):
     if bearer_token:
-        bearer_token = f"--bearer {TEMP_DIR}{bearer_token}"
+        bearer_token = f"--bearer {ASSETS_DIR}/{bearer_token}"
 
     object_cmd = (
         f'{NEOFS_CLI_EXEC} --rpc-endpoint {NEOFS_ENDPOINT} --key {private_key} '
@@ -911,7 +911,7 @@ def get_range_hash(private_key: str, cid: str, oid: str, bearer_token: str,
 def get_object(private_key: str, cid: str, oid: str, bearer_token: str,
     write_object: str, endpoint: str="", options: str="" ):
 
-    file_path = TEMP_DIR + write_object
+    file_path = f"{ASSETS_DIR}/{write_object}"
 
     logger.info("Going to put the object")
     if not endpoint:
@@ -919,7 +919,7 @@ def get_object(private_key: str, cid: str, oid: str, bearer_token: str,
 
 
     if bearer_token:
-        bearer_token = f"--bearer {TEMP_DIR}{bearer_token}"
+        bearer_token = f"--bearer {ASSETS_DIR}/{bearer_token}"
 
     object_cmd = (
         f'{NEOFS_CLI_EXEC} --rpc-endpoint {endpoint} --key {private_key} '
@@ -943,7 +943,7 @@ def put_storagegroup(private_key: str, cid: str, bearer_token: str="", *oid_list
     cmd_oid_line = ",".join(oid_list)
 
     if bearer_token:
-        bearer_token = f"--bearer {TEMP_DIR}{bearer_token}"
+        bearer_token = f"--bearer {ASSETS_DIR}/{bearer_token}"
 
     object_cmd = (
         f'{NEOFS_CLI_EXEC} --rpc-endpoint {NEOFS_ENDPOINT} --key {private_key} storagegroup '
@@ -965,7 +965,7 @@ def put_storagegroup(private_key: str, cid: str, bearer_token: str="", *oid_list
 def list_storagegroup(private_key: str, cid: str, bearer_token: str="", *expected_list):
 
     if bearer_token:
-        bearer_token = f"--bearer {TEMP_DIR}{bearer_token}"
+        bearer_token = f"--bearer {ASSETS_DIR}/{bearer_token}"
 
     object_cmd = (
         f'{NEOFS_CLI_EXEC} --rpc-endpoint {NEOFS_ENDPOINT} --key {private_key} '
@@ -996,7 +996,7 @@ def list_storagegroup(private_key: str, cid: str, bearer_token: str="", *expecte
 def get_storagegroup(private_key: str, cid: str, oid: str, bearer_token: str, expected_size,  *expected_objects_list):
 
     if bearer_token:
-        bearer_token = f"--bearer {TEMP_DIR}{bearer_token}"
+        bearer_token = f"--bearer {ASSETS_DIR}/{bearer_token}"
 
     object_cmd = f'{NEOFS_CLI_EXEC} --rpc-endpoint {NEOFS_ENDPOINT} --key {private_key} storagegroup get --cid {cid} --id {oid} {bearer_token}'
     logger.info(f"Cmd: {object_cmd}")
@@ -1028,7 +1028,7 @@ def get_storagegroup(private_key: str, cid: str, oid: str, bearer_token: str, ex
 def delete_storagegroup(private_key: str, cid: str, oid: str, bearer_token: str=""):
 
     if bearer_token:
-        bearer_token = f"--bearer {TEMP_DIR}{bearer_token}"
+        bearer_token = f"--bearer {ASSETS_DIR}/{bearer_token}"
 
     object_cmd = (
         f'{NEOFS_CLI_EXEC} --rpc-endpoint {NEOFS_ENDPOINT} --key {private_key} storagegroup '

--- a/robot/resources/lib/payment_operations.robot
+++ b/robot/resources/lib/payment_operations.robot
@@ -12,8 +12,8 @@ ${DEPOSIT_AMOUNT} =     ${25}
 *** Keywords ***
 
 Generate Keys
-    ${WALLET}   ${ADDR}     ${USER_KEY_GEN} =   Init Wallet with Address    ${TEMP_DIR}
-    ${WALLET_OTH}   ${ADDR_OTH}     ${OTHER_KEY_GEN} =   Init Wallet with Address    ${TEMP_DIR}
+    ${WALLET}   ${ADDR}     ${USER_KEY_GEN} =   Init Wallet with Address    ${ASSETS_DIR}
+    ${WALLET_OTH}   ${ADDR_OTH}     ${OTHER_KEY_GEN} =   Init Wallet with Address    ${ASSETS_DIR}
 
     Set Global Variable     ${USER_KEY}          ${USER_KEY_GEN}
     Set Global Variable     ${OTHER_KEY}         ${OTHER_KEY_GEN}
@@ -37,3 +37,9 @@ Payment Operations
     ${TX_DEPOSIT} =         NeoFS Deposit           ${WIF}      ${DEPOSIT_AMOUNT}
                             Wait Until Keyword Succeeds         ${MAINNET_TIMEOUT}  ${MAINNET_BLOCK_TIME}
                             ...  Transaction accepted in block  ${TX_DEPOSIT}
+    # Now we have TX in main chain, but deposit might not propagate into the side chain yet.
+    # For certainty, sleeping during one morph block.
+    Sleep                   ${MORPH_BLOCK_TIME}
+
+    ${NEOFS_BALANCE} =  Get NeoFS Balance       ${WIF}
+    Should Be Equal As Numbers                  ${NEOFS_BALANCE}    ${DEPOSIT_AMOUNT}

--- a/robot/resources/lib/setup_teardown.robot
+++ b/robot/resources/lib/setup_teardown.robot
@@ -1,0 +1,16 @@
+*** Settings ***
+Variables   ../../variables/common.py
+
+Library     OperatingSystem
+
+Library     utility_keywords.py
+
+*** Keywords ***
+
+Setup
+    Create Directory    ${ASSETS_DIR}
+
+Teardown
+    [Arguments]     ${LOGFILE}
+    Remove Directory    ${ASSETS_DIR}   True
+    Get Docker Logs     ${LOGFILE}

--- a/robot/resources/lib/utility_keywords.py
+++ b/robot/resources/lib/utility_keywords.py
@@ -2,7 +2,6 @@
 
 import docker
 import os
-import shutil
 import tarfile
 import uuid
 
@@ -22,11 +21,11 @@ def generate_file_of_bytes(size: str) -> str:
     :param size:        the size in bytes, can be declared as 6e+6 for example
     """
     size = int(float(size))
-    filename = TEMP_DIR + str(uuid.uuid4())
+    filename = f"{os.getcwd()}/{ASSETS_DIR}/{str(uuid.uuid4())}"
     with open(filename, 'wb') as fout:
         fout.write(os.urandom(size))
-    logger.info(f"Random binary file with size {size} bytes has been generated.")
-    return f"{os.getcwd()}/{filename}"
+    logger.info(f"file with size {size} bytes has been generated: {filename}")
+    return filename
 
 @keyword('Get Docker Logs')
 def get_container_logs(testcase_name: str) -> None:
@@ -43,20 +42,3 @@ def get_container_logs(testcase_name: str) -> None:
             tar.add(file_name)
             os.remove(file_name)
     tar.close()
-
-@keyword('Cleanup Files')
-def cleanup_file() -> None:
-    if os.path.isdir(TEMP_DIR):
-        try:
-            shutil.rmtree(TEMP_DIR)
-            logger.info(f"File '{TEMP_DIR}' has been deleted.")
-        except OSError as e:
-            raise Exception(f"Error: '{TEMP_DIR}' - {e.strerror}.")
-    else:
-        logger.warn(f"Error: '{TEMP_DIR}' file not found")
-
-@keyword('Create Temporary Directory')
-def create_temp_dir() -> None:
-    if not os.path.exists(TEMP_DIR):
-        os.makedirs(TEMP_DIR)
-        logger.info(f"Created temporary directory: {TEMP_DIR}")

--- a/robot/testsuites/integration/acl/acl_basic_private_container.robot
+++ b/robot/testsuites/integration/acl/acl_basic_private_container.robot
@@ -2,10 +2,10 @@
 Variables       ../../../variables/common.py
 Library         ../${RESOURCES}/neofs.py
 Library         ../${RESOURCES}/payment_neogo.py
-Library         ../${RESOURCES}/utility_keywords.py
 
 Resource        common_steps_acl_basic.robot
 Resource        ../${RESOURCES}/payment_operations.robot
+Resource        ../${RESOURCES}/setup_teardown.robot
 
 
 *** Test cases ***
@@ -14,7 +14,7 @@ Basic ACL Operations for Private Container
     [Tags]                  ACL  NeoFS  NeoCLI
     [Timeout]               20 min
 
-    [Setup]                 Create Temporary Directory
+    [Setup]                 Setup
 
                             Generate Keys
 
@@ -26,7 +26,7 @@ Basic ACL Operations for Private Container
                             Generate file    ${COMPLEX_OBJ_SIZE}
                             Check Private Container
 
-    [Teardown]              Cleanup
+    [Teardown]              Teardown    acl_basic_private_container
 
 
 
@@ -91,7 +91,3 @@ Check Private Container
                             Run Keyword And Expect Error        *
                             ...  Delete object                  ${SYSTEM_KEY_SN}    ${PRIV_CID}    ${S_OID_USER}    ${EMPTY}
                             Delete object                       ${USER_KEY}         ${PRIV_CID}    ${S_OID_USER}    ${EMPTY}
-
-
-Cleanup
-                            Cleanup Files

--- a/robot/testsuites/integration/acl/acl_basic_private_container_storagegroup.robot
+++ b/robot/testsuites/integration/acl/acl_basic_private_container_storagegroup.robot
@@ -1,12 +1,13 @@
 *** Settings ***
 Variables       ../../../variables/common.py
-Library     Collections
 Library     ../${RESOURCES}/neofs.py
 Library     ../${RESOURCES}/payment_neogo.py
-Library     ../${RESOURCES}/utility_keywords.py
+
+Library     Collections
 
 Resource    common_steps_acl_basic.robot
 Resource    ../${RESOURCES}/payment_operations.robot
+Resource    ../${RESOURCES}/setup_teardown.robot
 
 
 *** Test cases ***
@@ -15,7 +16,7 @@ Basic ACL Operations for Private Container
     [Tags]                  ACL  NeoFS  NeoCLI
     [Timeout]               20 min
 
-    [Setup]                 Create Temporary Directory
+    [Setup]                 Setup
 
                             Generate Keys
 
@@ -27,7 +28,7 @@ Basic ACL Operations for Private Container
                             Generate file    ${COMPLEX_OBJ_SIZE}
                             Check Private Container    Complex
 
-    [Teardown]              Cleanup
+    [Teardown]              Teardown    acl_basic_private_container_storagegroup
 
 
 *** Keywords ***
@@ -83,9 +84,3 @@ Check Private Container
 
                         Run Keyword And Expect Error        *
                         ...  Delete Storagegroup    ${SYSTEM_KEY_IR}    ${PRIV_CID}    ${SG_OID_INV}    ${EMPTY}
-
-
-
-Cleanup
-                            Cleanup Files
-                            Get Docker Logs    acl_basic

--- a/robot/testsuites/integration/acl/acl_basic_public_container.robot
+++ b/robot/testsuites/integration/acl/acl_basic_public_container.robot
@@ -2,10 +2,10 @@
 Variables    ../../../variables/common.py
 Library      ../${RESOURCES}/neofs.py
 Library      ../${RESOURCES}/payment_neogo.py
-Library      ../${RESOURCES}/utility_keywords.py
 
 Resource     common_steps_acl_basic.robot
 Resource     ../${RESOURCES}/payment_operations.robot
+Resource     ../${RESOURCES}/setup_teardown.robot
 
 
 *** Test cases ***
@@ -14,7 +14,7 @@ Basic ACL Operations for Public Container
     [Tags]                  ACL  NeoFS  NeoCLI
     [Timeout]               20 min
 
-    [Setup]                 Create Temporary Directory
+    [Setup]                 Setup
 
                             Generate Keys
 
@@ -26,7 +26,7 @@ Basic ACL Operations for Public Container
                             Generate file    ${COMPLEX_OBJ_SIZE}
                             Check Public Container
 
-    [Teardown]              Cleanup
+    [Teardown]              Teardown    acl_basic_public_container
 
 
 *** Keywords ***
@@ -87,8 +87,3 @@ Check Public Container
                             Delete object     ${OTHER_KEY}        ${PUBLIC_CID}    ${S_OID_SYS_SN}    ${EMPTY}
                             Delete object     ${SYSTEM_KEY_IR}    ${PUBLIC_CID}    ${S_OID_USER}      ${EMPTY}
                             Delete object     ${SYSTEM_KEY_SN}    ${PUBLIC_CID}    ${S_OID_OTHER}     ${EMPTY}
-
-
-
-Cleanup
-                            Cleanup Files

--- a/robot/testsuites/integration/acl/acl_basic_public_container_storagegroup.robot
+++ b/robot/testsuites/integration/acl/acl_basic_public_container_storagegroup.robot
@@ -3,10 +3,10 @@ Variables    ../../../variables/common.py
 
 Library      ../${RESOURCES}/neofs.py
 Library      ../${RESOURCES}/payment_neogo.py
-Library      ../${RESOURCES}/utility_keywords.py
 
 Resource     common_steps_acl_basic.robot
 Resource     ../${RESOURCES}/payment_operations.robot
+Resource     ../${RESOURCES}/setup_teardown.robot
 
 
 *** Test cases ***
@@ -15,7 +15,7 @@ Basic ACL Operations for Public Container
     [Tags]                  ACL  NeoFS  NeoCLI
     [Timeout]               20 min
 
-    [Setup]                 Create Temporary Directory
+    [Setup]                 Setup
 
                             Generate Keys
 
@@ -27,7 +27,7 @@ Basic ACL Operations for Public Container
                             Generate file    ${COMPLEX_OBJ_SIZE}
                             Check Public Container    Complex
 
-    [Teardown]              Cleanup
+    [Teardown]              Teardown    acl_basic_public_container_storagegroup
 
 
 *** Keywords ***
@@ -51,8 +51,3 @@ Check Public Container
                             Get Storagegroup    ${role_key}    ${PUBLIC_CID}    ${SG_OID_1}   ${EMPTY}    ${EMPTY}    @{EXPECTED_OIDS}
                             Delete Storagegroup    ${role_key}    ${PUBLIC_CID}    ${SG_OID_1}    ${EMPTY}
     END
-
-
-Cleanup
-                            Cleanup Files
-                            Get Docker Logs    acl_basic

--- a/robot/testsuites/integration/acl/acl_basic_readonly_container.robot
+++ b/robot/testsuites/integration/acl/acl_basic_readonly_container.robot
@@ -2,10 +2,10 @@
 Variables    ../../../variables/common.py
 Library      ../${RESOURCES}/neofs.py
 Library      ../${RESOURCES}/payment_neogo.py
-Library      ../${RESOURCES}/utility_keywords.py
 
 Resource     common_steps_acl_basic.robot
 Resource     ../${RESOURCES}/payment_operations.robot
+Resource     ../${RESOURCES}/setup_teardown.robot
 
 
 *** Test cases ***
@@ -14,7 +14,7 @@ Basic ACL Operations for Read-Only Container
     [Tags]                  ACL  NeoFS  NeoCLI
     [Timeout]               20 min
 
-    [Setup]                 Create Temporary Directory
+    [Setup]                 Setup
 
                             Generate Keys
 
@@ -26,7 +26,7 @@ Basic ACL Operations for Read-Only Container
                             Generate file    ${COMPLEX_OBJ_SIZE}
                             Check Read-Only Container    Complex
 
-    [Teardown]              Cleanup
+    [Teardown]              Teardown    acl_basic_readonly_container
 
 
 *** Keywords ***
@@ -112,8 +112,3 @@ Check Read-Only Container
                             Run Keyword And Expect Error        *
                             ...  Delete object                  ${SYSTEM_KEY_SN}    ${READONLY_CID}    ${S_OID_USER}    ${EMPTY}
                             Delete object                       ${USER_KEY}         ${READONLY_CID}    ${S_OID_USER}    ${EMPTY}
-
-
-
-Cleanup
-                            Cleanup Files

--- a/robot/testsuites/integration/acl/acl_basic_readonly_container_storagegroup.robot
+++ b/robot/testsuites/integration/acl/acl_basic_readonly_container_storagegroup.robot
@@ -3,10 +3,10 @@ Variables    ../../../variables/common.py
 
 Library      ../${RESOURCES}/neofs.py
 Library      ../${RESOURCES}/payment_neogo.py
-Library      ../${RESOURCES}/utility_keywords.py
 
 Resource     common_steps_acl_basic.robot
 Resource     ../${RESOURCES}/payment_operations.robot
+Resource     ../${RESOURCES}/setup_teardown.robot
 
 
 *** Test cases ***
@@ -15,7 +15,7 @@ Basic ACL Operations for Read-Only Container
     [Tags]                  ACL  NeoFS  NeoCLI
     [Timeout]               20 min
 
-    [Setup]                 Create Temporary Directory
+    [Setup]                 Setup
 
                             Generate Keys
 
@@ -27,7 +27,7 @@ Basic ACL Operations for Read-Only Container
                             Generate file    ${COMPLEX_OBJ_SIZE}
                             Check Read-Only Container    Complex
 
-    [Teardown]              Cleanup
+    [Teardown]              Teardown    acl_basic_readonly_container_storagegroup
 
 
 *** Keywords ***
@@ -68,10 +68,3 @@ Check Read-Only Container
                         Get Storagegroup    ${SYSTEM_KEY_IR}    ${READONLY_CID}    ${SG_OID_INV}   ${EMPTY}    ${EMPTY}    @{EXPECTED_OIDS}
                         Run Keyword And Expect Error        *
                         ...  Delete Storagegroup    ${SYSTEM_KEY_IR}    ${READONLY_CID}    ${SG_OID_INV}    ${EMPTY}
-
-
-
-
-Cleanup
-                            Cleanup Files
-                            Get Docker Logs    acl_basic

--- a/robot/testsuites/integration/acl/acl_bearer_allow.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_allow.robot
@@ -2,11 +2,11 @@
 Variables   ../../../variables/common.py
 Library     ../${RESOURCES}/neofs.py
 Library     ../${RESOURCES}/payment_neogo.py
-Library     ../${RESOURCES}/utility_keywords.py
 Library     Collections
 
 Resource    common_steps_acl_bearer.robot
 Resource    ../${RESOURCES}/payment_operations.robot
+Resource    ../${RESOURCES}/setup_teardown.robot
 
 
 *** Test cases ***
@@ -15,7 +15,7 @@ BearerToken Operations
     [Tags]                  ACL  NeoFS  NeoCLI BearerToken
     [Timeout]               20 min
 
-    [Setup]                 Create Temporary Directory
+    [Setup]                 Setup
 
                             Generate Keys
                             Generate eACL Keys
@@ -30,7 +30,7 @@ BearerToken Operations
                             Check eACL Deny and Allow All Bearer
 
 
-    [Teardown]              Cleanup
+    [Teardown]              Teardown    acl_bearer_allow
 
 
 
@@ -87,6 +87,3 @@ Check eACL Deny and Allow All Bearer
                             Head object         ${USER_KEY}    ${CID}       ${S_OID_USER}    bearer_allow_all_user
                             Get Range           ${USER_KEY}    ${CID}       ${S_OID_USER}    s_get_range              bearer_allow_all_user    0:256
                             Delete object       ${USER_KEY}    ${CID}       ${S_OID_USER}    bearer_allow_all_user
-
-Cleanup
-                            Cleanup Files

--- a/robot/testsuites/integration/acl/acl_bearer_allow_storagegroup.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_allow_storagegroup.robot
@@ -2,11 +2,11 @@
 Variables   ../../../variables/common.py
 Library     ../${RESOURCES}/neofs.py
 Library     ../${RESOURCES}/payment_neogo.py
-Library     ../${RESOURCES}/utility_keywords.py
 
 Library     Collections
 Resource    common_steps_acl_bearer.robot
 Resource    ../${RESOURCES}/payment_operations.robot
+Resource    ../${RESOURCES}/setup_teardown.robot
 
 
 *** Test cases ***
@@ -15,7 +15,7 @@ BearerToken Operations
     [Tags]                  ACL  NeoFS  NeoCLI BearerToken
     [Timeout]               20 min
 
-    [Setup]                 Create Temporary Directory
+    [Setup]                 Setup
 
                             Generate Keys
                             Generate eACL Keys
@@ -30,7 +30,7 @@ BearerToken Operations
                             Check eACL Deny and Allow All Bearer    Complex
 
 
-    [Teardown]              Cleanup
+    [Teardown]              Teardown    acl_bearer_allow_storagegroup
 
 
 
@@ -83,8 +83,3 @@ Check eACL Deny and Allow All Bearer
                             List Storagegroup    ${USER_KEY}    ${CID}    bearer_allow_all_user    ${SG_OID_NEW}  ${SG_OID_INV}
                             Get Storagegroup    ${USER_KEY}    ${CID}    ${SG_OID_INV}   bearer_allow_all_user    ${EMPTY}    @{EXPECTED_OIDS}
                             Delete Storagegroup    ${USER_KEY}    ${CID}    ${SG_OID_INV}    bearer_allow_all_user
-
-
-Cleanup
-                            Cleanup Files
-                            Get Docker Logs    acl_bearer

--- a/robot/testsuites/integration/acl/acl_bearer_compound.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_compound.robot
@@ -2,11 +2,12 @@
 Variables   ../../../variables/common.py
 Library     ../${RESOURCES}/neofs.py
 Library     ../${RESOURCES}/payment_neogo.py
-Library     ../${RESOURCES}/utility_keywords.py
 
 Library     Collections
+
 Resource    common_steps_acl_bearer.robot
 Resource    ../${RESOURCES}/payment_operations.robot
+Resource    ../${RESOURCES}/setup_teardown.robot
 
 *** Test cases ***
 BearerToken Operations for Сompound Operations
@@ -14,7 +15,7 @@ BearerToken Operations for Сompound Operations
     [Tags]                  ACL  NeoFS  NeoCLI BearerToken
     [Timeout]               20 min
 
-    [Setup]                 Create Temporary Directory
+    [Setup]                 Setup
 
                             Generate Keys
                             Generate eACL Keys
@@ -29,7 +30,7 @@ BearerToken Operations for Сompound Operations
                             Generate file    ${COMPLEX_OBJ_SIZE}
                             Check Сompound Operations
 
-    [Teardown]              Cleanup
+    [Teardown]              Teardown    acl_bearer_compound
 
 
 *** Keywords ***
@@ -133,7 +134,3 @@ Check Bearer Сompound Get Range Hash
                             ...  Get object      ${KEY}    ${CID}    ${S_OID_USER}    bearer_allow    local_file_eacl
 
                             Get Range Hash                  ${KEY}    ${CID}    ${S_OID_USER}    bearer_allow    0:256
-
-
-Cleanup
-                            Cleanup Files

--- a/robot/testsuites/integration/acl/acl_bearer_filter_oid_equal.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_filter_oid_equal.robot
@@ -2,11 +2,11 @@
 Variables   ../../../variables/common.py
 Library     ../${RESOURCES}/neofs.py
 Library     ../${RESOURCES}/payment_neogo.py
-Library     ../${RESOURCES}/utility_keywords.py
 
 Library     Collections
 Resource    common_steps_acl_bearer.robot
 Resource    ../${RESOURCES}/payment_operations.robot
+Resource    ../${RESOURCES}/setup_teardown.robot
 
 
 *** Test cases ***
@@ -15,7 +15,7 @@ BearerToken Operations with Filter OID Equal
     [Tags]                  ACL  NeoFS  NeoCLI BearerToken
     [Timeout]               20 min
 
-    [Setup]                 Create Temporary Directory
+    [Setup]                 Setup
 
                             Generate Keys
                             Generate eACL Keys
@@ -30,7 +30,7 @@ BearerToken Operations with Filter OID Equal
                             Generate file    ${COMPLEX_OBJ_SIZE}
                             Check eACL Deny and Allow All Bearer Filter OID Equal
 
-    [Teardown]              Cleanup
+    [Teardown]              Teardown    acl_bearer_filter_oid_equal
 
 
 
@@ -95,8 +95,3 @@ Check eACL Deny and Allow All Bearer Filter OID Equal
                             Delete object                       ${USER_KEY}    ${CID}        ${S_OID_USER}        bearer_allow_all_user
                             Run Keyword And Expect Error        *
                             ...  Delete object                  ${USER_KEY}    ${CID}        ${D_OID_USER}        bearer_allow_all_user
-
-
-Cleanup
-                            Cleanup Files
-                            Get Docker Logs    acl_bearer

--- a/robot/testsuites/integration/acl/acl_bearer_filter_oid_not_equal.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_filter_oid_not_equal.robot
@@ -2,11 +2,12 @@
 Variables   ../../../variables/common.py
 Library     ../${RESOURCES}/neofs.py
 Library     ../${RESOURCES}/payment_neogo.py
-Library     ../${RESOURCES}/utility_keywords.py
 
 Library     Collections
+
 Resource    common_steps_acl_bearer.robot
 Resource    ../${RESOURCES}/payment_operations.robot
+Resource    ../${RESOURCES}/setup_teardown.robot
 
 
 *** Test cases ***
@@ -15,7 +16,7 @@ BearerToken Operations with Filter OID NotEqual
     [Tags]                  ACL  NeoFS  NeoCLI BearerToken
     [Timeout]               20 min
 
-    [Setup]                 Create Temporary Directory
+    [Setup]                 Setup
 
                             Generate Keys
                             Generate eACL Keys
@@ -30,7 +31,7 @@ BearerToken Operations with Filter OID NotEqual
                             Generate file    ${COMPLEX_OBJ_SIZE}
                             Check eACL Deny and Allow All Bearer Filter OID NotEqual
 
-    [Teardown]              Cleanup
+    [Teardown]              Teardown    acl_bearer_filter_oid_not_equal
 
 
 
@@ -123,8 +124,3 @@ Check eACL Deny and Allow All Bearer Filter OID NotEqual
 
                             Run Keyword And Expect Error        *
                             ...  Delete object                  ${USER_KEY}    ${CID}        ${D_OID_USER_2}          bearer_allow_all_user
-
-
-Cleanup
-                            Cleanup Files
-                            Get Docker Logs    acl_bearer

--- a/robot/testsuites/integration/acl/acl_bearer_filter_userheader_equal.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_filter_userheader_equal.robot
@@ -2,11 +2,12 @@
 Variables   ../../../variables/common.py
 Library     ../${RESOURCES}/neofs.py
 Library     ../${RESOURCES}/payment_neogo.py
-Library     ../${RESOURCES}/utility_keywords.py
 
 Library     Collections
+
 Resource    common_steps_acl_bearer.robot
 Resource    ../${RESOURCES}/payment_operations.robot
+Resource    ../${RESOURCES}/setup_teardown.robot
 
 *** Test cases ***
 BearerToken Operations with Filter UserHeader Equal
@@ -14,7 +15,7 @@ BearerToken Operations with Filter UserHeader Equal
     [Tags]                  ACL  NeoFS  NeoCLI BearerToken
     [Timeout]               20 min
 
-    [Setup]                 Create Temporary Directory
+    [Setup]                 Setup
 
                             Generate Keys
                             Generate eACL Keys
@@ -29,7 +30,7 @@ BearerToken Operations with Filter UserHeader Equal
                             Generate file    ${COMPLEX_OBJ_SIZE}
                             Check eACL Deny and Allow All Bearer Filter UserHeader Equal
 
-    [Teardown]              Cleanup
+    [Teardown]              Teardown    acl_bearer_filter_userheader_equal
 
 *** Keywords ***
 
@@ -121,8 +122,3 @@ Check eACL Deny and Allow All Bearer Filter UserHeader Equal
                             ...  Delete object                  ${USER_KEY}    ${CID}        ${S_OID_USER}            bearer_allow_all_user
                             Run Keyword And Expect Error        *
                             ...  Delete object                  ${USER_KEY}    ${CID}        ${S_OID_USER_2}          bearer_allow_all_user
-
-
-Cleanup
-                            Cleanup Files
-                            Get Docker Logs    acl_bearer

--- a/robot/testsuites/integration/acl/acl_bearer_filter_userheader_not_equal.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_filter_userheader_not_equal.robot
@@ -2,11 +2,11 @@
 Variables   ../../../variables/common.py
 Library     ../${RESOURCES}/neofs.py
 Library     ../${RESOURCES}/payment_neogo.py
-Library     ../${RESOURCES}/utility_keywords.py
 
 Library     Collections
 Resource    common_steps_acl_bearer.robot
 Resource    ../${RESOURCES}/payment_operations.robot
+Resource    ../${RESOURCES}/setup_teardown.robot
 
 *** Test cases ***
 BearerToken Operations Filter UserHeader NotEqual
@@ -14,7 +14,7 @@ BearerToken Operations Filter UserHeader NotEqual
     [Tags]                  ACL  NeoFS  NeoCLI BearerToken
     [Timeout]               20 min
 
-    [Setup]                 Create Temporary Directory
+    [Setup]                 Setup
 
                             Generate Keys
                             Generate eACL Keys
@@ -29,7 +29,7 @@ BearerToken Operations Filter UserHeader NotEqual
                             Generate file    ${COMPLEX_OBJ_SIZE}
                             Check eACL Deny and Allow All Bearer Filter UserHeader NotEqual
 
-    [Teardown]              Cleanup
+    [Teardown]              Teardown    acl_bearer_filter_userheader_not_equal
 
 *** Keywords ***
 
@@ -108,8 +108,3 @@ Check eACL Deny and Allow All Bearer Filter UserHeader NotEqual
                             ...  Delete object                  ${USER_KEY}    ${CID}        ${S_OID_USER}      bearer_allow_all_user
                             Run Keyword And Expect Error        *
                             ...  Delete object                  ${USER_KEY}    ${CID}        ${S_OID_USER_2}    bearer_allow_all_user
-
-
-Cleanup
-                            Cleanup Files
-                            Get Docker Logs    acl_bearer

--- a/robot/testsuites/integration/acl/acl_bearer_inaccessible.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_inaccessible.robot
@@ -3,11 +3,11 @@
 Variables   ../../../variables/common.py
 Library     ../${RESOURCES}/neofs.py
 Library     ../${RESOURCES}/payment_neogo.py
-Library     ../${RESOURCES}/utility_keywords.py
 
 Library     Collections
 Resource    common_steps_acl_bearer.robot
 Resource    ../${RESOURCES}/payment_operations.robot
+Resource    ../${RESOURCES}/setup_teardown.robot
 
 *** Test cases ***
 BearerToken Operations for Inaccessible Container
@@ -15,7 +15,7 @@ BearerToken Operations for Inaccessible Container
     [Tags]                  ACL  NeoFS  NeoCLI BearerToken
     [Timeout]               20 min
 
-    [Setup]                 Create Temporary Directory
+    [Setup]                 Setup
 
                             Generate Keys
                             Generate eACL Keys
@@ -30,7 +30,7 @@ BearerToken Operations for Inaccessible Container
                             Generate file    ${COMPLEX_OBJ_SIZE}
                             Check Container Inaccessible and Allow All Bearer
 
-    [Teardown]              Cleanup
+    [Teardown]              Teardown    acl_bearer_inaccessible
 
 *** Keywords ***
 
@@ -61,8 +61,3 @@ Check Container Inaccessible and Allow All Bearer
                             ...  Put object            ${USER_KEY}    ${FILE_S}     ${CID}           bearer_allow_all_user       ${FILE_USR_HEADER}
                             Run Keyword And Expect Error        *
                             ...  Search object                  ${USER_KEY}    ${CID}        ${EMPTY}         bearer_allow_all_user       ${FILE_USR_HEADER}
-
-
-Cleanup
-                            Cleanup Files
-                            Get Docker Logs    acl_bearer

--- a/robot/testsuites/integration/acl/acl_bearer_request_filter_xheader_deny.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_request_filter_xheader_deny.robot
@@ -1,12 +1,13 @@
 *** Settings ***
 Variables   ../../../variables/common.py
-Library     Collections
 Library     ../${RESOURCES}/neofs.py
 Library     ../${RESOURCES}/payment_neogo.py
-Library     ../${RESOURCES}/utility_keywords.py
+
+Library     Collections
 
 Resource    common_steps_acl_bearer.robot
 Resource    ../${RESOURCES}/payment_operations.robot
+Resource    ../${RESOURCES}/setup_teardown.robot
 
 *** Test cases ***
 BearerToken Operations
@@ -14,7 +15,7 @@ BearerToken Operations
     [Tags]                  ACL  NeoFS  NeoCLI BearerToken
     [Timeout]               20 min
 
-    [Setup]                 Create Temporary Directory
+    [Setup]                 Setup
 
                             Generate Keys
                             Generate eACL Keys
@@ -29,7 +30,7 @@ BearerToken Operations
                             Generate file    ${COMPLEX_OBJ_SIZE}
                             Check eACL Allow All Bearer Filter Requst Equal Deny
 
-    [Teardown]              Cleanup
+    [Teardown]              Teardown    acl_bearer_request_filter_xheader_deny
 
 
 
@@ -76,8 +77,3 @@ Check eACL Allow All Bearer Filter Requst Equal Deny
                             ...  Get Range Hash                  ${USER_KEY}    ${CID}       ${S_OID_USER}    bearer_allow_all_user    0:256                    --xhdr a=256
                             Run Keyword And Expect Error    *
                             ...  Delete object                   ${USER_KEY}    ${CID}       ${S_OID_USER}    bearer_allow_all_user    --xhdr a=256
-
-
-Cleanup
-                            Cleanup Files
-                            Get Docker Logs    acl_bearer

--- a/robot/testsuites/integration/acl/acl_bearer_request_filter_xheader_equal.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_request_filter_xheader_equal.robot
@@ -2,11 +2,12 @@
 Variables   ../../../variables/common.py
 Library     ../${RESOURCES}/neofs.py
 Library     ../${RESOURCES}/payment_neogo.py
-Library     ../${RESOURCES}/utility_keywords.py
 
 Library     Collections
+
 Resource    common_steps_acl_bearer.robot
 Resource    ../${RESOURCES}/payment_operations.robot
+Resource    ../${RESOURCES}/setup_teardown.robot
 
 
 *** Test cases ***
@@ -15,7 +16,7 @@ BearerToken Operations with Filter Requst Equal
     [Tags]                  ACL  NeoFS  NeoCLI BearerToken
     [Timeout]               20 min
 
-    [Setup]                 Create Temporary Directory
+    [Setup]                 Setup
 
                             Generate Keys
                             Generate eACL Keys
@@ -30,7 +31,7 @@ BearerToken Operations with Filter Requst Equal
                             Generate file    ${COMPLEX_OBJ_SIZE}
                             Check eACL Deny and Allow All Bearer Filter Requst Equal
 
-    [Teardown]              Cleanup
+    [Teardown]              Teardown    acl_bearer_request_filter_xheader_equal
 
 
 
@@ -86,8 +87,3 @@ Check eACL Deny and Allow All Bearer Filter Requst Equal
                             Get Range                       ${USER_KEY}    ${CID}       ${S_OID_USER}    s_get_range              bearer_allow_all_user    0:256          --xhdr a=256
                             Get Range Hash                  ${USER_KEY}    ${CID}       ${S_OID_USER}    bearer_allow_all_user    0:256                    --xhdr a=256
                             Delete object                   ${USER_KEY}    ${CID}       ${S_OID_USER}    bearer_allow_all_user    --xhdr a=256
-
-
-Cleanup
-                            Cleanup Files
-                            Get Docker Logs    acl_bearer

--- a/robot/testsuites/integration/acl/acl_bearer_request_filter_xheader_not_equal.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_request_filter_xheader_not_equal.robot
@@ -2,11 +2,12 @@
 Variables   ../../../variables/common.py
 Library     ../${RESOURCES}/neofs.py
 Library     ../${RESOURCES}/payment_neogo.py
-Library     ../${RESOURCES}/utility_keywords.py
 
 Library     Collections
+
 Resource    common_steps_acl_bearer.robot
 Resource    ../${RESOURCES}/payment_operations.robot
+Resource    ../${RESOURCES}/setup_teardown.robot
 
 
 *** Test cases ***
@@ -15,7 +16,7 @@ BearerToken Operations with Filter Requst NotEqual
     [Tags]                  ACL  NeoFS  NeoCLI BearerToken
     [Timeout]               20 min
 
-    [Setup]                 Create Temporary Directory
+    [Setup]                 Setup
 
                             Generate Keys
                             Generate eACL Keys
@@ -30,7 +31,7 @@ BearerToken Operations with Filter Requst NotEqual
                             Generate file    ${COMPLEX_OBJ_SIZE}
                             Check eACL Deny and Allow All Bearer Filter Requst NotEqual
 
-    [Teardown]              Cleanup
+    [Teardown]              Teardown    acl_bearer_request_filter_xheader_not_equal
 
 
 *** Keywords ***
@@ -85,8 +86,3 @@ Check eACL Deny and Allow All Bearer Filter Requst NotEqual
                             Get Range                       ${USER_KEY}    ${CID}       ${S_OID_USER}    s_get_range              bearer_allow_all_user    0:256          --xhdr a=2
                             Get Range Hash                  ${USER_KEY}    ${CID}       ${S_OID_USER}    bearer_allow_all_user    0:256                    --xhdr a=2
                             Delete object                   ${USER_KEY}    ${CID}       ${S_OID_USER}    bearer_allow_all_user    --xhdr a=2
-
-
-Cleanup
-                            Cleanup Files
-                            Get Docker Logs    acl_bearer

--- a/robot/testsuites/integration/acl/acl_extended_actions_other.robot
+++ b/robot/testsuites/integration/acl/acl_extended_actions_other.robot
@@ -3,10 +3,10 @@ Variables                   ../../../variables/common.py
 Library                     Collections
 Library                     ../${RESOURCES}/neofs.py
 Library                     ../${RESOURCES}/payment_neogo.py
-Library                     ../${RESOURCES}/utility_keywords.py
 
 Resource                    common_steps_acl_extended.robot
 Resource                    ../${RESOURCES}/payment_operations.robot
+Resource                    ../${RESOURCES}/setup_teardown.robot
 
 *** Test cases ***
 Extended ACL Operations
@@ -14,7 +14,7 @@ Extended ACL Operations
     [Tags]                  ACL  eACL  NeoFS  NeoCLI
     [Timeout]               20 min
 
-    [Setup]                 Create Temporary Directory
+    [Setup]                 Setup
 
                             Generate Keys
                             Generate eACL Keys
@@ -28,15 +28,10 @@ Extended ACL Operations
                             Generate files    ${COMPLEX_OBJ_SIZE}
                             Check eACL Deny and Allow All Other
 
-    [Teardown]              Cleanup
+    [Teardown]              Teardown    acl_extended_actions_other
 
 
 *** Keywords ***
 
 Check eACL Deny and Allow All Other
                             Check eACL Deny and Allow All    ${OTHER_KEY}    ${EACL_DENY_ALL_OTHER}    ${EACL_ALLOW_ALL_OTHER}
-
-
-Cleanup
-                            Cleanup Files
-                            Get Docker Logs    acl_extended

--- a/robot/testsuites/integration/acl/acl_extended_actions_pubkey.robot
+++ b/robot/testsuites/integration/acl/acl_extended_actions_pubkey.robot
@@ -1,12 +1,13 @@
 *** Settings ***
 Variables                   ../../../variables/common.py
-Library                     Collections
 Library                     ../${RESOURCES}/neofs.py
 Library                     ../${RESOURCES}/payment_neogo.py
-Library                     ../${RESOURCES}/utility_keywords.py
+
+Library                     Collections
 
 Resource                    common_steps_acl_extended.robot
 Resource                    ../${RESOURCES}/payment_operations.robot
+Resource                    ../${RESOURCES}/setup_teardown.robot
 
 *** Test cases ***
 Extended ACL Operations
@@ -14,7 +15,7 @@ Extended ACL Operations
     [Tags]                  ACL  eACL  NeoFS  NeoCLI
     [Timeout]               20 min
 
-    [Setup]                 Create Temporary Directory
+    [Setup]                 Setup
 
                             Generate Keys
                             Generate eACL Keys
@@ -29,7 +30,7 @@ Extended ACL Operations
                             Check eACL Deny All Other and Allow All Pubkey
 
 
-    [Teardown]              Cleanup
+    [Teardown]              Teardown    acl_extended_actions_pubkey
 
 
 *** Keywords ***
@@ -78,8 +79,3 @@ Check eACL Deny All Other and Allow All Pubkey
                             Get Range                           ${EACL_KEY}    ${CID}        ${S_OID_USER}           s_get_range         ${EMPTY}            0:256
                             Get Range Hash                      ${EACL_KEY}    ${CID}        ${S_OID_USER}           ${EMPTY}            0:256
                             Delete object                       ${EACL_KEY}    ${CID}        ${S_OID_USER}           ${EMPTY}
-
-
-Cleanup
-                            Cleanup Files
-                            Get Docker Logs    acl_extended

--- a/robot/testsuites/integration/acl/acl_extended_actions_system.robot
+++ b/robot/testsuites/integration/acl/acl_extended_actions_system.robot
@@ -3,10 +3,10 @@ Variables                   ../../../variables/common.py
 Library                     Collections
 Library                     ../${RESOURCES}/neofs.py
 Library                     ../${RESOURCES}/payment_neogo.py
-Library                     ../${RESOURCES}/utility_keywords.py
 
 Resource                    common_steps_acl_extended.robot
 Resource                    ../${RESOURCES}/payment_operations.robot
+Resource                    ../${RESOURCES}/setup_teardown.robot
 
 *** Test cases ***
 Extended ACL Operations
@@ -14,7 +14,7 @@ Extended ACL Operations
     [Tags]                  ACL  eACL  NeoFS  NeoCLI
     [Timeout]               20 min
 
-    [Setup]                 Create Temporary Directory
+    [Setup]                 Setup
 
                             Generate Keys
                             Generate eACL Keys
@@ -28,7 +28,7 @@ Extended ACL Operations
                             Generate files    ${COMPLEX_OBJ_SIZE}
                             Check eACL Deny and Allow All System
 
-    [Teardown]              Cleanup
+    [Teardown]              Teardown    acl_extended_actions_system
 
 
 *** Keywords ***
@@ -136,8 +136,3 @@ Check eACL Deny and Allow All System
 
                             Delete object                       ${SYSTEM_KEY}       ${CID}        ${D_OID_USER_S}            ${EMPTY}
                             Delete object                       ${SYSTEM_KEY_SN}    ${CID}        ${D_OID_USER_SN}           ${EMPTY}
-
-
-Cleanup
-                            Cleanup Files
-                            Get Docker Logs    acl_extended

--- a/robot/testsuites/integration/acl/acl_extended_actions_user.robot
+++ b/robot/testsuites/integration/acl/acl_extended_actions_user.robot
@@ -3,10 +3,10 @@ Variables                   ../../../variables/common.py
 Library                     Collections
 Library                     ../${RESOURCES}/neofs.py
 Library                     ../${RESOURCES}/payment_neogo.py
-Library                     ../${RESOURCES}/utility_keywords.py
 
 Resource                    common_steps_acl_extended.robot
 Resource                    ../${RESOURCES}/payment_operations.robot
+Resource                    ../${RESOURCES}/setup_teardown.robot
 
 *** Test cases ***
 Extended ACL Operations
@@ -14,7 +14,7 @@ Extended ACL Operations
     [Tags]                  ACL  eACL  NeoFS  NeoCLI
     [Timeout]               20 min
 
-    [Setup]                 Create Temporary Directory
+    [Setup]                 Setup
 
                             Generate Keys
                             Generate eACL Keys
@@ -28,15 +28,10 @@ Extended ACL Operations
                             Generate files    ${COMPLEX_OBJ_SIZE}
                             Check eACL Deny and Allow All User
 
-    [Teardown]              Cleanup
+    [Teardown]              Teardown    acl_extended_action_user
 
 
 *** Keywords ***
 
 Check eACL Deny and Allow All User
                             Check eACL Deny and Allow All    ${USER_KEY}    ${EACL_DENY_ALL_USER}    ${EACL_ALLOW_ALL_USER}
-
-
-Cleanup
-                            Cleanup Files
-                            Get Docker Logs    acl_extended

--- a/robot/testsuites/integration/acl/acl_extended_compound.robot
+++ b/robot/testsuites/integration/acl/acl_extended_compound.robot
@@ -3,10 +3,10 @@ Variables                   ../../../variables/common.py
 Library                     Collections
 Library                     ../${RESOURCES}/neofs.py
 Library                     ../${RESOURCES}/payment_neogo.py
-Library                     ../${RESOURCES}/utility_keywords.py
 
 Resource                    common_steps_acl_extended.robot
 Resource                    ../${RESOURCES}/payment_operations.robot
+Resource                    ../${RESOURCES}/setup_teardown.robot
 
 
 *** Test cases ***
@@ -15,7 +15,7 @@ Extended ACL Operations
     [Tags]                  ACL  eACL  NeoFS  NeoCLI
     [Timeout]               20 min
 
-    [Setup]                 Create Temporary Directory
+    [Setup]                 Setup
 
                             Generate Keys
                             Generate eACL Keys
@@ -31,7 +31,7 @@ Extended ACL Operations
                             Generate files    ${COMPLEX_OBJ_SIZE}
                             Check Сompound Operations
 
-    [Teardown]              Cleanup
+    [Teardown]              Teardown    acl_extended_compound
 
 
 *** Keywords ***
@@ -116,9 +116,3 @@ Check eACL Сompound Get Range Hash
                             ...  Get object      ${KEY}    ${CID}    ${S_OID_USER}    ${EMPTY}       local_file_eacl
 
                             Get Range Hash                  ${KEY}    ${CID}    ${S_OID_USER}    ${EMPTY}       0:256
-
-
-
-Cleanup
-                            Cleanup Files
-                            Get Docker Logs    acl_extended

--- a/robot/testsuites/integration/acl/acl_extended_filters.robot
+++ b/robot/testsuites/integration/acl/acl_extended_filters.robot
@@ -1,12 +1,13 @@
 *** Settings ***
-Variables                   ../../../variables/common.py
-Library                     Collections
-Library                     ../${RESOURCES}/neofs.py
-Library                     ../${RESOURCES}/payment_neogo.py
-Library                     ../${RESOURCES}/utility_keywords.py
+Variables       ../../../variables/common.py
+Library         ../${RESOURCES}/neofs.py
+Library         ../${RESOURCES}/payment_neogo.py
 
-Resource                    common_steps_acl_extended.robot
-Resource                    ../${RESOURCES}/payment_operations.robot
+Library         Collections
+
+Resource        common_steps_acl_extended.robot
+Resource        ../${RESOURCES}/payment_operations.robot
+Resource        ../${RESOURCES}/setup_teardown.robot
 
 *** Test cases ***
 Extended ACL Operations
@@ -14,7 +15,7 @@ Extended ACL Operations
     [Tags]                  ACL  eACL  NeoFS  NeoCLI
     [Timeout]               20 min
 
-    [Setup]                 Create Temporary Directory
+    [Setup]                 Setup
 
                             Generate Keys
                             Generate eACL Keys
@@ -28,7 +29,7 @@ Extended ACL Operations
                             Generate files    ${COMPLEX_OBJ_SIZE}
                             Check Filters
 
-    [Teardown]              Cleanup
+    [Teardown]              Teardown    acl_extended_filters
 
 
 *** Keywords ***
@@ -205,9 +206,3 @@ Check eACL MatchType String Not Equal Object
                             Run Keyword And Expect Error    *
                             ...  Get object      ${OTHER_KEY}    ${CID}      ${S_OID_USER_OTH}    ${EMPTY}            local_file_eacl
                             Get object           ${OTHER_KEY}    ${CID}      ${S_OID_USER}        ${EMPTY}            local_file_eacl
-
-
-
-Cleanup
-                            Cleanup Files
-                            Get Docker Logs    acl_extended

--- a/robot/testsuites/integration/network/netmap_simple.robot
+++ b/robot/testsuites/integration/network/netmap_simple.robot
@@ -3,11 +3,11 @@ Variables   ../../../variables/common.py
 
 Library     ../${RESOURCES}/neofs.py
 Library     ../${RESOURCES}/payment_neogo.py
-Library     ../${RESOURCES}/utility_keywords.py
 Library     ${KEYWORDS}/wallet_keywords.py
 Library     ${KEYWORDS}/rpc_call_keywords.py
 
 Resource    ../${RESOURCES}/payment_operations.robot
+Resource    ../${RESOURCES}/setup_teardown.robot
 
 
 *** Test cases ***
@@ -16,7 +16,7 @@ NeoFS Simple Netmap
     [Tags]              Netmap  NeoFS  NeoCLI
     [Timeout]           20 min
 
-    [Setup]             Create Temporary Directory
+    [Setup]             Setup
 
     Generate Key and Pre-payment
 
@@ -67,7 +67,7 @@ NeoFS Simple Netmap
                        Run Keyword And Expect Error    *
                        ...  Validate Policy    REP 2 IN X CBF 2 SELECT 6 FROM * AS X    2    @{EMPTY}
 
-    [Teardown]         Cleanup
+    [Teardown]         Teardown     netmap_simple
 
 *** Keywords ***
 
@@ -77,7 +77,7 @@ Generate file
                         Set Global Variable       ${FILE}    ${FILE}
 
 Generate Key and Pre-payment
-    ${WALLET}   ${ADDR}     ${USER_KEY_GEN} =   Init Wallet with Address    ${TEMP_DIR}
+    ${WALLET}   ${ADDR}     ${USER_KEY_GEN} =   Init Wallet with Address    ${ASSETS_DIR}
                         Set Global Variable     ${PRIV_KEY}     ${USER_KEY_GEN}
                         Payment Operations      ${ADDR}      ${PRIV_KEY}
 
@@ -92,8 +92,3 @@ Validate Policy
     ${S_OID} =          Put object                 ${PRIV_KEY}    ${FILE}       ${CID}        ${EMPTY}     ${EMPTY}
                         Validate storage policy for object  ${PRIV_KEY}    ${EXPECTED_VAL}             ${CID}       ${S_OID}   @{EXPECTED_LIST}
                         Get object               ${PRIV_KEY}    ${CID}    ${S_OID}    ${EMPTY}    s_file_read
-
-
-Cleanup
-                            Cleanup Files
-                            Get Docker Logs    netmap_simple

--- a/robot/testsuites/integration/network/replication.robot
+++ b/robot/testsuites/integration/network/replication.robot
@@ -3,11 +3,11 @@ Variables   ../../../variables/common.py
 
 Library     ../${RESOURCES}/neofs.py
 Library     ../${RESOURCES}/payment_neogo.py
-Library     ../${RESOURCES}/utility_keywords.py
 Library     ${KEYWORDS}/wallet_keywords.py
 Library     ${KEYWORDS}/rpc_call_keywords.py
 
 Resource    ../${RESOURCES}/payment_operations.robot
+Resource    ../${RESOURCES}/setup_teardown.robot
 
 *** Variables ***
 ${PLACEMENT_RULE} =     REP 2 IN X CBF 1 SELECT 4 FROM * AS X
@@ -18,9 +18,9 @@ NeoFS Object Replication
     [Tags]                  Migration  Replication  NeoFS  NeoCLI
     [Timeout]               25 min
 
-    [Setup]                 Create Temporary Directory
+    [Setup]                 Setup
 
-    ${WALLET}   ${ADDR}     ${WIF} =    Init Wallet with Address    ${TEMP_DIR}
+    ${WALLET}   ${ADDR}     ${WIF} =    Init Wallet with Address    ${ASSETS_DIR}
     Payment Operations      ${ADDR}     ${WIF}
 
     ${CID} =                Create container                      ${WIF}    ${EMPTY}   ${PLACEMENT_RULE}
@@ -50,11 +50,4 @@ NeoFS Object Replication
     Sleep                                 ${NEOFS_EPOCH_TIMEOUT}
     Validate storage policy for object    ${WIF}    2       ${CID}      ${S_OID}
 
-    [Teardown]              Cleanup
-
-
-*** Keywords ***
-
-Cleanup
-                            Cleanup Files
-                            Get Docker Logs                       replication
+    [Teardown]      Teardown    replaication

--- a/robot/testsuites/integration/object/common_steps_object.robot
+++ b/robot/testsuites/integration/object/common_steps_object.robot
@@ -8,37 +8,19 @@ Library     ${KEYWORDS}/rpc_call_keywords.py
 ${FILE_USR_HEADER} =    key1=1,key2=abc
 ${FILE_USR_HEADER_OTH} =    key1=2
 ${UNEXIST_OID} =        B2DKvkHnLnPvapbDgfpU1oVUPuXQo5LTfKVxmNDZXQff
-${TRANSFER_AMOUNT} =    15
-${DEPOSIT_AMOUNT} =     10
 
 *** Keywords ***
 
-Payment operations
-    ${WALLET}   ${ADDR}     ${WIF} =   Init Wallet with Address    ${TEMP_DIR}
-    ${TX} =             Transfer Mainnet Gas                  ${MAINNET_WALLET_WIF}    ${ADDR}     ${TRANSFER_AMOUNT}
-                        Wait Until Keyword Succeeds           ${MAINNET_TIMEOUT}    ${MAINNET_BLOCK_TIME}
-                        ...  Transaction accepted in block    ${TX}
-
-    ${MAINNET_BALANCE} =    Get Mainnet Balance               ${ADDR}
-    Should Be Equal As Numbers                                ${MAINNET_BALANCE}  ${TRANSFER_AMOUNT}
-
-    ${TX_DEPOSIT} =     NeoFS Deposit                         ${WIF}    ${DEPOSIT_AMOUNT}
-                        Wait Until Keyword Succeeds           ${MAINNET_TIMEOUT}    ${MAINNET_BLOCK_TIME}
-                        ...  Transaction accepted in block    ${TX_DEPOSIT}
-
-    ${NEOFS_BALANCE} =  Get NeoFS Balance       ${WIF}
-    Should Be Equal As Numbers                  ${NEOFS_BALANCE}    ${DEPOSIT_AMOUNT}
-
-                        Set Global Variable                   ${PRIV_KEY}    ${WIF}
-                        Set Global Variable                   ${ADDR}    ${ADDR}
-
 Prepare container
-    ${CID} =            Create container                      ${PRIV_KEY}   ${EMPTY}     ${COMMON_PLACEMENT_RULE}
-                        Container Existing                    ${PRIV_KEY}   ${CID}
+    [Arguments]     ${WIF}
+    ${NEOFS_BALANCE} =  Get NeoFS Balance       ${WIF}
 
-    ${NEOFS_BALANCE} =  Get NeoFS Balance     ${PRIV_KEY}
-    Should Be True      ${NEOFS_BALANCE} < ${DEPOSIT_AMOUNT}
-    ${CONTAINER_FEE} =  Evaluate      ${DEPOSIT_AMOUNT} - ${NEOFS_BALANCE}
+    ${CID} =            Create container          ${WIF}   ${EMPTY}     ${COMMON_PLACEMENT_RULE}
+                        Container Existing        ${WIF}   ${CID}
+
+    ${NEW_NEOFS_BALANCE} =  Get NeoFS Balance     ${WIF}
+    Should Be True      ${NEW_NEOFS_BALANCE} < ${NEOFS_BALANCE}
+    ${CONTAINER_FEE} =  Evaluate      ${NEOFS_BALANCE} - ${NEW_NEOFS_BALANCE}
     Log                 Container fee is ${CONTAINER_FEE}
 
-                        Set Global Variable                   ${CID}    ${CID}
+    Set Global Variable       ${CID}    ${CID}

--- a/robot/testsuites/integration/object/object_complex.robot
+++ b/robot/testsuites/integration/object/object_complex.robot
@@ -3,8 +3,10 @@ Variables   ../../../variables/common.py
 
 Library     ../${RESOURCES}/neofs.py
 Library     ../${RESOURCES}/payment_neogo.py
-Library     ../${RESOURCES}/utility_keywords.py
+
 Resource    common_steps_object.robot
+Resource    ../${RESOURCES}/setup_teardown.robot
+Resource    ../${RESOURCES}/payment_operations.robot
 
 
 *** Test cases ***
@@ -13,70 +15,64 @@ NeoFS Complex Object Operations
     [Tags]              Object  NeoFS  NeoCLI
     [Timeout]           20 min
 
-    [Setup]             Create Temporary Directory
+    [Setup]             Setup
 
-                        Payment operations
-                        Prepare container
+    ${WALLET}   ${ADDR}     ${WIF} =   Init Wallet with Address    ${ASSETS_DIR}
+    Payment Operations      ${ADDR}     ${WIF}
+    Prepare container       ${WIF}
 
     ${FILE} =           Generate file of bytes              ${COMPLEX_OBJ_SIZE}
     ${FILE_HASH} =      Get file hash                       ${FILE}
 
-    ${S_OID} =          Put object                 ${PRIV_KEY}    ${FILE}       ${CID}            ${EMPTY}         ${EMPTY}
-    ${H_OID} =          Put object                 ${PRIV_KEY}    ${FILE}       ${CID}            ${EMPTY}         ${FILE_USR_HEADER}
-    ${H_OID_OTH} =      Put object                 ${PRIV_KEY}    ${FILE}       ${CID}            ${EMPTY}         ${FILE_USR_HEADER_OTH}
+    ${S_OID} =          Put object                 ${WIF}    ${FILE}       ${CID}            ${EMPTY}         ${EMPTY}
+    ${H_OID} =          Put object                 ${WIF}    ${FILE}       ${CID}            ${EMPTY}         ${FILE_USR_HEADER}
+    ${H_OID_OTH} =      Put object                 ${WIF}    ${FILE}       ${CID}            ${EMPTY}         ${FILE_USR_HEADER_OTH}
 
     Should Be True     '${S_OID}'!='${H_OID}' and '${H_OID}'!='${H_OID_OTH}'
 
-                        Validate storage policy for object  ${PRIV_KEY}    2             ${CID}         ${S_OID}
-                        Validate storage policy for object  ${PRIV_KEY}    2             ${CID}         ${H_OID}
-                        Validate storage policy for object  ${PRIV_KEY}    2             ${CID}         ${H_OID_OTH}
+                        Validate storage policy for object  ${WIF}    2             ${CID}         ${S_OID}
+                        Validate storage policy for object  ${WIF}    2             ${CID}         ${H_OID}
+                        Validate storage policy for object  ${WIF}    2             ${CID}         ${H_OID_OTH}
 
     @{S_OBJ_ALL} =	Create List	                        ${S_OID}       ${H_OID}     ${H_OID_OTH}
     @{S_OBJ_H} =	Create List	                        ${H_OID}
     @{S_OBJ_H_OTH} =    Create List	                        ${H_OID_OTH}
 
-                        Search object                       ${PRIV_KEY}    ${CID}        --root           ${EMPTY}       ${EMPTY}    ${S_OBJ_ALL}
+                        Search object                       ${WIF}    ${CID}        --root           ${EMPTY}       ${EMPTY}    ${S_OBJ_ALL}
 
-    ${GET_OBJ_S} =      Get object               ${PRIV_KEY}    ${CID}        ${S_OID}           ${EMPTY}       s_file_read
-    ${GET_OBJ_H} =      Get object               ${PRIV_KEY}    ${CID}        ${H_OID}           ${EMPTY}       h_file_read
+    ${GET_OBJ_S} =      Get object               ${WIF}    ${CID}        ${S_OID}           ${EMPTY}       s_file_read
+    ${GET_OBJ_H} =      Get object               ${WIF}    ${CID}        ${H_OID}           ${EMPTY}       h_file_read
 
                         Verify file hash                    ${GET_OBJ_S}   ${FILE_HASH}
                         Verify file hash                    ${GET_OBJ_H}   ${FILE_HASH}
 
-                        Get Range Hash                      ${PRIV_KEY}    ${CID}        ${S_OID}          ${EMPTY}       0:10
-                        Get Range Hash                      ${PRIV_KEY}    ${CID}        ${H_OID}          ${EMPTY}       0:10
+                        Get Range Hash                      ${WIF}    ${CID}        ${S_OID}          ${EMPTY}       0:10
+                        Get Range Hash                      ${WIF}    ${CID}        ${H_OID}          ${EMPTY}       0:10
 
-                        Get Range                           ${PRIV_KEY}    ${CID}        ${S_OID}          s_get_range    ${EMPTY}       0:10
-                        Get Range                           ${PRIV_KEY}    ${CID}        ${H_OID}          h_get_range    ${EMPTY}       0:10
+                        Get Range                           ${WIF}    ${CID}        ${S_OID}          s_get_range    ${EMPTY}       0:10
+                        Get Range                           ${WIF}    ${CID}        ${H_OID}          h_get_range    ${EMPTY}       0:10
 
-                        Search object                       ${PRIV_KEY}    ${CID}        --root            ${EMPTY}       ${EMPTY}                ${S_OBJ_ALL}
-                        Search object                       ${PRIV_KEY}    ${CID}        --root            ${EMPTY}       ${FILE_USR_HEADER}      ${S_OBJ_H}
-                        Search object                       ${PRIV_KEY}    ${CID}        --root            ${EMPTY}       ${FILE_USR_HEADER_OTH}  ${S_OBJ_H_OTH}
+                        Search object                       ${WIF}    ${CID}        --root            ${EMPTY}       ${EMPTY}                ${S_OBJ_ALL}
+                        Search object                       ${WIF}    ${CID}        --root            ${EMPTY}       ${FILE_USR_HEADER}      ${S_OBJ_H}
+                        Search object                       ${WIF}    ${CID}        --root            ${EMPTY}       ${FILE_USR_HEADER_OTH}  ${S_OBJ_H_OTH}
 
-                        Head object                         ${PRIV_KEY}    ${CID}        ${S_OID}          ${EMPTY}
-                        Head object                         ${PRIV_KEY}    ${CID}        ${H_OID}          ${EMPTY}       ${FILE_USR_HEADER}
+                        Head object                         ${WIF}    ${CID}        ${S_OID}          ${EMPTY}
+                        Head object                         ${WIF}    ${CID}        ${H_OID}          ${EMPTY}       ${FILE_USR_HEADER}
 
-                        Verify Split Chain                  ${PRIV_KEY}    ${CID}        ${S_OID}
-                        Verify Split Chain                  ${PRIV_KEY}    ${CID}        ${H_OID}
+                        Verify Split Chain                  ${WIF}    ${CID}        ${S_OID}
+                        Verify Split Chain                  ${WIF}    ${CID}        ${H_OID}
 
-    ${TOMBSTONE_S} =    Delete object                       ${PRIV_KEY}    ${CID}        ${S_OID}          ${EMPTY}
-    ${TOMBSTONE_H} =    Delete object                       ${PRIV_KEY}    ${CID}        ${H_OID}          ${EMPTY}
+    ${TOMBSTONE_S} =    Delete object                       ${WIF}    ${CID}        ${S_OID}          ${EMPTY}
+    ${TOMBSTONE_H} =    Delete object                       ${WIF}    ${CID}        ${H_OID}          ${EMPTY}
 
-                        Verify Head tombstone               ${PRIV_KEY}    ${CID}        ${TOMBSTONE_S}     ${S_OID}    ${ADDR}
-                        Verify Head tombstone               ${PRIV_KEY}    ${CID}        ${TOMBSTONE_H}     ${H_OID}    ${ADDR}
+                        Verify Head tombstone               ${WIF}    ${CID}        ${TOMBSTONE_S}     ${S_OID}    ${ADDR}
+                        Verify Head tombstone               ${WIF}    ${CID}        ${TOMBSTONE_H}     ${H_OID}    ${ADDR}
 
                         Sleep                               2min
 
                         Run Keyword And Expect Error        *
-                        ...  Get object          ${PRIV_KEY}    ${CID}        ${S_OID}           ${EMPTY}       ${GET_OBJ_S}
+                        ...  Get object          ${WIF}    ${CID}        ${S_OID}           ${EMPTY}       ${GET_OBJ_S}
                         Run Keyword And Expect Error        *
-                        ...  Get object          ${PRIV_KEY}    ${CID}        ${H_OID}           ${EMPTY}       ${GET_OBJ_H}
+                        ...  Get object          ${WIF}    ${CID}        ${H_OID}           ${EMPTY}       ${GET_OBJ_H}
 
-    [Teardown]          Cleanup
-
-
-*** Keywords ***
-
-Cleanup
-                        Cleanup Files
-                        Get Docker Logs                     object_complex
+    [Teardown]          Teardown    object_complex

--- a/robot/testsuites/integration/object/object_expiration.robot
+++ b/robot/testsuites/integration/object/object_expiration.robot
@@ -3,8 +3,10 @@ Variables   ../../../variables/common.py
 
 Library     ../${RESOURCES}/neofs.py
 Library     ../${RESOURCES}/payment_neogo.py
-Library     ../${RESOURCES}/utility_keywords.py
+
 Resource    common_steps_object.robot
+Resource    ../${RESOURCES}/setup_teardown.robot
+Resource    ../${RESOURCES}/payment_operations.robot
 
 
 *** Test cases ***
@@ -13,15 +15,16 @@ NeoFS Simple Object Operations
     [Tags]              Object  NeoFS  NeoCLI
     [Timeout]           20 min
 
-    [Setup]             Create Temporary Directory
+    [Setup]             Setup
 
-                        Payment operations
-                        Prepare container
+    ${WALLET}   ${ADDR}     ${WIF} =   Init Wallet with Address    ${ASSETS_DIR}
+    Payment Operations      ${ADDR}     ${WIF}
+    Prepare container       ${WIF}
 
     ${FILE} =           Generate file of bytes    ${SIMPLE_OBJ_SIZE}
     ${FILE_HASH} =      Get file hash    ${FILE}
 
-    ${EPOCH} =          Get Epoch    ${PRIV_KEY}
+    ${EPOCH} =          Get Epoch    ${WIF}
 
     ${EPOCH_PRE} =      Evaluate    ${EPOCH}-1
     ${EPOCH_NEXT} =     Evaluate    ${EPOCH}+1
@@ -29,48 +32,35 @@ NeoFS Simple Object Operations
 
                         # Failed on attempt to create epoch from the past
                         Run Keyword And Expect Error        *
-                        ...  Put object    ${PRIV_KEY}    ${FILE}    ${CID}    ${EMPTY}    __NEOFS__EXPIRATION_EPOCH=${EPOCH_PRE}
+                        ...  Put object    ${WIF}    ${FILE}    ${CID}    ${EMPTY}    __NEOFS__EXPIRATION_EPOCH=${EPOCH_PRE}
 
                         # Put object with different expiration epoch numbers (current, next, and from the distant future)
-    ${OID_CUR} =        Put object    ${PRIV_KEY}    ${FILE}    ${CID}    ${EMPTY}    __NEOFS__EXPIRATION_EPOCH=${EPOCH}
-    ${OID_NXT} =        Put object    ${PRIV_KEY}    ${FILE}    ${CID}    ${EMPTY}    __NEOFS__EXPIRATION_EPOCH=${EPOCH_NEXT}
-    ${OID_PST} =        Put object    ${PRIV_KEY}    ${FILE}    ${CID}    ${EMPTY}    __NEOFS__EXPIRATION_EPOCH=${EPOCH_POST}
+    ${OID_CUR} =        Put object    ${WIF}    ${FILE}    ${CID}    ${EMPTY}    __NEOFS__EXPIRATION_EPOCH=${EPOCH}
+    ${OID_NXT} =        Put object    ${WIF}    ${FILE}    ${CID}    ${EMPTY}    __NEOFS__EXPIRATION_EPOCH=${EPOCH_NEXT}
+    ${OID_PST} =        Put object    ${WIF}    ${FILE}    ${CID}    ${EMPTY}    __NEOFS__EXPIRATION_EPOCH=${EPOCH_POST}
 
                         # Check objects for existence
-                        Get object    ${PRIV_KEY}    ${CID}    ${OID_CUR}    ${EMPTY}    file_read_cur
-                        Get object    ${PRIV_KEY}    ${CID}    ${OID_NXT}    ${EMPTY}    file_read_nxt
-                        Get object    ${PRIV_KEY}    ${CID}    ${OID_PST}    ${EMPTY}    file_read_pst
+                        Get object    ${WIF}    ${CID}    ${OID_CUR}    ${EMPTY}    file_read_cur
+                        Get object    ${WIF}    ${CID}    ${OID_NXT}    ${EMPTY}    file_read_nxt
+                        Get object    ${WIF}    ${CID}    ${OID_PST}    ${EMPTY}    file_read_pst
 
                         # Wait one epoch to check that expired objects (OID_CUR) will be removed
                         Sleep   ${NEOFS_EPOCH_TIMEOUT}
 
                         Run Keyword And Expect Error        *
-                        ...  Get object    ${PRIV_KEY}    ${CID}    ${OID_CUR}    ${EMPTY}    file_read
+                        ...  Get object    ${WIF}    ${CID}    ${OID_CUR}    ${EMPTY}    file_read
 
                         # Check that correct object with expiration in the future is existed
-                        Get object    ${PRIV_KEY}    ${CID}    ${OID_NXT}    ${EMPTY}    file_read
-                        Get object    ${PRIV_KEY}    ${CID}    ${OID_PST}    ${EMPTY}    file_read_pst
+                        Get object    ${WIF}    ${CID}    ${OID_NXT}    ${EMPTY}    file_read
+                        Get object    ${WIF}    ${CID}    ${OID_PST}    ${EMPTY}    file_read_pst
 
                         # Wait one more epoch to check that expired object (OID_NXT) will be removed
                         Sleep   ${NEOFS_EPOCH_TIMEOUT}
 
                         Run Keyword And Expect Error        *
-                        ...  Get object    ${PRIV_KEY}    ${CID}    ${OID_NXT}    ${EMPTY}    file_read
+                        ...  Get object    ${WIF}    ${CID}    ${OID_NXT}    ${EMPTY}    file_read
 
                         # Check that correct object with expiration in the distant future is existed
-                        Get object    ${PRIV_KEY}    ${CID}    ${OID_PST}    ${EMPTY}    file_read_pst
+                        Get object    ${WIF}    ${CID}    ${OID_PST}    ${EMPTY}    file_read_pst
 
-    [Teardown]          Cleanup
-
-
-
-*** Keywords ***
-
-Cleanup
-                        Cleanup Files
-                        Get Docker Logs    object_expiration
-
-
-
-
-
+    [Teardown]          Teardown    object_expiration

--- a/robot/testsuites/integration/object/object_simple.robot
+++ b/robot/testsuites/integration/object/object_simple.robot
@@ -3,8 +3,10 @@ Variables   ../../../variables/common.py
 
 Library     ../${RESOURCES}/neofs.py
 Library     ../${RESOURCES}/payment_neogo.py
-Library     ../${RESOURCES}/utility_keywords.py
+
 Resource    common_steps_object.robot
+Resource    ../${RESOURCES}/payment_operations.robot
+Resource    ../${RESOURCES}/setup_teardown.robot
 
 
 *** Test cases ***
@@ -13,66 +15,59 @@ NeoFS Simple Object Operations
     [Tags]              Object  NeoFS  NeoCLI
     [Timeout]           10 min
 
-    [Setup]             Create Temporary Directory
+    [Setup]             Setup
 
-                        Payment operations
-                        Prepare container
+    ${WALLET}   ${ADDR}     ${WIF} =   Init Wallet with Address    ${ASSETS_DIR}
+    Payment Operations      ${ADDR}     ${WIF}
+    Prepare container       ${WIF}
 
     ${FILE} =           Generate file of bytes              ${SIMPLE_OBJ_SIZE}
     ${FILE_HASH} =      Get file hash                       ${FILE}
 
 
-    ${S_OID} =          Put object          ${PRIV_KEY}    ${FILE}       ${CID}            ${EMPTY}         ${EMPTY}
-    ${H_OID} =          Put object          ${PRIV_KEY}    ${FILE}       ${CID}            ${EMPTY}         ${FILE_USR_HEADER}
-    ${H_OID_OTH} =      Put object          ${PRIV_KEY}    ${FILE}       ${CID}            ${EMPTY}         ${FILE_USR_HEADER_OTH}
+    ${S_OID} =          Put object          ${WIF}    ${FILE}       ${CID}            ${EMPTY}         ${EMPTY}
+    ${H_OID} =          Put object          ${WIF}    ${FILE}       ${CID}            ${EMPTY}         ${FILE_USR_HEADER}
+    ${H_OID_OTH} =      Put object          ${WIF}    ${FILE}       ${CID}            ${EMPTY}         ${FILE_USR_HEADER_OTH}
 
-                        Validate storage policy for object  ${PRIV_KEY}    2             ${CID}            ${S_OID}
-                        Validate storage policy for object  ${PRIV_KEY}    2             ${CID}            ${H_OID}
-                        Validate storage policy for object  ${PRIV_KEY}    2             ${CID}            ${H_OID_OTH}
+                        Validate storage policy for object  ${WIF}    2             ${CID}            ${S_OID}
+                        Validate storage policy for object  ${WIF}    2             ${CID}            ${H_OID}
+                        Validate storage policy for object  ${WIF}    2             ${CID}            ${H_OID_OTH}
 
     @{S_OBJ_ALL} =	Create List         ${S_OID}       ${H_OID}      ${H_OID_OTH}
     @{S_OBJ_H} =	Create List         ${H_OID}
     @{S_OBJ_H_OTH} =    Create List         ${H_OID_OTH}
 
-    ${GET_OBJ_S} =      Get object          ${PRIV_KEY}    ${CID}        ${S_OID}           ${EMPTY}       s_file_read
-    ${GET_OBJ_H} =      Get object          ${PRIV_KEY}    ${CID}        ${H_OID}           ${EMPTY}       h_file_read
+    ${GET_OBJ_S} =      Get object          ${WIF}    ${CID}        ${S_OID}           ${EMPTY}       s_file_read
+    ${GET_OBJ_H} =      Get object          ${WIF}    ${CID}        ${H_OID}           ${EMPTY}       h_file_read
 
                         Verify file hash                    ${GET_OBJ_S}   ${FILE_HASH}
                         Verify file hash                    ${GET_OBJ_H}   ${FILE_HASH}
 
-                        Get Range Hash                      ${PRIV_KEY}    ${CID}        ${S_OID}            ${EMPTY}       0:10
-                        Get Range Hash                      ${PRIV_KEY}    ${CID}        ${H_OID}            ${EMPTY}       0:10
+                        Get Range Hash                      ${WIF}    ${CID}        ${S_OID}            ${EMPTY}       0:10
+                        Get Range Hash                      ${WIF}    ${CID}        ${H_OID}            ${EMPTY}       0:10
 
-                        Get Range                           ${PRIV_KEY}    ${CID}        ${S_OID}            s_get_range    ${EMPTY}       0:10
-                        Get Range                           ${PRIV_KEY}    ${CID}        ${H_OID}            h_get_range    ${EMPTY}       0:10
+                        Get Range                           ${WIF}    ${CID}        ${S_OID}            s_get_range    ${EMPTY}       0:10
+                        Get Range                           ${WIF}    ${CID}        ${H_OID}            h_get_range    ${EMPTY}       0:10
 
-                        Search object                       ${PRIV_KEY}    ${CID}        ${EMPTY}            ${EMPTY}       ${EMPTY}                  ${S_OBJ_ALL}
-                        Search object                       ${PRIV_KEY}    ${CID}        ${EMPTY}            ${EMPTY}       ${FILE_USR_HEADER}        ${S_OBJ_H}
-                        Search object                       ${PRIV_KEY}    ${CID}        ${EMPTY}            ${EMPTY}       ${FILE_USR_HEADER_OTH}    ${S_OBJ_H_OTH}
+                        Search object                       ${WIF}    ${CID}        ${EMPTY}            ${EMPTY}       ${EMPTY}                  ${S_OBJ_ALL}
+                        Search object                       ${WIF}    ${CID}        ${EMPTY}            ${EMPTY}       ${FILE_USR_HEADER}        ${S_OBJ_H}
+                        Search object                       ${WIF}    ${CID}        ${EMPTY}            ${EMPTY}       ${FILE_USR_HEADER_OTH}    ${S_OBJ_H_OTH}
 
-                        Head object                         ${PRIV_KEY}    ${CID}        ${S_OID}            ${EMPTY}
-                        Head object                         ${PRIV_KEY}    ${CID}        ${H_OID}            ${EMPTY}       ${FILE_USR_HEADER}
+                        Head object                         ${WIF}    ${CID}        ${S_OID}            ${EMPTY}
+                        Head object                         ${WIF}    ${CID}        ${H_OID}            ${EMPTY}       ${FILE_USR_HEADER}
 
-    ${TOMBSTONE_S} =    Delete object                       ${PRIV_KEY}    ${CID}        ${S_OID}            ${EMPTY}
-    ${TOMBSTONE_H} =    Delete object                       ${PRIV_KEY}    ${CID}        ${H_OID}            ${EMPTY}
+    ${TOMBSTONE_S} =    Delete object                       ${WIF}    ${CID}        ${S_OID}            ${EMPTY}
+    ${TOMBSTONE_H} =    Delete object                       ${WIF}    ${CID}        ${H_OID}            ${EMPTY}
 
-                        Verify Head tombstone               ${PRIV_KEY}    ${CID}        ${TOMBSTONE_S}     ${S_OID}    ${ADDR}
-                        Verify Head tombstone               ${PRIV_KEY}    ${CID}        ${TOMBSTONE_H}     ${H_OID}    ${ADDR}
+                        Verify Head tombstone               ${WIF}    ${CID}        ${TOMBSTONE_S}     ${S_OID}    ${ADDR}
+                        Verify Head tombstone               ${WIF}    ${CID}        ${TOMBSTONE_H}     ${H_OID}    ${ADDR}
 
                         Sleep                               2min
 
                         Run Keyword And Expect Error        *
-                        ...  Get object          ${PRIV_KEY}    ${CID}        ${S_OID}           ${EMPTY}       ${GET_OBJ_S}
+                        ...  Get object          ${WIF}    ${CID}        ${S_OID}           ${EMPTY}       ${GET_OBJ_S}
 
                         Run Keyword And Expect Error        *
-                        ...  Get object          ${PRIV_KEY}    ${CID}        ${H_OID}           ${EMPTY}       ${GET_OBJ_H}
+                        ...  Get object          ${WIF}    ${CID}        ${H_OID}           ${EMPTY}       ${GET_OBJ_H}
 
-    [Teardown]          Cleanup
-
-
-
-*** Keywords ***
-
-Cleanup
-                        Cleanup Files
-                        Get Docker Logs                     object_simple
+    [Teardown]          Teardown    object_simple

--- a/robot/testsuites/integration/object/object_storagegroup_complex.robot
+++ b/robot/testsuites/integration/object/object_storagegroup_complex.robot
@@ -3,8 +3,10 @@ Variables   ../../../variables/common.py
 Library     Collections
 Library     ../${RESOURCES}/neofs.py
 Library     ../${RESOURCES}/payment_neogo.py
-Library     ../${RESOURCES}/utility_keywords.py
+
 Resource    common_steps_object.robot
+Resource    ../${RESOURCES}/setup_teardown.robot
+Resource    ../${RESOURCES}/payment_operations.robot
 
 *** Test cases ***
 NeoFS Complex Storagegroup
@@ -12,55 +14,50 @@ NeoFS Complex Storagegroup
     [Tags]              Object  NeoFS  NeoCLI
     [Timeout]           20 min
 
-    [Setup]             Create Temporary Directory
+    [Setup]             Setup
 
-                        Payment operations
-                        Prepare container
+    ${WALLET}   ${ADDR}     ${WIF} =   Init Wallet with Address    ${ASSETS_DIR}
+    Payment Operations      ${ADDR}     ${WIF}
+    Prepare container       ${WIF}
 
     ${FILE_S} =         Generate file of bytes            ${COMPLEX_OBJ_SIZE}
     ${FILE_HASH_S} =    Get file hash                     ${FILE_S}
 
     # Put two Simple Object
-    ${S_OID_1} =        Put object    ${PRIV_KEY}    ${FILE_S}    ${CID}    ${EMPTY}    ${EMPTY}
-    ${S_OID_2} =        Put object    ${PRIV_KEY}    ${FILE_S}    ${CID}    ${EMPTY}    ${FILE_USR_HEADER}
+    ${S_OID_1} =        Put object    ${WIF}    ${FILE_S}    ${CID}    ${EMPTY}    ${EMPTY}
+    ${S_OID_2} =        Put object    ${WIF}    ${FILE_S}    ${CID}    ${EMPTY}    ${FILE_USR_HEADER}
 
     @{S_OBJ_ALL} =	Create List    ${S_OID_1}    ${S_OID_2}
 
                         Log    Storage group with 1 object
-    ${SG_OID_1} =       Put Storagegroup    ${PRIV_KEY}    ${CID}   ${EMPTY}    ${S_OID_1}
-                        List Storagegroup    ${PRIV_KEY}    ${CID}   ${EMPTY}    ${SG_OID_1}
-    @{SPLIT_OBJ_1} =    Get Split objects    ${PRIV_KEY}    ${CID}   ${S_OID_1}
-                        Get Storagegroup    ${PRIV_KEY}    ${CID}    ${SG_OID_1}   ${EMPTY}    ${COMPLEX_OBJ_SIZE}    @{SPLIT_OBJ_1}
-    ${Tombstone} =      Delete Storagegroup    ${PRIV_KEY}    ${CID}    ${SG_OID_1}    ${EMPTY}
-                        Verify Head tombstone    ${PRIV_KEY}    ${CID}    ${Tombstone}    ${SG_OID_1}    ${ADDR}
+    ${SG_OID_1} =       Put Storagegroup    ${WIF}    ${CID}   ${EMPTY}    ${S_OID_1}
+                        List Storagegroup    ${WIF}    ${CID}   ${EMPTY}    ${SG_OID_1}
+    @{SPLIT_OBJ_1} =    Get Split objects    ${WIF}    ${CID}   ${S_OID_1}
+                        Get Storagegroup    ${WIF}    ${CID}    ${SG_OID_1}   ${EMPTY}    ${COMPLEX_OBJ_SIZE}    @{SPLIT_OBJ_1}
+    ${Tombstone} =      Delete Storagegroup    ${WIF}    ${CID}    ${SG_OID_1}    ${EMPTY}
+                        Verify Head tombstone    ${WIF}    ${CID}    ${Tombstone}    ${SG_OID_1}    ${ADDR}
                         Run Keyword And Expect Error    *
-                        ...  Get Storagegroup    ${PRIV_KEY}    ${CID}    ${SG_OID_1}   ${EMPTY}    ${COMPLEX_OBJ_SIZE}    @{SPLIT_OBJ_1}
-                        List Storagegroup    ${PRIV_KEY}    ${CID}   ${EMPTY}    @{EMPTY}
+                        ...  Get Storagegroup    ${WIF}    ${CID}    ${SG_OID_1}   ${EMPTY}    ${COMPLEX_OBJ_SIZE}    @{SPLIT_OBJ_1}
+                        List Storagegroup    ${WIF}    ${CID}   ${EMPTY}    @{EMPTY}
 
                         Log    Storage group with 2 objects
-    ${SG_OID_2} =       Put Storagegroup    ${PRIV_KEY}    ${CID}    ${EMPTY}    @{S_OBJ_ALL}
-                        List Storagegroup    ${PRIV_KEY}    ${CID}   ${EMPTY}    ${SG_OID_2}
-    @{SPLIT_OBJ_2} =    Get Split objects    ${PRIV_KEY}    ${CID}   ${S_OID_2}
+    ${SG_OID_2} =       Put Storagegroup    ${WIF}    ${CID}    ${EMPTY}    @{S_OBJ_ALL}
+                        List Storagegroup    ${WIF}    ${CID}   ${EMPTY}    ${SG_OID_2}
+    @{SPLIT_OBJ_2} =    Get Split objects    ${WIF}    ${CID}   ${S_OID_2}
     @{SPLIT_OBJ_ALL} =  Combine Lists    ${SPLIT_OBJ_1}    ${SPLIT_OBJ_2}
     ${EXPECTED_SIZE} =  Evaluate    2*${COMPLEX_OBJ_SIZE}
-                        Get Storagegroup    ${PRIV_KEY}    ${CID}    ${SG_OID_2}   ${EMPTY}    ${EXPECTED_SIZE}    @{SPLIT_OBJ_ALL}
-    ${Tombstone} =      Delete Storagegroup    ${PRIV_KEY}    ${CID}    ${SG_OID_2}    ${EMPTY}
-                        Verify Head tombstone    ${PRIV_KEY}    ${CID}    ${Tombstone}    ${SG_OID_2}    ${ADDR}
+                        Get Storagegroup    ${WIF}    ${CID}    ${SG_OID_2}   ${EMPTY}    ${EXPECTED_SIZE}    @{SPLIT_OBJ_ALL}
+    ${Tombstone} =      Delete Storagegroup    ${WIF}    ${CID}    ${SG_OID_2}    ${EMPTY}
+                        Verify Head tombstone    ${WIF}    ${CID}    ${Tombstone}    ${SG_OID_2}    ${ADDR}
                         Run Keyword And Expect Error    *
-                        ...  Get Storagegroup    ${PRIV_KEY}    ${CID}    ${SG_OID_2}   ${EMPTY}    ${EXPECTED_SIZE}    @{SPLIT_OBJ_ALL}
-                        List Storagegroup    ${PRIV_KEY}    ${CID}   ${EMPTY}    @{EMPTY}
+                        ...  Get Storagegroup    ${WIF}    ${CID}    ${SG_OID_2}   ${EMPTY}    ${EXPECTED_SIZE}    @{SPLIT_OBJ_ALL}
+                        List Storagegroup    ${WIF}    ${CID}   ${EMPTY}    @{EMPTY}
 
                         Log    Incorrect input
 
                         Run Keyword And Expect Error    *
-                        ...  Put Storagegroup    ${PRIV_KEY}    ${CID}    ${EMPTY}    ${UNEXIST_OID}
+                        ...  Put Storagegroup    ${WIF}    ${CID}    ${EMPTY}    ${UNEXIST_OID}
                         Run Keyword And Expect Error    *
-                        ...  Delete Storagegroup    ${PRIV_KEY}    ${CID}    ${UNEXIST_OID}    ${EMPTY}
+                        ...  Delete Storagegroup    ${WIF}    ${CID}    ${UNEXIST_OID}    ${EMPTY}
 
-    [Teardown]          Cleanup
-
-*** Keywords ***
-
-Cleanup
-                        Cleanup Files
-                        Get Docker Logs                     object_storage_group_complex
+    [Teardown]          Teardown    object_storage_group_complex

--- a/robot/testsuites/integration/object/object_storagegroup_simple.robot
+++ b/robot/testsuites/integration/object/object_storagegroup_simple.robot
@@ -3,8 +3,10 @@ Variables   ../../../variables/common.py
 
 Library     ../${RESOURCES}/neofs.py
 Library     ../${RESOURCES}/payment_neogo.py
-Library     ../${RESOURCES}/utility_keywords.py
+
 Resource    common_steps_object.robot
+Resource    ../${RESOURCES}/setup_teardown.robot
+Resource    ../${RESOURCES}/payment_operations.robot
 
 
 *** Test cases ***
@@ -13,53 +15,49 @@ NeoFS Simple Storagegroup
     [Tags]              Object  NeoFS  NeoCLI
     [Timeout]           20 min
 
-    [Setup]             Create Temporary Directory
+    [Setup]             Setup
 
-                        Payment operations
-                        Prepare container
+    ${WALLET}   ${ADDR}     ${WIF} =   Init Wallet with Address    ${ASSETS_DIR}
+    Payment Operations      ${ADDR}     ${WIF}
+    Prepare container       ${WIF}
 
     ${FILE_S} =         Generate file of bytes            ${SIMPLE_OBJ_SIZE}
     ${FILE_HASH_S} =    Get file hash                     ${FILE_S}
 
 
     # Put two Simple Object
-    ${S_OID_1} =        Put object    ${PRIV_KEY}    ${FILE_S}    ${CID}    ${EMPTY}    ${EMPTY}
-    ${S_OID_2} =        Put object    ${PRIV_KEY}    ${FILE_S}    ${CID}    ${EMPTY}    ${FILE_USR_HEADER}
+    ${S_OID_1} =        Put object    ${WIF}    ${FILE_S}    ${CID}    ${EMPTY}    ${EMPTY}
+    ${S_OID_2} =        Put object    ${WIF}    ${FILE_S}    ${CID}    ${EMPTY}    ${FILE_USR_HEADER}
 
     @{S_OBJ_ALL} =	    Create List    ${S_OID_1}    ${S_OID_2}
 
                         Log    Storage group with 1 object
-    ${SG_OID_1} =       Put Storagegroup    ${PRIV_KEY}    ${CID}   ${EMPTY}    ${S_OID_1}
-                        List Storagegroup    ${PRIV_KEY}    ${CID}   ${EMPTY}    ${SG_OID_1}
-                        Get Storagegroup    ${PRIV_KEY}    ${CID}    ${SG_OID_1}   ${EMPTY}    ${SIMPLE_OBJ_SIZE}    ${S_OID_1}
-    ${Tombstone} =      Delete Storagegroup    ${PRIV_KEY}    ${CID}    ${SG_OID_1}    ${EMPTY}
-                        Verify Head tombstone    ${PRIV_KEY}    ${CID}    ${Tombstone}    ${SG_OID_1}    ${ADDR}
+    ${SG_OID_1} =       Put Storagegroup    ${WIF}    ${CID}   ${EMPTY}    ${S_OID_1}
+                        List Storagegroup    ${WIF}    ${CID}   ${EMPTY}    ${SG_OID_1}
+                        Get Storagegroup    ${WIF}    ${CID}    ${SG_OID_1}   ${EMPTY}    ${SIMPLE_OBJ_SIZE}    ${S_OID_1}
+    ${Tombstone} =      Delete Storagegroup    ${WIF}    ${CID}    ${SG_OID_1}    ${EMPTY}
+                        Verify Head tombstone    ${WIF}    ${CID}    ${Tombstone}    ${SG_OID_1}    ${ADDR}
                         Run Keyword And Expect Error    *
-                        ...  Get Storagegroup    ${PRIV_KEY}    ${CID}    ${SG_OID_1}   ${EMPTY}    ${SIMPLE_OBJ_SIZE}    ${S_OID_1}
-                        List Storagegroup    ${PRIV_KEY}    ${CID}   ${EMPTY}    @{EMPTY}
+                        ...  Get Storagegroup    ${WIF}    ${CID}    ${SG_OID_1}   ${EMPTY}    ${SIMPLE_OBJ_SIZE}    ${S_OID_1}
+                        List Storagegroup    ${WIF}    ${CID}   ${EMPTY}    @{EMPTY}
 
 
                         Log    Storage group with 2 objects
-    ${SG_OID_2} =       Put Storagegroup    ${PRIV_KEY}    ${CID}    ${EMPTY}    @{S_OBJ_ALL}
-                        List Storagegroup    ${PRIV_KEY}    ${CID}   ${EMPTY}    ${SG_OID_2}
+    ${SG_OID_2} =       Put Storagegroup    ${WIF}    ${CID}    ${EMPTY}    @{S_OBJ_ALL}
+                        List Storagegroup    ${WIF}    ${CID}   ${EMPTY}    ${SG_OID_2}
     ${EXPECTED_SIZE} =  Evaluate    2*${SIMPLE_OBJ_SIZE}
-                        Get Storagegroup    ${PRIV_KEY}    ${CID}    ${SG_OID_2}   ${EMPTY}    ${EXPECTED_SIZE}    @{S_OBJ_ALL}
-    ${Tombstone} =      Delete Storagegroup    ${PRIV_KEY}    ${CID}    ${SG_OID_2}    ${EMPTY}
-                        Verify Head tombstone    ${PRIV_KEY}    ${CID}    ${Tombstone}    ${SG_OID_2}    ${ADDR}
+                        Get Storagegroup    ${WIF}    ${CID}    ${SG_OID_2}   ${EMPTY}    ${EXPECTED_SIZE}    @{S_OBJ_ALL}
+    ${Tombstone} =      Delete Storagegroup    ${WIF}    ${CID}    ${SG_OID_2}    ${EMPTY}
+                        Verify Head tombstone    ${WIF}    ${CID}    ${Tombstone}    ${SG_OID_2}    ${ADDR}
                         Run Keyword And Expect Error    *
-                        ...  Get Storagegroup    ${PRIV_KEY}    ${CID}    ${SG_OID_2}   ${EMPTY}    ${EXPECTED_SIZE}    @{S_OBJ_ALL}
-                        List Storagegroup    ${PRIV_KEY}    ${CID}   ${EMPTY}    @{EMPTY}
+                        ...  Get Storagegroup    ${WIF}    ${CID}    ${SG_OID_2}   ${EMPTY}    ${EXPECTED_SIZE}    @{S_OBJ_ALL}
+                        List Storagegroup    ${WIF}    ${CID}   ${EMPTY}    @{EMPTY}
 
                         Log    Incorrect input
 
                         Run Keyword And Expect Error    *
-                        ...  Put Storagegroup    ${PRIV_KEY}    ${CID}    ${EMPTY}    ${UNEXIST_OID}
+                        ...  Put Storagegroup    ${WIF}    ${CID}    ${EMPTY}    ${UNEXIST_OID}
                         Run Keyword And Expect Error    *
-                        ...  Delete Storagegroup    ${PRIV_KEY}    ${CID}    ${UNEXIST_OID}    ${EMPTY}
+                        ...  Delete Storagegroup    ${WIF}    ${CID}    ${UNEXIST_OID}    ${EMPTY}
 
-    [Teardown]          Cleanup
-
-*** Keywords ***
-
-Cleanup
-                        Get Docker Logs                     object_storage_group_simple
+    [Teardown]          Teardown    object_storage_group_simple

--- a/robot/testsuites/integration/payment/withdraw.robot
+++ b/robot/testsuites/integration/payment/withdraw.robot
@@ -3,9 +3,10 @@ Variables   ../../../variables/common.py
 
 Library     ../${RESOURCES}/neofs.py
 Library     ../${RESOURCES}/payment_neogo.py
-Library     ../${RESOURCES}/utility_keywords.py
 Library     ${KEYWORDS}/wallet_keywords.py
 Library     ${KEYWORDS}/rpc_call_keywords.py
+
+Resource    ../${RESOURCES}/setup_teardown.robot
 
 *** Variables ***
 ${DEPOSIT_AMOUNT} =     ${10}
@@ -18,9 +19,9 @@ NeoFS Deposit and Withdraw
     [Tags]                  Withdraw  NeoFS  NeoCLI
     [Timeout]               10 min
 
-    [Setup]                 Create Temporary Directory
+    [Setup]                 Setup
 
-    ${WALLET}   ${ADDR}     ${WIF} =   Init Wallet with Address    ${TEMP_DIR}
+    ${WALLET}   ${ADDR}     ${WIF} =   Init Wallet with Address    ${ASSETS_DIR}
     ${SCRIPT_HASH} =        Get ScriptHash                        ${WIF}
 
     ##########################################################
@@ -69,11 +70,4 @@ NeoFS Deposit and Withdraw
     ${WITHDRAW_FEE} =       Evaluate      ${WITHDRAW_AMOUNT} - ${MAINNET_BALANCE_DIFF}
     Log                     Withdraw fee is ${WITHDRAW_FEE}
 
-    [Teardown]              Cleanup
-
-
-*** Keywords ***
-
-Cleanup
-                            Cleanup Files
-                            Get Docker Logs    withdraw
+    [Teardown]              Teardown    withdraw

--- a/robot/testsuites/integration/services/http_gate.robot
+++ b/robot/testsuites/integration/services/http_gate.robot
@@ -4,9 +4,10 @@ Variables   ../../../variables/common.py
 Library     ../${RESOURCES}/neofs.py
 Library     ../${RESOURCES}/payment_neogo.py
 Library     ../${RESOURCES}/gates.py
-Library     ../${RESOURCES}/utility_keywords.py
 Library     ${KEYWORDS}/wallet_keywords.py
 Library     ${KEYWORDS}/rpc_call_keywords.py
+
+Resource    ../${RESOURCES}/setup_teardown.robot
 
 *** Variables ***
 ${PLACEMENT_RULE} =     "REP 1 IN X CBF 1 SELECT 1 FROM * AS X"
@@ -19,8 +20,8 @@ NeoFS HTTP Gateway
     [Documentation]     Creates container and does PUT, GET via HTTP Gate
     [Timeout]           5 min
 
-    [Setup]             Create Temporary Directory
-    ${WALLET}   ${ADDR}     ${WIF} =   Init Wallet with Address    ${TEMP_DIR}
+    [Setup]             Setup
+    ${WALLET}   ${ADDR}     ${WIF} =   Init Wallet with Address    ${ASSETS_DIR}
     ${TX} =             Transfer Mainnet Gas     ${MAINNET_WALLET_WIF}    ${ADDR}    ${TRANSFER_AMOUNT}
 
                         Wait Until Keyword Succeeds         ${MAINNET_TIMEOUT}    ${MAINNET_BLOCK_TIME}
@@ -65,12 +66,4 @@ NeoFS HTTP Gateway
                         Verify file hash                    ${GET_OBJ_L}    ${FILE_L_HASH}
                         Verify file hash                    ${FILEPATH}    ${FILE_L_HASH}
 
-    [Teardown]          Cleanup
-
-
-
-*** Keywords ***
-
-Cleanup
-                            Cleanup Files
-                            Get Docker Logs    http_gate
+    [Teardown]          Teardown    http_gate

--- a/robot/testsuites/integration/services/s3_gate.robot
+++ b/robot/testsuites/integration/services/s3_gate.robot
@@ -5,7 +5,8 @@ Library                         ../${RESOURCES}/neofs.py
 Library                         ../${RESOURCES}/payment_neogo.py
 Library                         ../${RESOURCES}/gates.py
 Library                         ${KEYWORDS}/wallet_keywords.py
-Library                         ../${RESOURCES}/utility_keywords.py
+
+Resource                        ../${RESOURCES}/setup_teardown.robot
 
 *** Variables ***
 ${DEPOSIT_AMOUNT} =     ${5}
@@ -15,10 +16,10 @@ NeoFS S3 Gateway
     [Documentation]             Execute operations via S3 Gate
     [Timeout]                   5 min
 
-    [Setup]                     Create Temporary Directory
+    [Setup]                     Setup
 
     ${WIF} =	                Form WIF from String    1dd37fba80fec4e6a6f13fd708d8dcb3b29def768017052f6c930fa1c5d90bbb
-    ${WALLET}   ${ADDR} =       Init Wallet from WIF    ${TEMP_DIR}     ${WIF}
+    ${WALLET}   ${ADDR} =       Init Wallet from WIF    ${ASSETS_DIR}     ${WIF}
     ${TX_DEPOSIT} =             NeoFS Deposit                         ${WIF}    ${DEPOSIT_AMOUNT}
                                 Wait Until Keyword Succeeds           1 min            15 sec
                                 ...  Transaction accepted in block    ${TX_DEPOSIT}
@@ -82,10 +83,4 @@ NeoFS S3 Gateway
                                 ${LIST_S3_OBJECTS} =             List objects S3       ${S3_CLIENT}    ${BUCKET}
                                 List Should Not Contain Value    ${LIST_S3_OBJECTS}    FILE_S3_NAME
 
-    [Teardown]                  Cleanup
-
-*** Keywords ***
-
-Cleanup
-                            Cleanup Files
-                            Get Docker Logs    s3_gate
+    [Teardown]                  Teardown    s3_gate

--- a/robot/variables/common.py
+++ b/robot/variables/common.py
@@ -43,4 +43,4 @@ NEOFS_CONTRACT = (os.getenv("NEOFS_CONTRACT") if os.getenv("NEOFS_CONTRACT")
 
 COMMON_PLACEMENT_RULE = "REP 2 IN X CBF 1 SELECT 2 FROM * AS X"
 
-TEMP_DIR = os.getenv("TEMP_DIR", "TemporaryDir/")
+ASSETS_DIR = os.getenv("ASSETS_DIR", "TemporaryDir/")


### PR DESCRIPTION
#66 

Changes introduced:

- `TEMP_DIR` -> `ASSETS_DIR`; removed special keyword for ASSETS_DIR creation and deletion, using keywords from robot library instead
- `PRIV_KEY` -> `WIF`
-  When deposit transaction persisted in main-chain we immediately make neofs balance check and in rare cases get zero balance. Balance is tracked in morph-chain, and it takes some time to propagate transaction among the chains. To work this around, added sleep for one morph block time.
- Added parameter for `Prepare container` keyword; removed setting WIF as a global variable
- Specified exact test name on each teardown
- Removed `Payment Operations` from `common_steps_object.robo`t library; using `Payment Operations` from `payment_operations.robot` instead

Complementary PR: https://github.com/nspcc-dev/neofs-keywords/pull/10