### PR TITLE
replace --key with --wif  and  fixes for acl testsuites

### DIFF
--- a/robot/resources/lib/neofs.py
+++ b/robot/resources/lib/neofs.py
@@ -26,24 +26,6 @@ ROBOT_AUTO_KEYWORDS = False
 # path to neofs-cli executable
 NEOFS_CLI_EXEC = os.getenv('NEOFS_CLI_EXEC', 'neofs-cli')
 
-@keyword('Form WIF from String')
-def form_wif_from_string(private_key: str):
-    wif = ""
-    Cmd = f'{NEOFS_CLI_EXEC} util keyer {private_key}'
-    logger.info("Cmd: %s" % Cmd)
-    complProc = subprocess.run(Cmd, check=True, universal_newlines=True,
-                stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=150, shell=True)
-    output = complProc.stdout
-    logger.info("Output: %s" % output)
-
-    m = re.search(r'WIF\s+(\w+)', output)
-    if m.start() != m.end():
-        wif = m.group(1)
-    else:
-        raise Exception("Can not get WIF.")
-
-    return wif
-
 
 @keyword('Get ScriptHash')
 def get_scripthash(privkey: str):
@@ -156,7 +138,7 @@ def validate_storage_policy_for_object(private_key: str, expected_copies: int, c
 def get_eacl(private_key: str, cid: str):
 
     Cmd = (
-        f'{NEOFS_CLI_EXEC} --rpc-endpoint {NEOFS_ENDPOINT} --key {private_key} '
+        f'{NEOFS_CLI_EXEC} --rpc-endpoint {NEOFS_ENDPOINT} --wif {private_key} '
         f'container get-eacl --cid {cid}'
     )
     logger.info("Cmd: %s" % Cmd)
@@ -178,7 +160,7 @@ def get_eacl(private_key: str, cid: str):
 @keyword('Get Epoch')
 def get_epoch(private_key: str):
     cmd = (
-        f'{NEOFS_CLI_EXEC} --rpc-endpoint {NEOFS_ENDPOINT} --key {private_key} '
+        f'{NEOFS_CLI_EXEC} --rpc-endpoint {NEOFS_ENDPOINT} --wif {private_key} '
         f'netmap epoch'
     )
     logger.info(f"Cmd: {cmd}")
@@ -194,7 +176,7 @@ def get_epoch(private_key: str):
 @keyword('Set eACL')
 def set_eacl(private_key: str, cid: str, eacl_table_path: str):
     cmd = (
-        f'{NEOFS_CLI_EXEC} --rpc-endpoint {NEOFS_ENDPOINT} --key {private_key} '
+        f'{NEOFS_CLI_EXEC} --rpc-endpoint {NEOFS_ENDPOINT} --wif {private_key} '
         f'container set-eacl --cid {cid} --table {eacl_table_path} --await'
     )
     logger.info(f"Cmd: {cmd}")
@@ -249,7 +231,7 @@ def form_bearertoken_file(private_key: str, cid: str, file_name: str, eacl_oper_
     # Sign bearer token
     Cmd = (
         f'{NEOFS_CLI_EXEC} util sign bearer-token --from {file_path} '
-        f'--to {file_path} --key {private_key} --json'
+        f'--to {file_path} --wif {private_key} --json'
     )
     logger.info("Cmd: %s" % Cmd)
 
@@ -300,7 +282,7 @@ def get_range(private_key: str, cid: str, oid: str, range_file: str, bearer: str
         bearer_token = f"--bearer {ASSETS_DIR}/{bearer}"
 
     Cmd = (
-        f'{NEOFS_CLI_EXEC} --rpc-endpoint {NEOFS_ENDPOINT} --key {private_key} '
+        f'{NEOFS_CLI_EXEC} --rpc-endpoint {NEOFS_ENDPOINT} --wif {private_key} '
         f'object range --cid {cid} --oid {oid} {bearer_token} --range {range_cut} '
         f'--file {ASSETS_DIR}/{range_file} {options}'
     )
@@ -323,7 +305,7 @@ def create_container(private_key: str, basic_acl:str, rule:str):
         basic_acl = f"--basic-acl {basic_acl}"
 
     createContainerCmd = (
-        f'{NEOFS_CLI_EXEC} --rpc-endpoint {NEOFS_ENDPOINT} --key {private_key} '
+        f'{NEOFS_CLI_EXEC} --rpc-endpoint {NEOFS_ENDPOINT} --wif {private_key} '
         f'container create --policy "{rule}" {basic_acl} --await'
     )
     logger.info("Cmd: %s" % createContainerCmd)
@@ -339,7 +321,7 @@ def create_container(private_key: str, basic_acl:str, rule:str):
 @keyword('Container List')
 def container_list(private_key: str):
     Cmd = (
-        f'{NEOFS_CLI_EXEC} --rpc-endpoint {NEOFS_ENDPOINT} --key {private_key} '
+        f'{NEOFS_CLI_EXEC} --rpc-endpoint {NEOFS_ENDPOINT} --wif {private_key} '
         f'container list'
     )
     logger.info("Cmd: %s" % Cmd)
@@ -354,7 +336,7 @@ def container_list(private_key: str):
 @keyword('Container Existing')
 def container_existing(private_key: str, cid: str):
     Cmd = (
-        f'{NEOFS_CLI_EXEC} --rpc-endpoint {NEOFS_ENDPOINT} --key {private_key} '
+        f'{NEOFS_CLI_EXEC} --rpc-endpoint {NEOFS_ENDPOINT} --wif {private_key} '
         f'container list'
     )
     logger.info("Cmd: %s" % Cmd)
@@ -379,7 +361,7 @@ def search_object(private_key: str, cid: str, keys: str, bearer: str, filters: s
             filters_result += f"--filters '{filter_item}' "
 
     object_cmd = (
-        f'{NEOFS_CLI_EXEC} --rpc-endpoint {NEOFS_ENDPOINT} --key {private_key} '
+        f'{NEOFS_CLI_EXEC} --rpc-endpoint {NEOFS_ENDPOINT} --wif {private_key} '
         f'object search {keys} --cid {cid} {bearer_token} {filters_result} {options}'
     )
     logger.info("Cmd: %s" % object_cmd)
@@ -564,7 +546,7 @@ def _verify_child_link(private_key: str, cid: str, oid: str, header_last_parsed:
 @keyword('Verify Head Tombstone')
 def verify_head_tombstone(private_key: str, cid: str, oid_ts: str, oid: str, addr: str):
     object_cmd = (
-        f'{NEOFS_CLI_EXEC} --rpc-endpoint {NEOFS_ENDPOINT} --key {private_key} '
+        f'{NEOFS_CLI_EXEC} --rpc-endpoint {NEOFS_ENDPOINT} --wif {private_key} '
         f'object head --cid {cid} --oid {oid_ts} --json'
     )
     logger.info("Cmd: %s" % object_cmd)
@@ -628,7 +610,7 @@ def head_object(private_key: str, cid: str, oid: str, bearer_token: str="",
         endpoint = NEOFS_ENDPOINT
 
     object_cmd = (
-        f'{NEOFS_CLI_EXEC} --rpc-endpoint {endpoint} --key {private_key} object '
+        f'{NEOFS_CLI_EXEC} --rpc-endpoint {endpoint} --wif {private_key} object '
         f'head --cid {cid} --oid {oid} {bearer_token} {options}'
     )
     logger.info("Cmd: %s" % object_cmd)
@@ -763,7 +745,7 @@ def delete_object(private_key: str, cid: str, oid: str, bearer: str, options: st
         bearer_token = f"--bearer {ASSETS_DIR}/{bearer}"
 
     object_cmd = (
-        f'{NEOFS_CLI_EXEC} --rpc-endpoint {NEOFS_ENDPOINT} --key {private_key} '
+        f'{NEOFS_CLI_EXEC} --rpc-endpoint {NEOFS_ENDPOINT} --wif {private_key} '
         f'object delete --cid {cid} --oid {oid} {bearer_token} {options}'
     )
     logger.info("Cmd: %s" % object_cmd)
@@ -810,7 +792,7 @@ def put_object(private_key: str, path: str, cid: str, bearer: str, user_headers:
         bearer = f"--bearer {ASSETS_DIR}/{bearer}"
 
     putobject_cmd = (
-        f'{NEOFS_CLI_EXEC} --rpc-endpoint {endpoint} --key {private_key} object '
+        f'{NEOFS_CLI_EXEC} --rpc-endpoint {endpoint} --wif {private_key} object '
         f'put --file {path} --cid {cid} {bearer} {user_headers} {options}'
     )
     logger.info("Cmd: %s" % putobject_cmd)
@@ -893,7 +875,7 @@ def get_range_hash(private_key: str, cid: str, oid: str, bearer_token: str,
         bearer_token = f"--bearer {ASSETS_DIR}/{bearer_token}"
 
     object_cmd = (
-        f'{NEOFS_CLI_EXEC} --rpc-endpoint {NEOFS_ENDPOINT} --key {private_key} '
+        f'{NEOFS_CLI_EXEC} --rpc-endpoint {NEOFS_ENDPOINT} --wif {private_key} '
         f'object hash --cid {cid} --oid {oid} --range {range_cut} '
         f'{bearer_token} {options}'
     )
@@ -920,7 +902,7 @@ def get_object(private_key: str, cid: str, oid: str, bearer_token: str,
         bearer_token = f"--bearer {ASSETS_DIR}/{bearer_token}"
 
     object_cmd = (
-        f'{NEOFS_CLI_EXEC} --rpc-endpoint {endpoint} --key {private_key} '
+        f'{NEOFS_CLI_EXEC} --rpc-endpoint {endpoint} --wif {private_key} '
         f'object get --cid {cid} --oid {oid} --file {file_path} {bearer_token} '
         f'{options}'
     )
@@ -944,7 +926,7 @@ def put_storagegroup(private_key: str, cid: str, bearer_token: str="", *oid_list
         bearer_token = f"--bearer {ASSETS_DIR}/{bearer_token}"
 
     object_cmd = (
-        f'{NEOFS_CLI_EXEC} --rpc-endpoint {NEOFS_ENDPOINT} --key {private_key} storagegroup '
+        f'{NEOFS_CLI_EXEC} --rpc-endpoint {NEOFS_ENDPOINT} --wif {private_key} storagegroup '
         f'put --cid {cid} --members {cmd_oid_line} {bearer_token}'
     )
     logger.info(f"Cmd: {object_cmd}")
@@ -966,7 +948,7 @@ def list_storagegroup(private_key: str, cid: str, bearer_token: str="", *expecte
         bearer_token = f"--bearer {ASSETS_DIR}/{bearer_token}"
 
     object_cmd = (
-        f'{NEOFS_CLI_EXEC} --rpc-endpoint {NEOFS_ENDPOINT} --key {private_key} '
+        f'{NEOFS_CLI_EXEC} --rpc-endpoint {NEOFS_ENDPOINT} --wif {private_key} '
         f'storagegroup list --cid {cid} {bearer_token}'
     )
 
@@ -996,7 +978,7 @@ def get_storagegroup(private_key: str, cid: str, oid: str, bearer_token: str, ex
     if bearer_token:
         bearer_token = f"--bearer {ASSETS_DIR}/{bearer_token}"
 
-    object_cmd = f'{NEOFS_CLI_EXEC} --rpc-endpoint {NEOFS_ENDPOINT} --key {private_key} storagegroup get --cid {cid} --id {oid} {bearer_token}'
+    object_cmd = f'{NEOFS_CLI_EXEC} --rpc-endpoint {NEOFS_ENDPOINT} --wif {private_key} storagegroup get --cid {cid} --id {oid} {bearer_token}'
     logger.info(f"Cmd: {object_cmd}")
     try:
         complProc = subprocess.run(object_cmd, check=True, universal_newlines=True,
@@ -1029,7 +1011,7 @@ def delete_storagegroup(private_key: str, cid: str, oid: str, bearer_token: str=
         bearer_token = f"--bearer {ASSETS_DIR}/{bearer_token}"
 
     object_cmd = (
-        f'{NEOFS_CLI_EXEC} --rpc-endpoint {NEOFS_ENDPOINT} --key {private_key} storagegroup '
+        f'{NEOFS_CLI_EXEC} --rpc-endpoint {NEOFS_ENDPOINT} --wif {private_key} storagegroup '
         f'delete --cid {cid} --id {oid} {bearer_token}'
     )
     logger.info(f"Cmd: {object_cmd}")
@@ -1122,7 +1104,7 @@ def _search_object(node:str, private_key: str, cid:str, oid: str):
     if oid:
         oid_cmd = "--oid %s" % oid
     Cmd = (
-        f'{NEOFS_CLI_EXEC} --rpc-endpoint {node} --key {private_key} --ttl 1 '
+        f'{NEOFS_CLI_EXEC} --rpc-endpoint {node} --wif {private_key} --ttl 1 '
         f'object search --root --cid {cid} {oid_cmd}'
     )
     try:

--- a/robot/resources/lib/payment_neogo.py
+++ b/robot/resources/lib/payment_neogo.py
@@ -112,7 +112,7 @@ def _get_balance_request(privkey: str):
     Internal method.
     '''
     Cmd = (
-        f'{NEOFS_CLI_EXEC} --key {privkey} --rpc-endpoint {NEOFS_ENDPOINT}'
+        f'{NEOFS_CLI_EXEC} --wif {privkey} --rpc-endpoint {NEOFS_ENDPOINT}'
         f' accounting balance'
     )
     logger.info(f"Cmd: {Cmd}")

--- a/robot/testsuites/integration/acl/acl_bearer_allow.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_allow.robot
@@ -18,7 +18,6 @@ BearerToken Operations
     [Setup]                 Setup
 
                             Generate Keys
-                            Generate eACL Keys
                             Prepare eACL Role rules
 
                             Log    Check Bearer token with simple object

--- a/robot/testsuites/integration/acl/acl_bearer_allow_storagegroup.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_allow_storagegroup.robot
@@ -18,7 +18,6 @@ BearerToken Operations
     [Setup]                 Setup
 
                             Generate Keys
-                            Generate eACL Keys
                             Prepare eACL Role rules
 
                             Log    Check Bearer token with simple object

--- a/robot/testsuites/integration/acl/acl_bearer_compound.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_compound.robot
@@ -9,6 +9,9 @@ Resource    common_steps_acl_bearer.robot
 Resource    ../${RESOURCES}/payment_operations.robot
 Resource    ../${RESOURCES}/setup_teardown.robot
 
+*** Variables ***
+${SYSTEM_KEY} =     ${NEOFS_IR_WIF}
+
 *** Test cases ***
 BearerToken Operations for Сompound Operations
     [Documentation]         Testcase to validate NeoFS operations with BearerToken for Сompound Operations.
@@ -18,7 +21,6 @@ BearerToken Operations for Сompound Operations
     [Setup]                 Setup
 
                             Generate Keys
-                            Generate eACL Keys
                             Prepare eACL Role rules
 
                             Log    Check Bearer token with simple object

--- a/robot/testsuites/integration/acl/acl_bearer_filter_oid_equal.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_filter_oid_equal.robot
@@ -18,7 +18,6 @@ BearerToken Operations with Filter OID Equal
     [Setup]                 Setup
 
                             Generate Keys
-                            Generate eACL Keys
                             Prepare eACL Role rules
 
                             Log    Check Bearer token with simple object

--- a/robot/testsuites/integration/acl/acl_bearer_filter_oid_not_equal.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_filter_oid_not_equal.robot
@@ -18,7 +18,6 @@ BearerToken Operations with Filter OID NotEqual
 
     [Setup]                 Setup
 
-                            Generate Keys
                             Generate eACL Keys
                             Prepare eACL Role rules
 

--- a/robot/testsuites/integration/acl/acl_bearer_filter_userheader_equal.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_filter_userheader_equal.robot
@@ -18,7 +18,6 @@ BearerToken Operations with Filter UserHeader Equal
     [Setup]                 Setup
 
                             Generate Keys
-                            Generate eACL Keys
                             Prepare eACL Role rules
 
                             Log    Check Bearer token with simple object

--- a/robot/testsuites/integration/acl/acl_bearer_filter_userheader_not_equal.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_filter_userheader_not_equal.robot
@@ -17,7 +17,6 @@ BearerToken Operations Filter UserHeader NotEqual
     [Setup]                 Setup
 
                             Generate Keys
-                            Generate eACL Keys
                             Prepare eACL Role rules
 
                             Log    Check Bearer token with simple object

--- a/robot/testsuites/integration/acl/acl_bearer_inaccessible.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_inaccessible.robot
@@ -18,7 +18,6 @@ BearerToken Operations for Inaccessible Container
     [Setup]                 Setup
 
                             Generate Keys
-                            Generate eACL Keys
                             Prepare eACL Role rules
 
                             Log    Check Bearer token with simple object

--- a/robot/testsuites/integration/acl/acl_bearer_request_filter_xheader_deny.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_request_filter_xheader_deny.robot
@@ -18,7 +18,6 @@ BearerToken Operations
     [Setup]                 Setup
 
                             Generate Keys
-                            Generate eACL Keys
                             Prepare eACL Role rules
 
                             Log    Check Bearer token with simple object

--- a/robot/testsuites/integration/acl/acl_bearer_request_filter_xheader_equal.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_request_filter_xheader_equal.robot
@@ -19,7 +19,6 @@ BearerToken Operations with Filter Requst Equal
     [Setup]                 Setup
 
                             Generate Keys
-                            Generate eACL Keys
                             Prepare eACL Role rules
 
                             Log    Check Bearer token with simple object

--- a/robot/testsuites/integration/acl/acl_bearer_request_filter_xheader_not_equal.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_request_filter_xheader_not_equal.robot
@@ -19,7 +19,6 @@ BearerToken Operations with Filter Requst NotEqual
     [Setup]                 Setup
 
                             Generate Keys
-                            Generate eACL Keys
                             Prepare eACL Role rules
 
                             Log    Check Bearer token with simple object
@@ -27,7 +26,6 @@ BearerToken Operations with Filter Requst NotEqual
                             Check eACL Deny and Allow All Bearer Filter Requst NotEqual
 
                             Log    Check Bearer token with complex object
-
                             Generate file    ${COMPLEX_OBJ_SIZE}
                             Check eACL Deny and Allow All Bearer Filter Requst NotEqual
 

--- a/robot/testsuites/integration/acl/acl_extended_actions_other.robot
+++ b/robot/testsuites/integration/acl/acl_extended_actions_other.robot
@@ -19,7 +19,6 @@ Extended ACL Operations
     [Setup]                 Setup
 
                             Generate Keys
-                            Generate eACL Keys
 
                             Log    Check extended ACL with simple object
                             Generate files    ${SIMPLE_OBJ_SIZE}

--- a/robot/testsuites/integration/acl/acl_extended_actions_pubkey.robot
+++ b/robot/testsuites/integration/acl/acl_extended_actions_pubkey.robot
@@ -10,6 +10,10 @@ Resource     ../${RESOURCES}/payment_operations.robot
 Resource     ../${RESOURCES}/setup_teardown.robot
 Resource       ../../../variables/eacl_tables.robot
 
+*** Variables ***
+${EACL_KEY} =   L1FGTLE6shum3EC7mNTPArUqSCKnmtEweRzyuawtYRZwGjpeRuw1
+
+
 *** Test cases ***
 Extended ACL Operations
     [Documentation]         Testcase to validate NeoFS operations with extended ACL.
@@ -19,7 +23,6 @@ Extended ACL Operations
     [Setup]                 Setup
 
                             Generate Keys
-                            Generate eACL Keys
 
                             Log    Check extended ACL with simple object
                             Generate files    ${SIMPLE_OBJ_SIZE}

--- a/robot/testsuites/integration/acl/acl_extended_actions_system.robot
+++ b/robot/testsuites/integration/acl/acl_extended_actions_system.robot
@@ -10,6 +10,10 @@ Resource        ../${RESOURCES}/payment_operations.robot
 Resource        ../${RESOURCES}/setup_teardown.robot
 Resource        ../../../variables/eacl_tables.robot
 
+*** Variables ***
+${SYSTEM_KEY} =     ${NEOFS_IR_WIF}
+
+
 *** Test cases ***
 Extended ACL Operations
     [Documentation]         Testcase to validate NeoFS operations with extended ACL.
@@ -19,7 +23,6 @@ Extended ACL Operations
     [Setup]                 Setup
 
                             Generate Keys
-                            Generate eACL Keys
 
                             Log    Check extended ACL with simple object
                             Generate files    ${SIMPLE_OBJ_SIZE}

--- a/robot/testsuites/integration/acl/acl_extended_actions_user.robot
+++ b/robot/testsuites/integration/acl/acl_extended_actions_user.robot
@@ -18,7 +18,6 @@ Extended ACL Operations
     [Setup]                 Setup
 
                             Generate Keys
-                            Generate eACL Keys
 
                             Log    Check extended ACL with simple object
                             Generate files    ${SIMPLE_OBJ_SIZE}

--- a/robot/testsuites/integration/acl/acl_extended_compound.robot
+++ b/robot/testsuites/integration/acl/acl_extended_compound.robot
@@ -9,6 +9,9 @@ Resource     ../${RESOURCES}/payment_operations.robot
 Resource     ../${RESOURCES}/setup_teardown.robot
 Resource     ../../../variables/eacl_tables.robot
 
+*** Variables ***
+${SYSTEM_KEY} =     ${NEOFS_IR_WIF}
+
 
 *** Test cases ***
 Extended ACL Operations
@@ -19,7 +22,6 @@ Extended ACL Operations
     [Setup]                 Setup
 
                             Generate Keys
-                            Generate eACL Keys
 
                             Log    Check extended ACL with simple object
                             Generate files    ${SIMPLE_OBJ_SIZE}

--- a/robot/testsuites/integration/acl/acl_extended_filters.robot
+++ b/robot/testsuites/integration/acl/acl_extended_filters.robot
@@ -19,7 +19,6 @@ Extended ACL Operations
     [Setup]                 Setup
 
                             Generate Keys
-                            Generate eACL Keys
 
                             Log    Check extended ACL with simple object
                             Generate files    ${SIMPLE_OBJ_SIZE}

--- a/robot/testsuites/integration/acl/common_steps_acl_bearer.robot
+++ b/robot/testsuites/integration/acl/common_steps_acl_bearer.robot
@@ -10,12 +10,6 @@ ${RULE_FOR_ALL} =           REP 2 IN X CBF 1 SELECT 4 FROM * AS X
 
 *** Keywords ***
 
-Generate eACL Keys
-    ${EACL_KEY_GEN} =	    Form WIF from String    782676b81a35c5f07325ec523e8521ee4946b6e5d4c6cd652dd0c3ba51ce03de
-                            Set Global Variable     ${EACL_KEY}         ${EACL_KEY_GEN}
-                            Set Global Variable     ${SYSTEM_KEY}       ${NEOFS_IR_WIF}
-
-
 Create Container Public
                             Log	                  Create Public Container
     ${PUBLIC_CID_GEN} =     Create container      ${USER_KEY}    0x0FFFFFFF     ${COMMON_PLACEMENT_RULE}

--- a/robot/testsuites/integration/acl/common_steps_acl_extended.robot
+++ b/robot/testsuites/integration/acl/common_steps_acl_extended.robot
@@ -10,11 +10,6 @@ ${RULE_FOR_ALL} =           REP 2 IN X CBF 1 SELECT 4 FROM * AS X
 
 *** Keywords ***
 
-Generate eACL Keys
-    ${EACL_KEY_GEN} =	    Form WIF from String    782676b81a35c5f07325ec523e8521ee4946b6e5d4c6cd652dd0c3ba51ce03de
-                            Set Global Variable     ${EACL_KEY}         ${EACL_KEY_GEN}
-                            Set Global Variable     ${SYSTEM_KEY}       ${NEOFS_IR_WIF}
-
 Create Container Public
                             Log	                Create Public Container
     ${PUBLIC_CID_GEN} =     Create container    ${USER_KEY}    0x4FFFFFFF    ${RULE_FOR_ALL}

--- a/robot/testsuites/integration/services/s3_gate.robot
+++ b/robot/testsuites/integration/services/s3_gate.robot
@@ -10,6 +10,7 @@ Resource                        ../${RESOURCES}/setup_teardown.robot
 
 *** Variables ***
 ${DEPOSIT_AMOUNT} =     ${5}
+${WIF} =                ${MAINNET_WALLET_WIF}
 
 *** Test cases ***
 NeoFS S3 Gateway
@@ -18,7 +19,6 @@ NeoFS S3 Gateway
 
     [Setup]                     Setup
 
-    ${WIF} =	                Form WIF from String    1dd37fba80fec4e6a6f13fd708d8dcb3b29def768017052f6c930fa1c5d90bbb
     ${WALLET}   ${ADDR} =       Init Wallet from WIF    ${ASSETS_DIR}     ${WIF}
     ${TX_DEPOSIT} =             NeoFS Deposit                         ${WIF}    ${DEPOSIT_AMOUNT}
                                 Wait Until Keyword Succeeds           1 min            15 sec


### PR DESCRIPTION
- `--key` replaced with `--wif` in all of the keywords
- keyword `Form WIF from String` removed. It converted a constant (private key) into another constant (WIF) and slowed tests down. 
- WIFs that has been set as a global variables now exist as a variables in appropriate test suites
- keyword `Generate eACL Keys` removed from common keywords for acl_bearer_* and acl_extended_* groups

#69