### PR TITLE
static eacl tables

### DIFF
--- a/robot/resources/files/eacl_tables/gen_eacl_allow_all_OTHERS
+++ b/robot/resources/files/eacl_tables/gen_eacl_allow_all_OTHERS
@@ -1,0 +1,74 @@
+{
+    "records": [
+        {
+            "operation": "GET",
+            "action": "ALLOW",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "OTHERS"
+                }
+            ]
+        },
+        {
+            "operation": "HEAD",
+            "action": "ALLOW",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "OTHERS"
+                }
+            ]
+        },
+        {
+            "operation": "PUT",
+            "action": "ALLOW",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "OTHERS"
+                }
+            ]
+        },
+        {
+            "operation": "DELETE",
+            "action": "ALLOW",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "OTHERS"
+                }
+            ]
+        },
+        {
+            "operation": "SEARCH",
+            "action": "ALLOW",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "OTHERS"
+                }
+            ]
+        },
+        {
+            "operation": "GETRANGE",
+            "action": "ALLOW",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "OTHERS"
+                }
+            ]
+        },
+        {
+            "operation": "GETRANGEHASH",
+            "action": "ALLOW",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "OTHERS"
+                }
+            ]
+        }
+    ]
+}

--- a/robot/resources/files/eacl_tables/gen_eacl_allow_all_SYSTEM
+++ b/robot/resources/files/eacl_tables/gen_eacl_allow_all_SYSTEM
@@ -1,0 +1,74 @@
+{
+    "records": [
+        {
+            "operation": "GET",
+            "action": "ALLOW",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "SYSTEM"
+                }
+            ]
+        },
+        {
+            "operation": "HEAD",
+            "action": "ALLOW",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "SYSTEM"
+                }
+            ]
+        },
+        {
+            "operation": "PUT",
+            "action": "ALLOW",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "SYSTEM"
+                }
+            ]
+        },
+        {
+            "operation": "DELETE",
+            "action": "ALLOW",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "SYSTEM"
+                }
+            ]
+        },
+        {
+            "operation": "SEARCH",
+            "action": "ALLOW",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "SYSTEM"
+                }
+            ]
+        },
+        {
+            "operation": "GETRANGE",
+            "action": "ALLOW",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "SYSTEM"
+                }
+            ]
+        },
+        {
+            "operation": "GETRANGEHASH",
+            "action": "ALLOW",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "SYSTEM"
+                }
+            ]
+        }
+    ]
+}

--- a/robot/resources/files/eacl_tables/gen_eacl_allow_all_USER
+++ b/robot/resources/files/eacl_tables/gen_eacl_allow_all_USER
@@ -1,0 +1,74 @@
+{
+    "records": [
+        {
+            "operation": "GET",
+            "action": "ALLOW",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "USER"
+                }
+            ]
+        },
+        {
+            "operation": "HEAD",
+            "action": "ALLOW",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "USER"
+                }
+            ]
+        },
+        {
+            "operation": "PUT",
+            "action": "ALLOW",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "USER"
+                }
+            ]
+        },
+        {
+            "operation": "DELETE",
+            "action": "ALLOW",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "USER"
+                }
+            ]
+        },
+        {
+            "operation": "SEARCH",
+            "action": "ALLOW",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "USER"
+                }
+            ]
+        },
+        {
+            "operation": "GETRANGE",
+            "action": "ALLOW",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "USER"
+                }
+            ]
+        },
+        {
+            "operation": "GETRANGEHASH",
+            "action": "ALLOW",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "USER"
+                }
+            ]
+        }
+    ]
+}

--- a/robot/resources/files/eacl_tables/gen_eacl_allow_pubkey_deny_OTHERS
+++ b/robot/resources/files/eacl_tables/gen_eacl_allow_pubkey_deny_OTHERS
@@ -1,0 +1,158 @@
+{
+    "records": [
+        {
+            "operation": "GET",
+            "action": "ALLOW",
+            "filters": [],
+            "targets": [
+                {
+                    "keys": [
+                        "A9tDy6Ye+UimXCCzJrlAmRE0FDZHjf3XRyya9rELtgAA"
+                    ]
+                }
+            ]
+        },
+        {
+            "operation": "HEAD",
+            "action": "ALLOW",
+            "filters": [],
+            "targets": [
+                {
+                    "keys": [
+                        "A9tDy6Ye+UimXCCzJrlAmRE0FDZHjf3XRyya9rELtgAA"
+                    ]
+                }
+            ]
+        },
+        {
+            "operation": "PUT",
+            "action": "ALLOW",
+            "filters": [],
+            "targets": [
+                {
+                    "keys": [
+                        "A9tDy6Ye+UimXCCzJrlAmRE0FDZHjf3XRyya9rELtgAA"
+                    ]
+                }
+            ]
+        },
+        {
+            "operation": "DELETE",
+            "action": "ALLOW",
+            "filters": [],
+            "targets": [
+                {
+                    "keys": [
+                        "A9tDy6Ye+UimXCCzJrlAmRE0FDZHjf3XRyya9rELtgAA"
+                    ]
+                }
+            ]
+        },
+        {
+            "operation": "SEARCH",
+            "action": "ALLOW",
+            "filters": [],
+            "targets": [
+                {
+                    "keys": [
+                        "A9tDy6Ye+UimXCCzJrlAmRE0FDZHjf3XRyya9rELtgAA"
+                    ]
+                }
+            ]
+        },
+        {
+            "operation": "GETRANGE",
+            "action": "ALLOW",
+            "filters": [],
+            "targets": [
+                {
+                    "keys": [
+                        "A9tDy6Ye+UimXCCzJrlAmRE0FDZHjf3XRyya9rELtgAA"
+                    ]
+                }
+            ]
+        },
+        {
+            "operation": "GETRANGEHASH",
+            "action": "ALLOW",
+            "filters": [],
+            "targets": [
+                {
+                    "keys": [
+                        "A9tDy6Ye+UimXCCzJrlAmRE0FDZHjf3XRyya9rELtgAA"
+                    ]
+                }
+            ]
+        },
+        {
+            "operation": "GET",
+            "action": "DENY",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "OTHERS"
+                }
+            ]
+        },
+        {
+            "operation": "HEAD",
+            "action": "DENY",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "OTHERS"
+                }
+            ]
+        },
+        {
+            "operation": "PUT",
+            "action": "DENY",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "OTHERS"
+                }
+            ]
+        },
+        {
+            "operation": "DELETE",
+            "action": "DENY",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "OTHERS"
+                }
+            ]
+        },
+        {
+            "operation": "SEARCH",
+            "action": "DENY",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "OTHERS"
+                }
+            ]
+        },
+        {
+            "operation": "GETRANGE",
+            "action": "DENY",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "OTHERS"
+                }
+            ]
+        },
+        {
+            "operation": "GETRANGEHASH",
+            "action": "DENY",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "OTHERS"
+                }
+            ]
+        }
+    ]
+}

--- a/robot/resources/files/eacl_tables/gen_eacl_compound_del_OTHERS
+++ b/robot/resources/files/eacl_tables/gen_eacl_compound_del_OTHERS
@@ -1,0 +1,34 @@
+{
+    "records": [
+        {
+            "operation": "DELETE",
+            "action": "ALLOW",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "OTHERS"
+                }
+            ]
+        },
+        {
+            "operation": "PUT",
+            "action": "DENY",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "OTHERS"
+                }
+            ]
+        },
+        {
+            "operation": "HEAD",
+            "action": "DENY",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "OTHERS"
+                }
+            ]
+        }
+    ]
+}

--- a/robot/resources/files/eacl_tables/gen_eacl_compound_del_SYSTEM
+++ b/robot/resources/files/eacl_tables/gen_eacl_compound_del_SYSTEM
@@ -1,0 +1,34 @@
+{
+    "records": [
+        {
+            "operation": "DELETE",
+            "action": "ALLOW",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "SYSTEM"
+                }
+            ]
+        },
+        {
+            "operation": "PUT",
+            "action": "DENY",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "SYSTEM"
+                }
+            ]
+        },
+        {
+            "operation": "HEAD",
+            "action": "DENY",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "SYSTEM"
+                }
+            ]
+        }
+    ]
+}

--- a/robot/resources/files/eacl_tables/gen_eacl_compound_del_USER
+++ b/robot/resources/files/eacl_tables/gen_eacl_compound_del_USER
@@ -1,0 +1,34 @@
+{
+    "records": [
+        {
+            "operation": "DELETE",
+            "action": "ALLOW",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "USER"
+                }
+            ]
+        },
+        {
+            "operation": "PUT",
+            "action": "DENY",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "USER"
+                }
+            ]
+        },
+        {
+            "operation": "HEAD",
+            "action": "DENY",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "USER"
+                }
+            ]
+        }
+    ]
+}

--- a/robot/resources/files/eacl_tables/gen_eacl_compound_get_OTHERS
+++ b/robot/resources/files/eacl_tables/gen_eacl_compound_get_OTHERS
@@ -1,0 +1,44 @@
+{
+    "records": [
+        {
+            "operation": "GET",
+            "action": "ALLOW",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "OTHERS"
+                }
+            ]
+        },
+        {
+            "operation": "GETRANGE",
+            "action": "ALLOW",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "OTHERS"
+                }
+            ]
+        },
+        {
+            "operation": "GETRANGEHASH",
+            "action": "ALLOW",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "OTHERS"
+                }
+            ]
+        },
+        {
+            "operation": "HEAD",
+            "action": "DENY",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "OTHERS"
+                }
+            ]
+        }
+    ]
+}

--- a/robot/resources/files/eacl_tables/gen_eacl_compound_get_SYSTEM
+++ b/robot/resources/files/eacl_tables/gen_eacl_compound_get_SYSTEM
@@ -1,0 +1,44 @@
+{
+    "records": [
+        {
+            "operation": "GET",
+            "action": "ALLOW",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "SYSTEM"
+                }
+            ]
+        },
+        {
+            "operation": "GETRANGE",
+            "action": "ALLOW",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "SYSTEM"
+                }
+            ]
+        },
+        {
+            "operation": "GETRANGEHASH",
+            "action": "ALLOW",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "SYSTEM"
+                }
+            ]
+        },
+        {
+            "operation": "HEAD",
+            "action": "DENY",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "SYSTEM"
+                }
+            ]
+        }
+    ]
+}

--- a/robot/resources/files/eacl_tables/gen_eacl_compound_get_USER
+++ b/robot/resources/files/eacl_tables/gen_eacl_compound_get_USER
@@ -1,0 +1,44 @@
+{
+    "records": [
+        {
+            "operation": "GET",
+            "action": "ALLOW",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "USER"
+                }
+            ]
+        },
+        {
+            "operation": "GETRANGE",
+            "action": "ALLOW",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "USER"
+                }
+            ]
+        },
+        {
+            "operation": "GETRANGEHASH",
+            "action": "ALLOW",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "USER"
+                }
+            ]
+        },
+        {
+            "operation": "HEAD",
+            "action": "DENY",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "USER"
+                }
+            ]
+        }
+    ]
+}

--- a/robot/resources/files/eacl_tables/gen_eacl_compound_get_hash_OTHERS
+++ b/robot/resources/files/eacl_tables/gen_eacl_compound_get_hash_OTHERS
@@ -1,0 +1,34 @@
+{
+    "records": [
+        {
+            "operation": "GETRANGEHASH",
+            "action": "ALLOW",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "OTHERS"
+                }
+            ]
+        },
+        {
+            "operation": "GETRANGE",
+            "action": "DENY",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "OTHERS"
+                }
+            ]
+        },
+        {
+            "operation": "GET",
+            "action": "DENY",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "OTHERS"
+                }
+            ]
+        }
+    ]
+}

--- a/robot/resources/files/eacl_tables/gen_eacl_compound_get_hash_SYSTEM
+++ b/robot/resources/files/eacl_tables/gen_eacl_compound_get_hash_SYSTEM
@@ -1,0 +1,34 @@
+{
+    "records": [
+        {
+            "operation": "GETRANGEHASH",
+            "action": "ALLOW",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "SYSTEM"
+                }
+            ]
+        },
+        {
+            "operation": "GETRANGE",
+            "action": "DENY",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "SYSTEM"
+                }
+            ]
+        },
+        {
+            "operation": "GET",
+            "action": "DENY",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "SYSTEM"
+                }
+            ]
+        }
+    ]
+}

--- a/robot/resources/files/eacl_tables/gen_eacl_compound_get_hash_USER
+++ b/robot/resources/files/eacl_tables/gen_eacl_compound_get_hash_USER
@@ -1,0 +1,34 @@
+{
+    "records": [
+        {
+            "operation": "GETRANGEHASH",
+            "action": "ALLOW",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "USER"
+                }
+            ]
+        },
+        {
+            "operation": "GETRANGE",
+            "action": "DENY",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "USER"
+                }
+            ]
+        },
+        {
+            "operation": "GET",
+            "action": "DENY",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "USER"
+                }
+            ]
+        }
+    ]
+}

--- a/robot/resources/files/eacl_tables/gen_eacl_deny_all_OTHERS
+++ b/robot/resources/files/eacl_tables/gen_eacl_deny_all_OTHERS
@@ -1,0 +1,74 @@
+{
+    "records": [
+        {
+            "operation": "GET",
+            "action": "DENY",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "OTHERS"
+                }
+            ]
+        },
+        {
+            "operation": "HEAD",
+            "action": "DENY",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "OTHERS"
+                }
+            ]
+        },
+        {
+            "operation": "PUT",
+            "action": "DENY",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "OTHERS"
+                }
+            ]
+        },
+        {
+            "operation": "DELETE",
+            "action": "DENY",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "OTHERS"
+                }
+            ]
+        },
+        {
+            "operation": "SEARCH",
+            "action": "DENY",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "OTHERS"
+                }
+            ]
+        },
+        {
+            "operation": "GETRANGE",
+            "action": "DENY",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "OTHERS"
+                }
+            ]
+        },
+        {
+            "operation": "GETRANGEHASH",
+            "action": "DENY",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "OTHERS"
+                }
+            ]
+        }
+    ]
+}

--- a/robot/resources/files/eacl_tables/gen_eacl_deny_all_SYSTEM
+++ b/robot/resources/files/eacl_tables/gen_eacl_deny_all_SYSTEM
@@ -1,0 +1,74 @@
+{
+    "records": [
+        {
+            "operation": "GET",
+            "action": "DENY",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "SYSTEM"
+                }
+            ]
+        },
+        {
+            "operation": "HEAD",
+            "action": "DENY",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "SYSTEM"
+                }
+            ]
+        },
+        {
+            "operation": "PUT",
+            "action": "DENY",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "SYSTEM"
+                }
+            ]
+        },
+        {
+            "operation": "DELETE",
+            "action": "DENY",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "SYSTEM"
+                }
+            ]
+        },
+        {
+            "operation": "SEARCH",
+            "action": "DENY",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "SYSTEM"
+                }
+            ]
+        },
+        {
+            "operation": "GETRANGE",
+            "action": "DENY",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "SYSTEM"
+                }
+            ]
+        },
+        {
+            "operation": "GETRANGEHASH",
+            "action": "DENY",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "SYSTEM"
+                }
+            ]
+        }
+    ]
+}

--- a/robot/resources/files/eacl_tables/gen_eacl_deny_all_USER
+++ b/robot/resources/files/eacl_tables/gen_eacl_deny_all_USER
@@ -1,0 +1,74 @@
+{
+    "records": [
+        {
+            "operation": "GET",
+            "action": "DENY",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "USER"
+                }
+            ]
+        },
+        {
+            "operation": "HEAD",
+            "action": "DENY",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "USER"
+                }
+            ]
+        },
+        {
+            "operation": "PUT",
+            "action": "DENY",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "USER"
+                }
+            ]
+        },
+        {
+            "operation": "DELETE",
+            "action": "DENY",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "USER"
+                }
+            ]
+        },
+        {
+            "operation": "SEARCH",
+            "action": "DENY",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "USER"
+                }
+            ]
+        },
+        {
+            "operation": "GETRANGE",
+            "action": "DENY",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "USER"
+                }
+            ]
+        },
+        {
+            "operation": "GETRANGEHASH",
+            "action": "DENY",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "USER"
+                }
+            ]
+        }
+    ]
+}

--- a/robot/resources/files/eacl_tables/gen_eacl_xheader_allow_all
+++ b/robot/resources/files/eacl_tables/gen_eacl_xheader_allow_all
@@ -1,0 +1,193 @@
+{
+    "records": [
+        {
+            "operation": "GET",
+            "action": "ALLOW",
+            "filters": [
+                {
+                    "headerType": "REQUEST",
+                    "matchType": "STRING_EQUAL",
+                    "key": "a",
+                    "value": "2"
+                }
+            ],
+            "targets": [
+                {
+                    "role": "OTHERS"
+                }
+            ]
+        },
+        {
+            "operation": "GET",
+            "action": "DENY",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "OTHERS"
+                }
+            ]
+        },
+        {
+            "operation": "HEAD",
+            "action": "ALLOW",
+            "filters": [
+                {
+                    "headerType": "REQUEST",
+                    "matchType": "STRING_EQUAL",
+                    "key": "a",
+                    "value": "2"
+                }
+            ],
+            "targets": [
+                {
+                    "role": "OTHERS"
+                }
+            ]
+        },
+        {
+            "operation": "HEAD",
+            "action": "DENY",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "OTHERS"
+                }
+            ]
+        },
+        {
+            "operation": "PUT",
+            "action": "ALLOW",
+            "filters": [
+                {
+                    "headerType": "REQUEST",
+                    "matchType": "STRING_EQUAL",
+                    "key": "a",
+                    "value": "2"
+                }
+            ],
+            "targets": [
+                {
+                    "role": "OTHERS"
+                }
+            ]
+        },
+        {
+            "operation": "PUT",
+            "action": "DENY",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "OTHERS"
+                }
+            ]
+        },
+        {
+            "operation": "DELETE",
+            "action": "ALLOW",
+            "filters": [
+                {
+                    "headerType": "REQUEST",
+                    "matchType": "STRING_EQUAL",
+                    "key": "a",
+                    "value": "2"
+                }
+            ],
+            "targets": [
+                {
+                    "role": "OTHERS"
+                }
+            ]
+        },
+        {
+            "operation": "DELETE",
+            "action": "DENY",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "OTHERS"
+                }
+            ]
+        },
+        {
+            "operation": "SEARCH",
+            "action": "ALLOW",
+            "filters": [
+                {
+                    "headerType": "REQUEST",
+                    "matchType": "STRING_EQUAL",
+                    "key": "a",
+                    "value": "2"
+                }
+            ],
+            "targets": [
+                {
+                    "role": "OTHERS"
+                }
+            ]
+        },
+        {
+            "operation": "SEARCH",
+            "action": "DENY",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "OTHERS"
+                }
+            ]
+        },
+        {
+            "operation": "GETRANGE",
+            "action": "ALLOW",
+            "filters": [
+                {
+                    "headerType": "REQUEST",
+                    "matchType": "STRING_EQUAL",
+                    "key": "a",
+                    "value": "2"
+                }
+            ],
+            "targets": [
+                {
+                    "role": "OTHERS"
+                }
+            ]
+        },
+        {
+            "operation": "GETRANGE",
+            "action": "DENY",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "OTHERS"
+                }
+            ]
+        },
+        {
+            "operation": "GETRANGEHASH",
+            "action": "ALLOW",
+            "filters": [
+                {
+                    "headerType": "REQUEST",
+                    "matchType": "STRING_EQUAL",
+                    "key": "a",
+                    "value": "2"
+                }
+            ],
+            "targets": [
+                {
+                    "role": "OTHERS"
+                }
+            ]
+        },
+        {
+            "operation": "GETRANGEHASH",
+            "action": "DENY",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "OTHERS"
+                }
+            ]
+        }
+    ]
+}

--- a/robot/resources/files/eacl_tables/gen_eacl_xheader_deny_all
+++ b/robot/resources/files/eacl_tables/gen_eacl_xheader_deny_all
@@ -1,0 +1,123 @@
+{
+    "records": [
+        {
+            "operation": "GET",
+            "action": "DENY",
+            "filters": [
+                {
+                    "headerType": "REQUEST",
+                    "matchType": "STRING_EQUAL",
+                    "key": "a",
+                    "value": "2"
+                }
+            ],
+            "targets": [
+                {
+                    "role": "OTHERS"
+                }
+            ]
+        },
+        {
+            "operation": "HEAD",
+            "action": "DENY",
+            "filters": [
+                {
+                    "headerType": "REQUEST",
+                    "matchType": "STRING_EQUAL",
+                    "key": "a",
+                    "value": "2"
+                }
+            ],
+            "targets": [
+                {
+                    "role": "OTHERS"
+                }
+            ]
+        },
+        {
+            "operation": "PUT",
+            "action": "DENY",
+            "filters": [
+                {
+                    "headerType": "REQUEST",
+                    "matchType": "STRING_EQUAL",
+                    "key": "a",
+                    "value": "2"
+                }
+            ],
+            "targets": [
+                {
+                    "role": "OTHERS"
+                }
+            ]
+        },
+        {
+            "operation": "DELETE",
+            "action": "DENY",
+            "filters": [
+                {
+                    "headerType": "REQUEST",
+                    "matchType": "STRING_EQUAL",
+                    "key": "a",
+                    "value": "2"
+                }
+            ],
+            "targets": [
+                {
+                    "role": "OTHERS"
+                }
+            ]
+        },
+        {
+            "operation": "SEARCH",
+            "action": "DENY",
+            "filters": [
+                {
+                    "headerType": "REQUEST",
+                    "matchType": "STRING_EQUAL",
+                    "key": "a",
+                    "value": "2"
+                }
+            ],
+            "targets": [
+                {
+                    "role": "OTHERS"
+                }
+            ]
+        },
+        {
+            "operation": "GETRANGE",
+            "action": "DENY",
+            "filters": [
+                {
+                    "headerType": "REQUEST",
+                    "matchType": "STRING_EQUAL",
+                    "key": "a",
+                    "value": "2"
+                }
+            ],
+            "targets": [
+                {
+                    "role": "OTHERS"
+                }
+            ]
+        },
+        {
+            "operation": "GETRANGEHASH",
+            "action": "DENY",
+            "filters": [
+                {
+                    "headerType": "REQUEST",
+                    "matchType": "STRING_EQUAL",
+                    "key": "a",
+                    "value": "2"
+                }
+            ],
+            "targets": [
+                {
+                    "role": "OTHERS"
+                }
+            ]
+        }
+    ]
+}

--- a/robot/resources/lib/neofs.py
+++ b/robot/resources/lib/neofs.py
@@ -192,11 +192,10 @@ def get_epoch(private_key: str):
         raise Exception(f"command '{e.cmd}' return with error (code {e.returncode}): {e.output}")
 
 @keyword('Set eACL')
-def set_eacl(private_key: str, cid: str, eacl: str, add_keys: str = ""):
-    file_path = f"{ASSETS_DIR}/{eacl}"
+def set_eacl(private_key: str, cid: str, eacl_table_path: str):
     cmd = (
         f'{NEOFS_CLI_EXEC} --rpc-endpoint {NEOFS_ENDPOINT} --key {private_key} '
-        f'container set-eacl --cid {cid} --table {file_path} {add_keys}'
+        f'container set-eacl --cid {cid} --table {eacl_table_path} --await'
     )
     logger.info(f"Cmd: {cmd}")
     try:
@@ -265,9 +264,8 @@ def form_bearertoken_file(private_key: str, cid: str, file_name: str, eacl_oper_
     return file_path
 
 @keyword('Form eACL json common file')
-def form_eacl_json_common_file(file_name, eacl_oper_list ):
+def form_eacl_json_common_file(file_path, eacl_oper_list ):
     # Input role can be Role (USER, SYSTEM, OTHERS) or public key.
-    file_path = f"{ASSETS_DIR}/{file_name}"
     eacl = {"records":[]}
 
     logger.info(eacl_oper_list)
@@ -291,7 +289,7 @@ def form_eacl_json_common_file(file_name, eacl_oper_list ):
         with open(file_path, 'w', encoding='utf-8') as f:
             json.dump(eacl, f, ensure_ascii=False, indent=4)
 
-    return file_name
+    return file_path
 
 
 @keyword('Get Range')

--- a/robot/resources/scripts/acl_tables_generator.py
+++ b/robot/resources/scripts/acl_tables_generator.py
@@ -1,0 +1,185 @@
+#!/usr/bin/python3.8
+
+###################################
+# eACL tables generation functions
+###################################
+
+import json
+
+VERBS = [
+    'GET',
+    'HEAD',
+    'PUT',
+    'DELETE',
+    'SEARCH',
+    'GETRANGE',
+    'GETRANGEHASH'
+]
+
+ROLES = [
+    'OTHERS',
+    'USER',
+    'SYSTEM'
+]
+
+ACCESS = [
+    'DENY',
+    'ALLOW'
+]
+
+TABLES_DIR = '../files/eacl_tables/'
+
+
+def deny_allow_tables_per_role():
+    for a in ACCESS:
+        for r in ROLES:
+            table_dict = {
+                        "records": []
+                    }
+            for v in VERBS:
+                table_record =  {
+                    "operation": v,
+                    "action": a,
+                    "filters": [],
+                    "targets": [
+                        {
+                            "role": r
+                        }
+                    ]
+                }
+                table_dict['records'].append(table_record)
+            with open(f"{TABLES_DIR}/gen_eacl_{a.lower()}_all_{r}", "w+") as f:
+                json.dump(table_dict, f, indent=4)
+
+def allow_pubkey_deny_others():
+    table_dict = {
+                "records": []
+            }
+    for v in VERBS:
+        table_record =  {
+            "operation": v,
+            "action": "ALLOW",
+            "filters": [],
+            "targets": [
+                {
+                    # TODO: where do we take this value from?
+                    "keys": [ 'A9tDy6Ye+UimXCCzJrlAmRE0FDZHjf3XRyya9rELtgAA' ]
+                }
+            ]
+        }
+        table_dict['records'].append(table_record)
+    for v in VERBS:
+        table_record =  {
+            "operation": v,
+            "action": "DENY",
+            "filters": [],
+            "targets": [
+                {
+                    "role": 'OTHERS'
+                }
+            ]
+        }
+        table_dict['records'].append(table_record)
+    with open(f"{TABLES_DIR}/gen_eacl_allow_pubkey_deny_OTHERS", "w+") as f:
+        json.dump(table_dict, f, indent=4)
+
+def compound_tables():
+    compounds = {
+        'get': {
+            'GET': 'ALLOW',
+            'GETRANGE': 'ALLOW',
+            'GETRANGEHASH': 'ALLOW',
+            'HEAD': 'DENY'
+        },
+        'del': {
+            'DELETE': 'ALLOW',
+            'PUT': 'DENY',
+            'HEAD': 'DENY'
+        },
+        'get_hash': {
+            'GETRANGEHASH': 'ALLOW',
+            'GETRANGE': 'DENY',
+            'GET': 'DENY'
+        }
+    }
+    for op, compound in compounds.items():
+        for r in ROLES:
+            table_dict = {
+                        "records": []
+                    }
+            for verb, access in compound.items():
+                table_record =  {
+                    "operation": verb,
+                    "action": access,
+                    "filters": [],
+                    "targets": [
+                        {
+                            "role": r
+                        }
+                    ]
+                }
+                table_dict['records'].append(table_record)
+
+            with open(f"{TABLES_DIR}/gen_eacl_compound_{op}_{r}", "w+") as f:
+                json.dump(table_dict, f, indent=4)
+
+def xheader_tables():
+    filters = {
+        'headerType': 'REQUEST',
+        'matchType': 'STRING_EQUAL',
+        'key': 'a',
+        'value': '2'
+    }
+    table_dict = {
+                "records": []
+            }
+    for verb in VERBS:
+        table_record =  {
+            "operation": verb,
+            "action": "DENY",
+            "filters": [filters],
+            "targets": [
+                {
+                    "role": "OTHERS"
+                }
+            ]
+        }
+        table_dict['records'].append(table_record)
+    with open(f"{TABLES_DIR}/gen_eacl_xheader_deny_all", "w+") as f:
+        json.dump(table_dict, f, indent=4)
+
+    table_dict = {
+                "records": []
+            }
+    for verb in VERBS:
+        table_record =  {
+            "operation": verb,
+            "action": "ALLOW",
+            "filters": [filters],
+            "targets": [
+                {
+                    "role": "OTHERS"
+                }
+            ]
+        }
+        table_dict['records'].append(table_record)
+
+        table_record =  {
+            "operation": verb,
+            "action": "DENY",
+            "filters": [],
+            "targets": [
+                {
+                    "role": "OTHERS"
+                }
+            ]
+        }
+        table_dict['records'].append(table_record)
+    with open(f"{TABLES_DIR}/gen_eacl_xheader_allow_all", "w+") as f:
+        json.dump(table_dict, f, indent=4)
+
+
+deny_allow_tables_per_role()
+allow_pubkey_deny_others()
+compound_tables()
+xheader_tables()

--- a/robot/testsuites/integration/acl/acl_bearer_allow.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_allow.robot
@@ -50,7 +50,7 @@ Check eACL Deny and Allow All Bearer
                             Get Range         ${USER_KEY}    ${CID}        ${S_OID_USER}    s_get_range    ${EMPTY}              0:256
                             Delete object     ${USER_KEY}    ${CID}        ${D_OID_USER}    ${EMPTY}
 
-                            Set eACL          ${USER_KEY}    ${CID}        ${EACL_DENY_ALL_USER}    --await
+                            Set eACL          ${USER_KEY}    ${CID}        ${EACL_DENY_ALL_USER}
 
                             # The current ACL cache lifetime is 30 sec
                             Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}

--- a/robot/testsuites/integration/acl/acl_bearer_allow_storagegroup.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_allow_storagegroup.robot
@@ -51,7 +51,7 @@ Check eACL Deny and Allow All Bearer
                             Get Storagegroup    ${USER_KEY}    ${CID}    ${SG_OID_1}   ${EMPTY}    ${EMPTY}    @{EXPECTED_OIDS}
                             Delete Storagegroup    ${USER_KEY}    ${CID}    ${SG_OID_1}    ${EMPTY}
 
-                            Set eACL                            ${USER_KEY}    ${CID}        ${EACL_DENY_ALL_USER}    --await
+                            Set eACL                            ${USER_KEY}    ${CID}        ${EACL_DENY_ALL_USER}
 
                             # The current ACL cache lifetime is 30 sec
                             Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}

--- a/robot/testsuites/integration/acl/acl_bearer_compound.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_compound.robot
@@ -59,7 +59,7 @@ Check Bearer Сompound Get
     ${S_OID_USER} =         Put object             ${USER_KEY}    ${FILE_S}    ${CID}           ${EMPTY}    ${FILE_USR_HEADER}
                             Put object             ${KEY}         ${FILE_S}    ${CID}           ${EMPTY}    ${FILE_OTH_HEADER}
                             Get object           ${KEY}         ${CID}       ${S_OID_USER}    ${EMPTY}    local_file_eacl
-                            Set eACL                        ${USER_KEY}    ${CID}       ${DENY_EACL}     --await
+                            Set eACL                        ${USER_KEY}    ${CID}       ${DENY_EACL}
 
                             # The current ACL cache lifetime is 30 sec
                             Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}
@@ -88,7 +88,7 @@ Check Bearer Сompound Delete
                             Put object             ${KEY}         ${FILE_S}    ${CID}           ${EMPTY}    ${FILE_OTH_HEADER}
                             Delete object                   ${KEY}         ${CID}       ${D_OID_USER}    ${EMPTY}
 
-                            Set eACL                        ${USER_KEY}    ${CID}       ${DENY_EACL}     --await
+                            Set eACL                        ${USER_KEY}    ${CID}       ${DENY_EACL}
 
                             # The current ACL cache lifetime is 30 sec
                             Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}
@@ -117,7 +117,7 @@ Check Bearer Сompound Get Range Hash
                             Put object             ${KEY}              ${FILE_S}    ${CID}           ${EMPTY}    ${FILE_OTH_HEADER}
                             Get Range Hash                  ${SYSTEM_KEY_SN}    ${CID}       ${S_OID_USER}    ${EMPTY}    0:256
 
-                            Set eACL                        ${USER_KEY}         ${CID}       ${DENY_EACL}     --await
+                            Set eACL                        ${USER_KEY}         ${CID}       ${DENY_EACL}
 
                             # The current ACL cache lifetime is 30 sec
                             Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}

--- a/robot/testsuites/integration/acl/acl_bearer_filter_oid_equal.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_filter_oid_equal.robot
@@ -50,7 +50,7 @@ Check eACL Deny and Allow All Bearer Filter OID Equal
                             Get Range          ${USER_KEY}    ${CID}        ${S_OID_USER}        s_get_range       ${EMPTY}          0:256
                             Delete object      ${USER_KEY}    ${CID}        ${D_OID_USER}        ${EMPTY}
 
-                            Set eACL           ${USER_KEY}    ${CID}        ${EACL_DENY_ALL_USER}    --await
+                            Set eACL           ${USER_KEY}    ${CID}        ${EACL_DENY_ALL_USER}
 
                             # The current ACL cache lifetime is 30 sec
                             Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}

--- a/robot/testsuites/integration/acl/acl_bearer_filter_oid_not_equal.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_filter_oid_not_equal.robot
@@ -72,7 +72,7 @@ Check eACL Deny and Allow All Bearer Filter OID NotEqual
                             Get Range                           ${USER_KEY}    ${CID}        ${S_OID_USER}            s_get_range            ${EMPTY}              0:256
                             Delete object                       ${USER_KEY}    ${CID}        ${D_OID_USER}            ${EMPTY}
 
-                            Set eACL                            ${USER_KEY}    ${CID}        ${EACL_DENY_ALL_USER}    --await
+                            Set eACL                            ${USER_KEY}    ${CID}        ${EACL_DENY_ALL_USER}
 
                             # The current ACL cache lifetime is 30 sec
                             Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}

--- a/robot/testsuites/integration/acl/acl_bearer_filter_userheader_equal.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_filter_userheader_equal.robot
@@ -66,7 +66,7 @@ Check eACL Deny and Allow All Bearer Filter UserHeader Equal
                             Get Range                           ${USER_KEY}    ${CID}        ${S_OID_USER}            s_get_range            ${EMPTY}              0:256
                             Delete object                       ${USER_KEY}    ${CID}        ${D_OID_USER}            ${EMPTY}
 
-                            Set eACL                            ${USER_KEY}    ${CID}        ${EACL_DENY_ALL_USER}    --await
+                            Set eACL                            ${USER_KEY}    ${CID}        ${EACL_DENY_ALL_USER}
 
                             # The current ACL cache lifetime is 30 sec
                             Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}

--- a/robot/testsuites/integration/acl/acl_bearer_filter_userheader_not_equal.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_filter_userheader_not_equal.robot
@@ -48,7 +48,7 @@ Check eACL Deny and Allow All Bearer Filter UserHeader NotEqual
                             Get Range                           ${USER_KEY}    ${CID}        ${S_OID_USER}            s_get_range            ${EMPTY}              0:256
                             Delete object                       ${USER_KEY}    ${CID}        ${D_OID_USER}            ${EMPTY}
 
-                            Set eACL                            ${USER_KEY}    ${CID}        ${EACL_DENY_ALL_USER}    --await
+                            Set eACL                            ${USER_KEY}    ${CID}        ${EACL_DENY_ALL_USER}
 
                             # The current ACL cache lifetime is 30 sec
                             Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}

--- a/robot/testsuites/integration/acl/acl_bearer_request_filter_xheader_equal.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_request_filter_xheader_equal.robot
@@ -51,7 +51,7 @@ Check eACL Deny and Allow All Bearer Filter Requst Equal
                             Get Range                  ${USER_KEY}    ${CID}        ${S_OID_USER}            s_get_range            ${EMPTY}              0:256
                             Delete object              ${USER_KEY}    ${CID}        ${D_OID_USER}            ${EMPTY}
 
-                            Set eACL                   ${USER_KEY}    ${CID}        ${EACL_DENY_ALL_USER}    --await
+                            Set eACL                   ${USER_KEY}    ${CID}        ${EACL_DENY_ALL_USER}
 
                             # The current ACL cache lifetime is 30 sec
                             Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}

--- a/robot/testsuites/integration/acl/acl_bearer_request_filter_xheader_not_equal.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_request_filter_xheader_not_equal.robot
@@ -50,7 +50,7 @@ Check eACL Deny and Allow All Bearer Filter Requst NotEqual
                             Get Range                  ${USER_KEY}    ${CID}        ${S_OID_USER}            s_get_range            ${EMPTY}              0:256
                             Delete object              ${USER_KEY}    ${CID}        ${D_OID_USER}            ${EMPTY}
 
-                            Set eACL                   ${USER_KEY}    ${CID}        ${EACL_DENY_ALL_USER}    --await
+                            Set eACL                   ${USER_KEY}    ${CID}        ${EACL_DENY_ALL_USER}
 
                             # The current ACL cache lifetime is 30 sec
                             Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}

--- a/robot/testsuites/integration/acl/acl_extended_actions_other.robot
+++ b/robot/testsuites/integration/acl/acl_extended_actions_other.robot
@@ -1,12 +1,14 @@
 *** Settings ***
-Variables                   ../../../variables/common.py
-Library                     Collections
-Library                     ../${RESOURCES}/neofs.py
-Library                     ../${RESOURCES}/payment_neogo.py
+Variables    ../../../variables/common.py
 
-Resource                    common_steps_acl_extended.robot
-Resource                    ../${RESOURCES}/payment_operations.robot
-Resource                    ../${RESOURCES}/setup_teardown.robot
+Library      Collections
+Library      ../${RESOURCES}/neofs.py
+Library      ../${RESOURCES}/payment_neogo.py
+
+Resource     common_steps_acl_extended.robot
+Resource     ../${RESOURCES}/payment_operations.robot
+Resource     ../${RESOURCES}/setup_teardown.robot
+Resource       ../../../variables/eacl_tables.robot
 
 *** Test cases ***
 Extended ACL Operations
@@ -18,7 +20,6 @@ Extended ACL Operations
 
                             Generate Keys
                             Generate eACL Keys
-                            Prepare eACL Role rules
 
                             Log    Check extended ACL with simple object
                             Generate files    ${SIMPLE_OBJ_SIZE}

--- a/robot/testsuites/integration/acl/acl_extended_actions_pubkey.robot
+++ b/robot/testsuites/integration/acl/acl_extended_actions_pubkey.robot
@@ -1,13 +1,14 @@
 *** Settings ***
-Variables                   ../../../variables/common.py
-Library                     ../${RESOURCES}/neofs.py
-Library                     ../${RESOURCES}/payment_neogo.py
+Variables    ../../../variables/common.py
+Library      ../${RESOURCES}/neofs.py
+Library      ../${RESOURCES}/payment_neogo.py
 
-Library                     Collections
+Library      Collections
 
-Resource                    common_steps_acl_extended.robot
-Resource                    ../${RESOURCES}/payment_operations.robot
-Resource                    ../${RESOURCES}/setup_teardown.robot
+Resource     common_steps_acl_extended.robot
+Resource     ../${RESOURCES}/payment_operations.robot
+Resource     ../${RESOURCES}/setup_teardown.robot
+Resource       ../../../variables/eacl_tables.robot
 
 *** Test cases ***
 Extended ACL Operations
@@ -19,7 +20,6 @@ Extended ACL Operations
 
                             Generate Keys
                             Generate eACL Keys
-                            Prepare eACL Role rules
 
                             Log    Check extended ACL with simple object
                             Generate files    ${SIMPLE_OBJ_SIZE}
@@ -50,7 +50,7 @@ Check eACL Deny All Other and Allow All Pubkey
                             Get Range Hash                      ${EACL_KEY}    ${CID}        ${S_OID_USER}            ${EMPTY}            0:256
                             Delete object                       ${EACL_KEY}    ${CID}        ${D_OID_USER}            ${EMPTY}
 
-                            Set eACL                            ${USER_KEY}    ${CID}        ${EACL_ALLOW_ALL_Pubkey}    --await
+                            Set eACL                            ${USER_KEY}    ${CID}        ${EACL_ALLOW_ALL_Pubkey}
 
                             # The current ACL cache lifetime is 30 sec
                             Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}

--- a/robot/testsuites/integration/acl/acl_extended_actions_system.robot
+++ b/robot/testsuites/integration/acl/acl_extended_actions_system.robot
@@ -1,12 +1,14 @@
 *** Settings ***
-Variables                   ../../../variables/common.py
-Library                     Collections
-Library                     ../${RESOURCES}/neofs.py
-Library                     ../${RESOURCES}/payment_neogo.py
+Variables       ../../../variables/common.py
 
-Resource                    common_steps_acl_extended.robot
-Resource                    ../${RESOURCES}/payment_operations.robot
-Resource                    ../${RESOURCES}/setup_teardown.robot
+Library         Collections
+Library         ../${RESOURCES}/neofs.py
+Library         ../${RESOURCES}/payment_neogo.py
+
+Resource        common_steps_acl_extended.robot
+Resource        ../${RESOURCES}/payment_operations.robot
+Resource        ../${RESOURCES}/setup_teardown.robot
+Resource        ../../../variables/eacl_tables.robot
 
 *** Test cases ***
 Extended ACL Operations
@@ -18,7 +20,6 @@ Extended ACL Operations
 
                             Generate Keys
                             Generate eACL Keys
-                            Prepare eACL Role rules
 
                             Log    Check extended ACL with simple object
                             Generate files    ${SIMPLE_OBJ_SIZE}
@@ -42,97 +43,97 @@ Check eACL Deny and Allow All System
 
     @{S_OBJ_H} =	        Create List	             ${S_OID_USER}
 
-                            Put object      ${SYSTEM_KEY}       ${FILE_S}    ${CID}    ${EMPTY}    ${FILE_OTH_HEADER}
-                            Put object      ${SYSTEM_KEY_SN}    ${FILE_S}    ${CID}    ${EMPTY}    ${FILE_OTH_HEADER}
+    Put object      ${SYSTEM_KEY}       ${FILE_S}    ${CID}    ${EMPTY}    ${FILE_OTH_HEADER}
+    Put object      ${SYSTEM_KEY_SN}    ${FILE_S}    ${CID}    ${EMPTY}    ${FILE_OTH_HEADER}
 
-                            Get object    ${SYSTEM_KEY}       ${CID}    ${S_OID_USER}    ${EMPTY}    local_file_eacl
-                            Get object    ${SYSTEM_KEY_SN}    ${CID}    ${S_OID_USER}    ${EMPTY}    local_file_eacl
+    Get object    ${SYSTEM_KEY}       ${CID}    ${S_OID_USER}    ${EMPTY}    local_file_eacl
+    Get object    ${SYSTEM_KEY_SN}    ${CID}    ${S_OID_USER}    ${EMPTY}    local_file_eacl
 
-                            Search object            ${SYSTEM_KEY}       ${CID}    ${EMPTY}    ${EMPTY}    ${FILE_USR_HEADER}    ${S_OBJ_H}
-                            Search object            ${SYSTEM_KEY_SN}    ${CID}    ${EMPTY}    ${EMPTY}    ${FILE_USR_HEADER}    ${S_OBJ_H}
+    Search object            ${SYSTEM_KEY}       ${CID}    ${EMPTY}    ${EMPTY}    ${FILE_USR_HEADER}    ${S_OBJ_H}
+    Search object            ${SYSTEM_KEY_SN}    ${CID}    ${EMPTY}    ${EMPTY}    ${FILE_USR_HEADER}    ${S_OBJ_H}
 
-                            Head object              ${SYSTEM_KEY}       ${CID}    ${S_OID_USER}    ${EMPTY}
-                            Head object              ${SYSTEM_KEY_SN}    ${CID}    ${S_OID_USER}    ${EMPTY}
+    Head object              ${SYSTEM_KEY}       ${CID}    ${S_OID_USER}    ${EMPTY}
+    Head object              ${SYSTEM_KEY_SN}    ${CID}    ${S_OID_USER}    ${EMPTY}
 
-                            Get Range                ${SYSTEM_KEY}       ${CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
-                            Get Range                ${SYSTEM_KEY_SN}    ${CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+    Get Range                ${SYSTEM_KEY}       ${CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+    Get Range                ${SYSTEM_KEY_SN}    ${CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
 
-                            Get Range Hash           ${SYSTEM_KEY}       ${CID}    ${S_OID_USER}    ${EMPTY}    0:256
-                            Get Range Hash           ${SYSTEM_KEY_SN}    ${CID}    ${S_OID_USER}    ${EMPTY}    0:256
+    Get Range Hash           ${SYSTEM_KEY}       ${CID}    ${S_OID_USER}    ${EMPTY}    0:256
+    Get Range Hash           ${SYSTEM_KEY_SN}    ${CID}    ${S_OID_USER}    ${EMPTY}    0:256
 
-                            Delete object            ${SYSTEM_KEY}       ${CID}    ${D_OID_USER_S}     ${EMPTY}
-                            Delete object            ${SYSTEM_KEY_SN}    ${CID}    ${D_OID_USER_SN}    ${EMPTY}
+    Delete object            ${SYSTEM_KEY}       ${CID}    ${D_OID_USER_S}     ${EMPTY}
+    Delete object            ${SYSTEM_KEY_SN}    ${CID}    ${D_OID_USER_SN}    ${EMPTY}
 
-                            Set eACL                 ${USER_KEY}     ${CID}        ${EACL_DENY_ALL_SYSTEM}    --await
+    Set eACL                 ${USER_KEY}     ${CID}        ${EACL_DENY_ALL_SYSTEM}
 
-                            # The current ACL cache lifetime is 30 sec
-                            Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}
+    # The current ACL cache lifetime is 30 sec
+    Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}
 
-                            Run Keyword And Expect Error    *
-                            ...  Put object        ${SYSTEM_KEY}       ${FILE_S}    ${CID}    ${EMPTY}    ${FILE_OTH_HEADER}
-                            Run Keyword And Expect Error    *
-                            ...  Put object        ${SYSTEM_KEY_SN}    ${FILE_S}    ${CID}    ${EMPTY}    ${FILE_OTH_HEADER}
+    Run Keyword And Expect Error    *
+    ...  Put object        ${SYSTEM_KEY}       ${FILE_S}    ${CID}    ${EMPTY}    ${FILE_OTH_HEADER}
+    Run Keyword And Expect Error    *
+    ...  Put object        ${SYSTEM_KEY_SN}    ${FILE_S}    ${CID}    ${EMPTY}    ${FILE_OTH_HEADER}
 
-                            Run Keyword And Expect Error    *
-                            ...  Get object      ${SYSTEM_KEY}       ${CID}    ${S_OID_USER}    ${EMPTY}    local_file_eacl
-                            Run Keyword And Expect Error    *
-                            ...  Get object      ${SYSTEM_KEY_SN}    ${CID}    ${S_OID_USER}    ${EMPTY}    local_file_eacl
+    Run Keyword And Expect Error    *
+    ...  Get object      ${SYSTEM_KEY}       ${CID}    ${S_OID_USER}    ${EMPTY}    local_file_eacl
+    Run Keyword And Expect Error    *
+    ...  Get object      ${SYSTEM_KEY_SN}    ${CID}    ${S_OID_USER}    ${EMPTY}    local_file_eacl
 
-                            Run Keyword And Expect Error    *
-                            ...  Search object              ${SYSTEM_KEY}       ${CID}    ${EMPTY}    ${EMPTY}    ${FILE_USR_HEADER}    ${S_OBJ_H}
-                            Run Keyword And Expect Error    *
-                            ...  Search object              ${SYSTEM_KEY_SN}    ${CID}    ${EMPTY}    ${EMPTY}    ${FILE_USR_HEADER}    ${S_OBJ_H}
-
-
-                            Run Keyword And Expect Error        *
-                            ...  Head object                         ${SYSTEM_KEY}       ${CID}    ${S_OID_USER}    ${EMPTY}
-                            Run Keyword And Expect Error        *
-                            ...  Head object                         ${SYSTEM_KEY_SN}    ${CID}    ${S_OID_USER}    ${EMPTY}
-
-                            Run Keyword And Expect Error        *
-                            ...  Get Range                           ${SYSTEM_KEY}       ${CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
-                            Run Keyword And Expect Error        *
-                            ...  Get Range                           ${SYSTEM_KEY_SN}    ${CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+    Run Keyword And Expect Error    *
+    ...  Search object              ${SYSTEM_KEY}       ${CID}    ${EMPTY}    ${EMPTY}    ${FILE_USR_HEADER}    ${S_OBJ_H}
+    Run Keyword And Expect Error    *
+    ...  Search object              ${SYSTEM_KEY_SN}    ${CID}    ${EMPTY}    ${EMPTY}    ${FILE_USR_HEADER}    ${S_OBJ_H}
 
 
-                            Run Keyword And Expect Error        *
-                            ...  Get Range Hash                      ${SYSTEM_KEY}       ${CID}    ${S_OID_USER}    ${EMPTY}    0:256
-                            Run Keyword And Expect Error        *
-                            ...  Get Range Hash                      ${SYSTEM_KEY_SN}    ${CID}    ${S_OID_USER}    ${EMPTY}    0:256
+    Run Keyword And Expect Error        *
+    ...  Head object                         ${SYSTEM_KEY}       ${CID}    ${S_OID_USER}    ${EMPTY}
+    Run Keyword And Expect Error        *
+    ...  Head object                         ${SYSTEM_KEY_SN}    ${CID}    ${S_OID_USER}    ${EMPTY}
+
+    Run Keyword And Expect Error        *
+    ...  Get Range                           ${SYSTEM_KEY}       ${CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+    Run Keyword And Expect Error        *
+    ...  Get Range                           ${SYSTEM_KEY_SN}    ${CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
 
 
-                            Run Keyword And Expect Error        *
-                            ...  Delete object                       ${SYSTEM_KEY}    ${CID}        ${S_OID_USER}            ${EMPTY}
-                            Run Keyword And Expect Error        *
-                            ...  Delete object                       ${SYSTEM_KEY_SN}    ${CID}        ${S_OID_USER}            ${EMPTY}
+    Run Keyword And Expect Error        *
+    ...  Get Range Hash                      ${SYSTEM_KEY}       ${CID}    ${S_OID_USER}    ${EMPTY}    0:256
+    Run Keyword And Expect Error        *
+    ...  Get Range Hash                      ${SYSTEM_KEY_SN}    ${CID}    ${S_OID_USER}    ${EMPTY}    0:256
 
 
-                            Set eACL                            ${USER_KEY}     ${CID}        ${EACL_ALLOW_ALL_SYSTEM}    --await
-
-                            # The current ACL cache lifetime is 30 sec
-                            Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}
-
-    ${D_OID_USER_S} =       Put object                 ${USER_KEY}     ${FILE_S}            ${CID}            ${EMPTY}            ${FILE_USR_HEADER_DEL}
-    ${D_OID_USER_SN} =      Put object                 ${USER_KEY}     ${FILE_S}            ${CID}            ${EMPTY}            ${FILE_USR_HEADER_DEL}
+    Run Keyword And Expect Error        *
+    ...  Delete object                       ${SYSTEM_KEY}    ${CID}        ${S_OID_USER}            ${EMPTY}
+    Run Keyword And Expect Error        *
+    ...  Delete object                       ${SYSTEM_KEY_SN}    ${CID}        ${S_OID_USER}            ${EMPTY}
 
 
-                            Put object                 ${SYSTEM_KEY}       ${FILE_S}     ${CID}            ${EMPTY}                   ${FILE_OTH_HEADER}
-                            Put object                 ${SYSTEM_KEY_SN}    ${FILE_S}     ${CID}            ${EMPTY}                   ${FILE_OTH_HEADER}
+    Set eACL                            ${USER_KEY}     ${CID}        ${EACL_ALLOW_ALL_SYSTEM}
 
-                            Get object               ${SYSTEM_KEY}       ${CID}        ${S_OID_USER}            ${EMPTY}            local_file_eacl
-                            Get object               ${SYSTEM_KEY_SN}    ${CID}        ${S_OID_USER}            ${EMPTY}            local_file_eacl
+    # The current ACL cache lifetime is 30 sec
+    Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}
 
-                            Search object                       ${SYSTEM_KEY}       ${CID}        ${EMPTY}            ${EMPTY}                 ${FILE_USR_HEADER}       ${S_OBJ_H}
-                            Search object                       ${SYSTEM_KEY_SN}    ${CID}        ${EMPTY}            ${EMPTY}                 ${FILE_USR_HEADER}       ${S_OBJ_H}
+    ${D_OID_USER_S} =       Put object             ${USER_KEY}     ${FILE_S}            ${CID}            ${EMPTY}            ${FILE_USR_HEADER_DEL}
+    ${D_OID_USER_SN} =      Put object             ${USER_KEY}     ${FILE_S}            ${CID}            ${EMPTY}            ${FILE_USR_HEADER_DEL}
 
-                            Head object                         ${SYSTEM_KEY}       ${CID}        ${S_OID_USER}            ${EMPTY}
-                            Head object                         ${SYSTEM_KEY_SN}    ${CID}        ${S_OID_USER}            ${EMPTY}
 
-                            Get Range                           ${SYSTEM_KEY}       ${CID}        ${S_OID_USER}            s_get_range      ${EMPTY}            0:256
-                            Get Range                           ${SYSTEM_KEY_SN}    ${CID}        ${S_OID_USER}            s_get_range      ${EMPTY}            0:256
+    Put object             ${SYSTEM_KEY}       ${FILE_S}     ${CID}            ${EMPTY}                   ${FILE_OTH_HEADER}
+    Put object             ${SYSTEM_KEY_SN}    ${FILE_S}     ${CID}            ${EMPTY}                   ${FILE_OTH_HEADER}
 
-                            Get Range Hash                      ${SYSTEM_KEY}       ${CID}        ${S_OID_USER}            ${EMPTY}            0:256
-                            Get Range Hash                      ${SYSTEM_KEY_SN}    ${CID}        ${S_OID_USER}            ${EMPTY}            0:256
+    Get object               ${SYSTEM_KEY}       ${CID}        ${S_OID_USER}            ${EMPTY}            local_file_eacl
+    Get object               ${SYSTEM_KEY_SN}    ${CID}        ${S_OID_USER}            ${EMPTY}            local_file_eacl
 
-                            Delete object                       ${SYSTEM_KEY}       ${CID}        ${D_OID_USER_S}            ${EMPTY}
-                            Delete object                       ${SYSTEM_KEY_SN}    ${CID}        ${D_OID_USER_SN}           ${EMPTY}
+    Search object            ${SYSTEM_KEY}       ${CID}    ${EMPTY}        ${EMPTY}     ${FILE_USR_HEADER}       ${S_OBJ_H}
+    Search object            ${SYSTEM_KEY_SN}    ${CID}    ${EMPTY}        ${EMPTY}     ${FILE_USR_HEADER}       ${S_OBJ_H}
+
+    Head object              ${SYSTEM_KEY}       ${CID}        ${S_OID_USER}            ${EMPTY}
+    Head object              ${SYSTEM_KEY_SN}    ${CID}        ${S_OID_USER}            ${EMPTY}
+
+    Get Range                ${SYSTEM_KEY}       ${CID}        ${S_OID_USER}    s_get_range      ${EMPTY}    0:256
+    Get Range                ${SYSTEM_KEY_SN}    ${CID}        ${S_OID_USER}    s_get_range      ${EMPTY}    0:256
+
+    Get Range Hash           ${SYSTEM_KEY}       ${CID}        ${S_OID_USER}            ${EMPTY}            0:256
+    Get Range Hash           ${SYSTEM_KEY_SN}    ${CID}        ${S_OID_USER}            ${EMPTY}            0:256
+
+    Delete object            ${SYSTEM_KEY}       ${CID}        ${D_OID_USER_S}            ${EMPTY}
+    Delete object            ${SYSTEM_KEY_SN}    ${CID}        ${D_OID_USER_SN}           ${EMPTY}

--- a/robot/testsuites/integration/acl/acl_extended_actions_user.robot
+++ b/robot/testsuites/integration/acl/acl_extended_actions_user.robot
@@ -1,12 +1,13 @@
 *** Settings ***
-Variables                   ../../../variables/common.py
-Library                     Collections
-Library                     ../${RESOURCES}/neofs.py
-Library                     ../${RESOURCES}/payment_neogo.py
+Variables    ../../../variables/common.py
+Library      Collections
+Library      ../${RESOURCES}/neofs.py
+Library      ../${RESOURCES}/payment_neogo.py
 
-Resource                    common_steps_acl_extended.robot
-Resource                    ../${RESOURCES}/payment_operations.robot
-Resource                    ../${RESOURCES}/setup_teardown.robot
+Resource     common_steps_acl_extended.robot
+Resource     ../${RESOURCES}/payment_operations.robot
+Resource     ../${RESOURCES}/setup_teardown.robot
+Resource     ../../../variables/eacl_tables.robot
 
 *** Test cases ***
 Extended ACL Operations
@@ -18,7 +19,6 @@ Extended ACL Operations
 
                             Generate Keys
                             Generate eACL Keys
-                            Prepare eACL Role rules
 
                             Log    Check extended ACL with simple object
                             Generate files    ${SIMPLE_OBJ_SIZE}

--- a/robot/testsuites/integration/acl/acl_extended_compound.robot
+++ b/robot/testsuites/integration/acl/acl_extended_compound.robot
@@ -1,12 +1,13 @@
 *** Settings ***
-Variables                   ../../../variables/common.py
-Library                     Collections
-Library                     ../${RESOURCES}/neofs.py
-Library                     ../${RESOURCES}/payment_neogo.py
+Variables    ../../../variables/common.py
+Library      Collections
+Library      ../${RESOURCES}/neofs.py
+Library      ../${RESOURCES}/payment_neogo.py
 
-Resource                    common_steps_acl_extended.robot
-Resource                    ../${RESOURCES}/payment_operations.robot
-Resource                    ../${RESOURCES}/setup_teardown.robot
+Resource     common_steps_acl_extended.robot
+Resource     ../${RESOURCES}/payment_operations.robot
+Resource     ../${RESOURCES}/setup_teardown.robot
+Resource     ../../../variables/eacl_tables.robot
 
 
 *** Test cases ***
@@ -19,13 +20,10 @@ Extended ACL Operations
 
                             Generate Keys
                             Generate eACL Keys
-                            Prepare eACL Role rules
 
                             Log    Check extended ACL with simple object
                             Generate files    ${SIMPLE_OBJ_SIZE}
                             Check Сompound Operations
-
-
 
                             Log    Check extended ACL with complex object
                             Generate files    ${COMPLEX_OBJ_SIZE}
@@ -59,7 +57,7 @@ Check eACL Сompound Get
     ${S_OID_USER} =         Put object             ${USER_KEY}    ${FILE_S}    ${CID}           ${EMPTY}    ${FILE_USR_HEADER}
                             Put object             ${KEY}         ${FILE_S}    ${CID}           ${EMPTY}    ${FILE_OTH_HEADER}
                             Get object           ${KEY}         ${CID}       ${S_OID_USER}    ${EMPTY}    local_file_eacl
-                            Set eACL                        ${USER_KEY}    ${CID}       ${DENY_EACL}     --await
+                            Set eACL                        ${USER_KEY}    ${CID}       ${DENY_EACL}
 
                             # The current ACL cache lifetime is 30 sec
                             Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}
@@ -82,7 +80,7 @@ Check eACL Сompound Delete
                             Put object             ${KEY}         ${FILE_S}    ${CID}           ${EMPTY}    ${FILE_OTH_HEADER}
                             Delete object                   ${KEY}         ${CID}       ${D_OID_USER}    ${EMPTY}
 
-                            Set eACL                        ${USER_KEY}    ${CID}       ${DENY_EACL}     --await
+                            Set eACL                        ${USER_KEY}    ${CID}       ${DENY_EACL}
 
                             # The current ACL cache lifetime is 30 sec
                             Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}
@@ -105,7 +103,7 @@ Check eACL Сompound Get Range Hash
                             Put object             ${KEY}              ${FILE_S}    ${CID}           ${EMPTY}    ${FILE_OTH_HEADER}
                             Get Range Hash                  ${SYSTEM_KEY_SN}    ${CID}       ${S_OID_USER}    ${EMPTY}    0:256
 
-                            Set eACL                        ${USER_KEY}         ${CID}       ${DENY_EACL}     --await
+                            Set eACL                        ${USER_KEY}         ${CID}       ${DENY_EACL}
 
                             # The current ACL cache lifetime is 30 sec
                             Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}

--- a/robot/testsuites/integration/acl/acl_extended_filters.robot
+++ b/robot/testsuites/integration/acl/acl_extended_filters.robot
@@ -1,13 +1,14 @@
 *** Settings ***
 Variables       ../../../variables/common.py
+
 Library         ../${RESOURCES}/neofs.py
 Library         ../${RESOURCES}/payment_neogo.py
-
 Library         Collections
 
 Resource        common_steps_acl_extended.robot
 Resource        ../${RESOURCES}/payment_operations.robot
 Resource        ../${RESOURCES}/setup_teardown.robot
+Resource        ../../../variables/eacl_tables.robot
 
 *** Test cases ***
 Extended ACL Operations
@@ -19,7 +20,6 @@ Extended ACL Operations
 
                             Generate Keys
                             Generate eACL Keys
-                            Prepare eACL Role rules
 
                             Log    Check extended ACL with simple object
                             Generate files    ${SIMPLE_OBJ_SIZE}
@@ -51,7 +51,7 @@ Check eACL MatchType String Equal Request Deny
 
     ${ID_value} =	        Get From Dictionary	            ${HEADER_DICT}    ID
 
-                            Set eACL                        ${USER_KEY}    ${CID}    ${EACL_XHEADER_DENY_ALL}    --await
+                            Set eACL                        ${USER_KEY}    ${CID}    ${EACL_XHEADER_DENY_ALL}
 
                             # The current ACL cache lifetime is 30 sec
                             Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}
@@ -95,7 +95,7 @@ Check eACL MatchType String Equal Request Allow
 
     ${ID_value} =	        Get From Dictionary	            ${HEADER_DICT}    ID
 
-                            Set eACL                        ${USER_KEY}    ${CID}    ${EACL_XHEADER_ALLOW_ALL}    --await
+                            Set eACL                        ${USER_KEY}    ${CID}    ${EACL_XHEADER_ALLOW_ALL}
 
                             # The current ACL cache lifetime is 30 sec
                             Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}
@@ -143,9 +143,9 @@ Check eACL MatchType String Equal Object
     ${filters} =            Create Dictionary    headerType=OBJECT    matchType=STRING_EQUAL    key=$Object:objectID    value=${ID_value}
     ${rule1} =              Create Dictionary    Operation=GET        Access=DENY               Role=OTHERS             Filters=${filters}
     ${eACL_gen} =           Create List          ${rule1}
-    ${EACL_CUSTOM} =        Form eACL json common file    eacl_custom    ${eACL_gen}
+    ${EACL_CUSTOM} =        Form eACL json common file    ${ASSETS_DIR}/eacl_custom    ${eACL_gen}
 
-                            Set eACL                        ${USER_KEY}       ${CID}    ${EACL_CUSTOM}    --await
+                            Set eACL                        ${USER_KEY}       ${CID}    ${EACL_CUSTOM}
                             Run Keyword And Expect Error    *
                             ...  Get object                 ${OTHER_KEY}      ${CID}    ${S_OID_USER}     ${EMPTY}        local_file_eacl
 
@@ -156,10 +156,10 @@ Check eACL MatchType String Equal Object
     ${filters} =            Create Dictionary    headerType=OBJECT    matchType=STRING_EQUAL    key=key1    value=1
     ${rule1} =              Create Dictionary    Operation=GET        Access=DENY               Role=OTHERS             Filters=${filters}
     ${eACL_gen} =           Create List    ${rule1}
-    ${EACL_CUSTOM} =        Form eACL json common file    eacl_custom    ${eACL_gen}
+    ${EACL_CUSTOM} =        Form eACL json common file    ${ASSETS_DIR}/eacl_custom    ${eACL_gen}
 
 
-                            Set eACL                        ${USER_KEY}     ${CID}       ${EACL_CUSTOM}       --await
+                            Set eACL                        ${USER_KEY}     ${CID}       ${EACL_CUSTOM}
                             Run Keyword And Expect Error    *
                             ...  Get object      ${OTHER_KEY}    ${CID}       ${S_OID_USER}        ${EMPTY}        local_file_eacl
                             Get object           ${OTHER_KEY}    ${CID}       ${S_OID_USER_OTH}    ${EMPTY}        local_file_eacl
@@ -186,9 +186,9 @@ Check eACL MatchType String Not Equal Object
     ${filters} =            Create Dictionary    headerType=OBJECT    matchType=STRING_NOT_EQUAL    key=$Object:objectID    value=${ID_value}
     ${rule1} =              Create Dictionary    Operation=GET        Access=DENY                   Role=OTHERS             Filters=${filters}
     ${eACL_gen} =           Create List    ${rule1}
-    ${EACL_CUSTOM} =        Form eACL json common file    eacl_custom    ${eACL_gen}
+    ${EACL_CUSTOM} =        Form eACL json common file    ${ASSETS_DIR}/eacl_custom    ${eACL_gen}
 
-                            Set eACL                        ${USER_KEY}       ${CID}    ${EACL_CUSTOM}    --await
+                            Set eACL                        ${USER_KEY}       ${CID}    ${EACL_CUSTOM}
                             Run Keyword And Expect Error    *
                             ...  Get object      ${OTHER_KEY}      ${CID}    ${S_OID_OTHER}    ${EMPTY}            local_file_eacl
                             Get object           ${OTHER_KEY}      ${CID}    ${S_OID_USER}     ${EMPTY}            local_file_eacl
@@ -200,9 +200,9 @@ Check eACL MatchType String Not Equal Object
     ${filters} =            Create Dictionary    headerType=OBJECT    matchType=STRING_NOT_EQUAL    key=key1       value=1
     ${rule1} =              Create Dictionary    Operation=GET        Access=DENY                   Role=OTHERS    Filters=${filters}
     ${eACL_gen} =           Create List    ${rule1}
-    ${EACL_CUSTOM} =        Form eACL json common file    eacl_custom    ${eACL_gen}
+    ${EACL_CUSTOM} =        Form eACL json common file    ${ASSETS_DIR}/eacl_custom    ${eACL_gen}
 
-                            Set eACL                        ${USER_KEY}    ${CID}       ${EACL_CUSTOM}       --await
+                            Set eACL                        ${USER_KEY}    ${CID}       ${EACL_CUSTOM}
                             Run Keyword And Expect Error    *
                             ...  Get object      ${OTHER_KEY}    ${CID}      ${S_OID_USER_OTH}    ${EMPTY}            local_file_eacl
                             Get object           ${OTHER_KEY}    ${CID}      ${S_OID_USER}        ${EMPTY}            local_file_eacl

--- a/robot/testsuites/integration/acl/common_steps_acl_extended.robot
+++ b/robot/testsuites/integration/acl/common_steps_acl_extended.robot
@@ -29,146 +29,6 @@ Generate files
                             Set Global Variable       ${FILE_S_2}    ${FILE_S_GEN_2}
 
 
-Prepare eACL Role rules
-                            Log	                   Set eACL for different Role cases
-
-    # eACL rules for all operations and similar permissions
-    @{Roles} =	        Create List    OTHERS    USER    SYSTEM
-    FOR	${role}	IN	@{Roles}
-        ${rule1}=               Create Dictionary    Operation=GET             Access=DENY    Role=${role}
-        ${rule2}=               Create Dictionary    Operation=HEAD            Access=DENY    Role=${role}
-        ${rule3}=               Create Dictionary    Operation=PUT             Access=DENY    Role=${role}
-        ${rule4}=               Create Dictionary    Operation=DELETE          Access=DENY    Role=${role}
-        ${rule5}=               Create Dictionary    Operation=SEARCH          Access=DENY    Role=${role}
-        ${rule6}=               Create Dictionary    Operation=GETRANGE        Access=DENY    Role=${role}
-        ${rule7}=               Create Dictionary    Operation=GETRANGEHASH    Access=DENY    Role=${role}
-
-        ${eACL_gen}=            Create List    ${rule1}    ${rule2}    ${rule3}    ${rule4}    ${rule5}    ${rule6}    ${rule7}
-                                Form eACL json common file    gen_eacl_deny_all_${role}    ${eACL_gen}
-    END
-
-
-    FOR	${role}	IN	@{Roles}
-        ${rule1}=               Create Dictionary    Operation=GET             Access=ALLOW    Role=${role}
-        ${rule2}=               Create Dictionary    Operation=HEAD            Access=ALLOW    Role=${role}
-        ${rule3}=               Create Dictionary    Operation=PUT             Access=ALLOW    Role=${role}
-        ${rule4}=               Create Dictionary    Operation=DELETE          Access=ALLOW    Role=${role}
-        ${rule5}=               Create Dictionary    Operation=SEARCH          Access=ALLOW    Role=${role}
-        ${rule6}=               Create Dictionary    Operation=GETRANGE        Access=ALLOW    Role=${role}
-        ${rule7}=               Create Dictionary    Operation=GETRANGEHASH    Access=ALLOW    Role=${role}
-
-        ${eACL_gen}=            Create List    ${rule1}    ${rule2}    ${rule3}    ${rule4}    ${rule5}    ${rule6}    ${rule7}
-                                Form eACL json common file    gen_eacl_allow_all_${role}    ${eACL_gen}
-    END
-
-
-    ${rule1}=               Create Dictionary    Operation=GET             Access=ALLOW    Role=A9tDy6Ye+UimXCCzJrlAmRE0FDZHjf3XRyya9rELtgAA
-    ${rule2}=               Create Dictionary    Operation=HEAD            Access=ALLOW    Role=A9tDy6Ye+UimXCCzJrlAmRE0FDZHjf3XRyya9rELtgAA
-    ${rule3}=               Create Dictionary    Operation=PUT             Access=ALLOW    Role=A9tDy6Ye+UimXCCzJrlAmRE0FDZHjf3XRyya9rELtgAA
-    ${rule4}=               Create Dictionary    Operation=DELETE          Access=ALLOW    Role=A9tDy6Ye+UimXCCzJrlAmRE0FDZHjf3XRyya9rELtgAA
-    ${rule5}=               Create Dictionary    Operation=SEARCH          Access=ALLOW    Role=A9tDy6Ye+UimXCCzJrlAmRE0FDZHjf3XRyya9rELtgAA
-    ${rule6}=               Create Dictionary    Operation=GETRANGE        Access=ALLOW    Role=A9tDy6Ye+UimXCCzJrlAmRE0FDZHjf3XRyya9rELtgAA
-    ${rule7}=               Create Dictionary    Operation=GETRANGEHASH    Access=ALLOW    Role=A9tDy6Ye+UimXCCzJrlAmRE0FDZHjf3XRyya9rELtgAA
-    ${rule8}=               Create Dictionary    Operation=GET             Access=DENY     Role=OTHERS
-    ${rule9}=               Create Dictionary    Operation=HEAD            Access=DENY     Role=OTHERS
-    ${rule10}=              Create Dictionary    Operation=PUT             Access=DENY     Role=OTHERS
-    ${rule11}=              Create Dictionary    Operation=DELETE          Access=DENY     Role=OTHERS
-    ${rule12}=              Create Dictionary    Operation=SEARCH          Access=DENY     Role=OTHERS
-    ${rule13}=              Create Dictionary    Operation=GETRANGE        Access=DENY     Role=OTHERS
-    ${rule14}=              Create Dictionary    Operation=GETRANGEHASH    Access=DENY     Role=OTHERS
-
-
-    ${eACL_gen}=            Create List    ${rule1}    ${rule2}    ${rule3}     ${rule4}     ${rule5}     ${rule6}     ${rule7}
-                            ...            ${rule8}    ${rule9}    ${rule10}    ${rule11}    ${rule12}    ${rule13}    ${rule14}
-                            Form eACL json common file    gen_eacl_allow_pubkey_deny_OTHERS    ${eACL_gen}
-
-                            Set Global Variable    ${EACL_DENY_ALL_OTHER}      gen_eacl_deny_all_OTHERS
-                            Set Global Variable    ${EACL_ALLOW_ALL_OTHER}     gen_eacl_allow_all_OTHERS
-
-                            Set Global Variable    ${EACL_DENY_ALL_USER}       gen_eacl_deny_all_USER
-                            Set Global Variable    ${EACL_ALLOW_ALL_USER}      gen_eacl_allow_all_USER
-
-                            Set Global Variable    ${EACL_DENY_ALL_SYSTEM}     gen_eacl_deny_all_SYSTEM
-                            Set Global Variable    ${EACL_ALLOW_ALL_SYSTEM}    gen_eacl_allow_all_SYSTEM
-
-                            Set Global Variable    ${EACL_ALLOW_ALL_Pubkey}    gen_eacl_allow_pubkey_deny_OTHERS
-
-
-    # eACL rules for Compound operations: GET/GetRange/GetRangeHash
-    @{Roles} =	        Create List    OTHERS    USER    SYSTEM
-    FOR	${role}	IN	@{Roles}
-        ${rule1}=               Create Dictionary    Operation=GET             Access=ALLOW    Role=${role}
-        ${rule2}=               Create Dictionary    Operation=GETRANGE        Access=ALLOW    Role=${role}
-        ${rule3}=               Create Dictionary    Operation=GETRANGEHASH    Access=ALLOW    Role=${role}
-        ${rule4}=               Create Dictionary    Operation=HEAD            Access=DENY     Role=${role}
-        ${eACL_gen}=            Create List    ${rule1}    ${rule2}    ${rule3}    ${rule4}
-                                Form eACL json common file    gen_eacl_compound_get_${role}    ${eACL_gen}
-                                Set Global Variable    ${EACL_COMPOUND_GET_${role}}    gen_eacl_compound_get_${role}
-    END
-
-    # eACL rules for Compound operations: DELETE
-    @{Roles} =	        Create List    OTHERS    USER    SYSTEM
-    FOR	${role}	IN	@{Roles}
-        ${rule1}=               Create Dictionary    Operation=DELETE          Access=ALLOW    Role=${role}
-        ${rule2}=               Create Dictionary    Operation=PUT             Access=DENY     Role=${role}
-        ${rule3}=               Create Dictionary    Operation=HEAD            Access=DENY     Role=${role}
-        ${eACL_gen}=            Create List    ${rule1}    ${rule2}    ${rule3}
-                                Form eACL json common file    gen_eacl_compound_del_${role}    ${eACL_gen}
-                                Set Global Variable    ${EACL_COMPOUND_DELETE_${role}}    gen_eacl_compound_del_${role}
-    END
-
-    # eACL rules for Compound operations: GETRANGEHASH
-    @{Roles} =	        Create List    OTHERS    USER    SYSTEM
-    FOR	${role}	IN	@{Roles}
-        ${rule1}=               Create Dictionary    Operation=GETRANGEHASH    Access=ALLOW    Role=${role}
-        ${rule2}=               Create Dictionary    Operation=GETRANGE        Access=DENY     Role=${role}
-        ${rule3}=               Create Dictionary    Operation=GET             Access=DENY     Role=${role}
-        ${eACL_gen}=            Create List    ${rule1}    ${rule2}    ${rule3}
-                                Form eACL json common file    gen_eacl_compound_get_hash_${role}    ${eACL_gen}
-                                Set Global Variable    ${EACL_COMPOUND_GET_HASH_${role}}    gen_eacl_compound_get_hash_${role}
-    END
-
-
-
-    # eACL for X-Header Other DENY and ALLOW for all
-    ${filters}=             Create Dictionary    headerType=REQUEST    matchType=STRING_EQUAL    key=a    value=2
-
-    ${rule1}=               Create Dictionary    Operation=GET             Access=DENY     Role=OTHERS    Filters=${filters}
-    ${rule2}=               Create Dictionary    Operation=HEAD            Access=DENY     Role=OTHERS    Filters=${filters}
-    ${rule3}=               Create Dictionary    Operation=PUT             Access=DENY     Role=OTHERS    Filters=${filters}
-    ${rule4}=               Create Dictionary    Operation=DELETE          Access=DENY     Role=OTHERS    Filters=${filters}
-    ${rule5}=               Create Dictionary    Operation=SEARCH          Access=DENY     Role=OTHERS    Filters=${filters}
-    ${rule6}=               Create Dictionary    Operation=GETRANGE        Access=DENY     Role=OTHERS    Filters=${filters}
-    ${rule7}=               Create Dictionary    Operation=GETRANGEHASH    Access=DENY     Role=OTHERS    Filters=${filters}
-    ${eACL_gen}=            Create List    ${rule1}    ${rule2}    ${rule3}    ${rule4}    ${rule5}    ${rule6}    ${rule7}
-                            Form eACL json common file    gen_eacl_xheader_deny_all    ${eACL_gen}
-                            Set Global Variable           ${EACL_XHEADER_DENY_ALL}     gen_eacl_xheader_deny_all
-
-
-
-    # eACL for X-Header Other ALLOW and DENY for all
-    ${filters}=             Create Dictionary    headerType=REQUEST    matchType=STRING_EQUAL    key=a    value=2
-
-    ${rule1}=               Create Dictionary    Operation=GET             Access=ALLOW     Role=OTHERS    Filters=${filters}
-    ${rule2}=               Create Dictionary    Operation=HEAD            Access=ALLOW     Role=OTHERS    Filters=${filters}
-    ${rule3}=               Create Dictionary    Operation=PUT             Access=ALLOW     Role=OTHERS    Filters=${filters}
-    ${rule4}=               Create Dictionary    Operation=DELETE          Access=ALLOW     Role=OTHERS    Filters=${filters}
-    ${rule5}=               Create Dictionary    Operation=SEARCH          Access=ALLOW     Role=OTHERS    Filters=${filters}
-    ${rule6}=               Create Dictionary    Operation=GETRANGE        Access=ALLOW     Role=OTHERS    Filters=${filters}
-    ${rule7}=               Create Dictionary    Operation=GETRANGEHASH    Access=ALLOW     Role=OTHERS    Filters=${filters}
-    ${rule8}=               Create Dictionary    Operation=GET             Access=DENY     Role=OTHERS
-    ${rule9}=               Create Dictionary    Operation=HEAD            Access=DENY     Role=OTHERS
-    ${rule10}=              Create Dictionary    Operation=PUT             Access=DENY     Role=OTHERS
-    ${rule11}=              Create Dictionary    Operation=DELETE          Access=DENY     Role=OTHERS
-    ${rule12}=              Create Dictionary    Operation=SEARCH          Access=DENY     Role=OTHERS
-    ${rule13}=              Create Dictionary    Operation=GETRANGE        Access=DENY     Role=OTHERS
-    ${rule14}=              Create Dictionary    Operation=GETRANGEHASH    Access=DENY     Role=OTHERS
-    ${eACL_gen}=            Create List    ${rule1}    ${rule2}    ${rule3}     ${rule4}     ${rule5}     ${rule6}     ${rule7}
-                            ...            ${rule8}    ${rule9}    ${rule10}    ${rule11}    ${rule12}    ${rule13}    ${rule14}
-                            Form eACL json common file    gen_eacl_xheader_allow_all    ${eACL_gen}
-                            Set Global Variable           ${EACL_XHEADER_ALLOW_ALL}     gen_eacl_xheader_allow_all
-
-
 
 Check eACL Deny and Allow All
     [Arguments]     ${KEY}       ${DENY_EACL}    ${ALLOW_EACL}
@@ -188,7 +48,7 @@ Check eACL Deny and Allow All
                             Get Range Hash             ${KEY}    ${CID}        ${S_OID_USER}            ${EMPTY}          0:256
                             Delete object              ${KEY}    ${CID}        ${D_OID_USER}            ${EMPTY}
 
-                            Set eACL                   ${USER_KEY}     ${CID}        ${DENY_EACL}    --await
+                            Set eACL                   ${USER_KEY}     ${CID}        ${DENY_EACL}
 
                             # The current ACL cache lifetime is 30 sec
                             Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}
@@ -208,7 +68,7 @@ Check eACL Deny and Allow All
                             Run Keyword And Expect Error        *
                             ...  Delete object                       ${KEY}    ${CID}       ${S_OID_USER}    ${EMPTY}
 
-                            Set eACL                            ${USER_KEY}    ${CID}       ${ALLOW_EACL}    --await
+                            Set eACL                            ${USER_KEY}    ${CID}       ${ALLOW_EACL}
 
                             # The current ACL cache lifetime is 30 sec
                             Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}

--- a/robot/variables/eacl_tables.robot
+++ b/robot/variables/eacl_tables.robot
@@ -1,0 +1,29 @@
+*** Variables ***
+
+${ACL_TEST_FILES} =     robot/resources/files/eacl_tables
+
+${EACL_DENY_ALL_OTHER} =      ${ACL_TEST_FILES}/gen_eacl_deny_all_OTHERS
+${EACL_ALLOW_ALL_OTHER} =     ${ACL_TEST_FILES}/gen_eacl_allow_all_OTHERS
+
+${EACL_DENY_ALL_USER} =       ${ACL_TEST_FILES}/gen_eacl_deny_all_USER
+${EACL_ALLOW_ALL_USER} =      ${ACL_TEST_FILES}/gen_eacl_allow_all_USER
+
+${EACL_DENY_ALL_SYSTEM} =     ${ACL_TEST_FILES}/gen_eacl_deny_all_SYSTEM
+${EACL_ALLOW_ALL_SYSTEM} =    ${ACL_TEST_FILES}/gen_eacl_allow_all_SYSTEM
+
+${EACL_ALLOW_ALL_Pubkey} =    ${ACL_TEST_FILES}/gen_eacl_allow_pubkey_deny_OTHERS
+
+${EACL_COMPOUND_GET_OTHERS} =    ${ACL_TEST_FILES}/gen_eacl_compound_get_OTHERS
+${EACL_COMPOUND_GET_USER} =      ${ACL_TEST_FILES}/gen_eacl_compound_get_USER
+${EACL_COMPOUND_GET_SYSTEM} =    ${ACL_TEST_FILES}/gen_eacl_compound_get_SYSTEM
+
+${EACL_COMPOUND_DELETE_OTHERS} =    ${ACL_TEST_FILES}/gen_eacl_compound_del_OTHERS
+${EACL_COMPOUND_DELETE_USER} =      ${ACL_TEST_FILES}/gen_eacl_compound_del_USER
+${EACL_COMPOUND_DELETE_SYSTEM} =    ${ACL_TEST_FILES}/gen_eacl_compound_del_SYSTEM
+
+${EACL_COMPOUND_GET_HASH_OTHERS} =    ${ACL_TEST_FILES}/gen_eacl_compound_get_hash_OTHERS
+${EACL_COMPOUND_GET_HASH_USER} =      ${ACL_TEST_FILES}/gen_eacl_compound_get_hash_USER
+${EACL_COMPOUND_GET_HASH_SYSTEM} =    ${ACL_TEST_FILES}/gen_eacl_compound_get_hash_SYSTEM
+
+${EACL_XHEADER_DENY_ALL} =     ${ACL_TEST_FILES}/gen_eacl_xheader_deny_all
+${EACL_XHEADER_ALLOW_ALL} =     ${ACL_TEST_FILES}/gen_eacl_xheader_allow_all


### PR DESCRIPTION
- removed keyword `Prepare eACL Role rules` because it generated same eACL tables from run to run. Instead, added pre-generated tables under `robot/resources/files/eacl_tables`.

- added variables file that contains names of eACL tables. It is imported into eACL test suites

- added python script that generates eacl tables for case, when it need to be re-generated

- in keyword `Set eACL` removed parameter with optional CLI keys, instead explicitly added `--await` postfix for CLI command that we run inside this kw