### PR TITLE
WIP (#98) Prepare Wallet And Deposit keywords instead of Generate Keys

### DIFF
--- a/robot/resources/lib/payment_operations.robot
+++ b/robot/resources/lib/payment_operations.robot
@@ -12,19 +12,6 @@ ${DEPOSIT_AMOUNT} =     ${25}
 
 *** Keywords ***
 
-Generate Keys
-    ${WALLET}   ${ADDR}     ${USER_KEY_GEN} =   Init Wallet with Address    ${ASSETS_DIR}
-    ${WALLET_OTH}   ${ADDR_OTH}     ${OTHER_KEY_GEN} =   Init Wallet with Address    ${ASSETS_DIR}
-
-    Set Global Variable     ${USER_KEY}          ${USER_KEY_GEN}
-    Set Global Variable     ${OTHER_KEY}         ${OTHER_KEY_GEN}
-    Set Global Variable     ${SYSTEM_KEY_IR}     ${NEOFS_IR_WIF}
-    Set Global Variable     ${SYSTEM_KEY_SN}     ${NEOFS_SN_WIF}
-
-    Payment Operations      ${ADDR}         ${USER_KEY}
-    Payment Operations      ${ADDR_OTH}     ${OTHER_KEY}
-
-
 Payment Operations
     [Arguments]   ${ADDR}     ${WIF}
 
@@ -46,8 +33,9 @@ Payment Operations
     Should Be Equal As Numbers      ${NEOFS_BALANCE}    ${DEPOSIT_AMOUNT}
 
 Prepare Wallet And Deposit
-    [Arguments]    ${DEPOSIT}
-
+    [Arguments]    ${DEPOSIT}=${30}
+    
+    Log    Deposit equals ${DEPOSIT}
     ${WALLET}    ${ADDR}    ${WIF} =    Init Wallet with Address    ${ASSETS_DIR}
     ${TX} =    Transfer Mainnet Gas                ${MAINNET_WALLET_WIF}    ${ADDR}    ${DEPOSIT+1}
                Wait Until Keyword Succeeds         ${MAINNET_TIMEOUT}    ${MAINNET_BLOCK_TIME}

--- a/robot/testsuites/integration/acl/acl_basic_private_container.robot
+++ b/robot/testsuites/integration/acl/acl_basic_private_container.robot
@@ -16,15 +16,16 @@ Basic ACL Operations for Private Container
 
     [Setup]                 Setup
 
-                            Generate Keys
+    ${WALLET}   ${ADDR}     ${USER_KEY} =   Prepare Wallet And Deposit
+    ${WALLET_OTH}   ${ADDR_OTH}     ${OTHER_KEY} =   Prepare Wallet And Deposit
 
-                            Create Containers
-                            Generate file    ${SIMPLE_OBJ_SIZE}
-                            Check Private Container
+    ${PRIV_CID} =           Create Private Container    ${USER_KEY}
+    ${FILE_S}    ${FILE_S_HASH} =                        Generate file    ${SIMPLE_OBJ_SIZE}
+                            Check Private Container    ${USER_KEY}    ${FILE_S}    ${PRIV_CID}    ${OTHER_KEY}
 
-                            Create Containers
-                            Generate file    ${COMPLEX_OBJ_SIZE}
-                            Check Private Container
+    ${PRIV_CID} =           Create Private Container    ${USER_KEY}
+    ${FILE_S}    ${FILE_S_HASH} =             Generate file    ${COMPLEX_OBJ_SIZE}
+                            Check Private Container    ${USER_KEY}    ${FILE_S}    ${PRIV_CID}    ${OTHER_KEY}
 
     [Teardown]              Teardown    acl_basic_private_container
 
@@ -34,60 +35,61 @@ Basic ACL Operations for Private Container
 *** Keywords ***
 
 Check Private Container
+    [Arguments]    ${USER_KEY}    ${FILE_S}    ${PRIV_CID}    ${OTHER_KEY}
 
     # Put
     ${S_OID_USER} =         Put object                 ${USER_KEY}         ${FILE_S}    ${PRIV_CID}    ${EMPTY}    ${EMPTY}
                             Run Keyword And Expect Error        *
                             ...  Put object            ${OTHER_KEY}        ${FILE_S}    ${PRIV_CID}    ${EMPTY}    ${EMPTY}
                             Run Keyword And Expect Error        *
-                            ...  Put object            ${SYSTEM_KEY_IR}    ${FILE_S}    ${PRIV_CID}    ${EMPTY}    ${EMPTY}
-    ${S_OID_SYS_SN} =       Put object                 ${SYSTEM_KEY_SN}    ${FILE_S}    ${PRIV_CID}    ${EMPTY}    ${EMPTY}
+                            ...  Put object            ${NEOFS_IR_WIF}    ${FILE_S}    ${PRIV_CID}    ${EMPTY}    ${EMPTY}
+    ${S_OID_SYS_SN} =       Put object                 ${NEOFS_SN_WIF}    ${FILE_S}    ${PRIV_CID}    ${EMPTY}    ${EMPTY}
 
     # Get
                             Get object               ${USER_KEY}         ${PRIV_CID}    ${S_OID_USER}    ${EMPTY}      s_file_read
                             Run Keyword And Expect Error        *
                             ...  Get object          ${OTHER_KEY}        ${PRIV_CID}    ${S_OID_USER}    ${EMPTY}      s_file_read
-                            Get object               ${SYSTEM_KEY_IR}    ${PRIV_CID}    ${S_OID_USER}    ${EMPTY}      s_file_read
-                            Get object               ${SYSTEM_KEY_SN}    ${PRIV_CID}    ${S_OID_USER}    ${EMPTY}      s_file_read
+                            Get object               ${NEOFS_IR_WIF}    ${PRIV_CID}    ${S_OID_USER}    ${EMPTY}      s_file_read
+                            Get object               ${NEOFS_SN_WIF}    ${PRIV_CID}    ${S_OID_USER}    ${EMPTY}      s_file_read
 
     # Get Range
                             Get Range                           ${USER_KEY}         ${PRIV_CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
                             Run Keyword And Expect Error        *
                             ...  Get Range                      ${OTHER_KEY}        ${PRIV_CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
                             Run Keyword And Expect Error        *
-                            ...  Get Range                      ${SYSTEM_KEY_IR}    ${PRIV_CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+                            ...  Get Range                      ${NEOFS_IR_WIF}    ${PRIV_CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
                             Run Keyword And Expect Error        *
-                            ...  Get Range                      ${SYSTEM_KEY_SN}    ${PRIV_CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+                            ...  Get Range                      ${NEOFS_SN_WIF}    ${PRIV_CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
 
     # Get Range Hash
                             Get Range Hash                      ${USER_KEY}         ${PRIV_CID}    ${S_OID_USER}    ${EMPTY}    0:256
                             Run Keyword And Expect Error        *
                             ...  Get Range Hash                 ${OTHER_KEY}        ${PRIV_CID}    ${S_OID_USER}    ${EMPTY}    0:256
-                            Get Range Hash                      ${SYSTEM_KEY_IR}    ${PRIV_CID}    ${S_OID_USER}    ${EMPTY}    0:256
-                            Get Range Hash                      ${SYSTEM_KEY_SN}    ${PRIV_CID}    ${S_OID_USER}    ${EMPTY}    0:256
+                            Get Range Hash                      ${NEOFS_IR_WIF}    ${PRIV_CID}    ${S_OID_USER}    ${EMPTY}    0:256
+                            Get Range Hash                      ${NEOFS_SN_WIF}    ${PRIV_CID}    ${S_OID_USER}    ${EMPTY}    0:256
 
     # Search
     @{S_OBJ_PRIV} =	    Create List	                        ${S_OID_USER}       ${S_OID_SYS_SN}
                             Search object                       ${USER_KEY}         ${PRIV_CID}    --root    ${EMPTY}    ${EMPTY}    ${S_OBJ_PRIV}
                             Run Keyword And Expect Error        *
                             ...  Search object                  ${OTHER_KEY}        ${PRIV_CID}    --root    ${EMPTY}    ${EMPTY}    ${S_OBJ_PRIV}
-                            Search object                       ${SYSTEM_KEY_IR}    ${PRIV_CID}    --root    ${EMPTY}    ${EMPTY}    ${S_OBJ_PRIV}
-                            Search object                       ${SYSTEM_KEY_SN}    ${PRIV_CID}    --root    ${EMPTY}    ${EMPTY}    ${S_OBJ_PRIV}
+                            Search object                       ${NEOFS_IR_WIF}    ${PRIV_CID}    --root    ${EMPTY}    ${EMPTY}    ${S_OBJ_PRIV}
+                            Search object                       ${NEOFS_SN_WIF}    ${PRIV_CID}    --root    ${EMPTY}    ${EMPTY}    ${S_OBJ_PRIV}
 
 
     # Head
                             Head object                         ${USER_KEY}         ${PRIV_CID}    ${S_OID_USER}    ${EMPTY}    ${EMPTY}
                             Run Keyword And Expect Error        *
                             ...  Head object                    ${OTHER_KEY}        ${PRIV_CID}    ${S_OID_USER}    ${EMPTY}    ${EMPTY}
-                            Head object                         ${SYSTEM_KEY_IR}    ${PRIV_CID}    ${S_OID_USER}    ${EMPTY}    ${EMPTY}
-                            Head object                         ${SYSTEM_KEY_SN}    ${PRIV_CID}    ${S_OID_USER}    ${EMPTY}    ${EMPTY}
+                            Head object                         ${NEOFS_IR_WIF}    ${PRIV_CID}    ${S_OID_USER}    ${EMPTY}    ${EMPTY}
+                            Head object                         ${NEOFS_SN_WIF}    ${PRIV_CID}    ${S_OID_USER}    ${EMPTY}    ${EMPTY}
 
 
     # Delete
                             Run Keyword And Expect Error        *
                             ...  Delete object                  ${OTHER_KEY}        ${PRIV_CID}    ${S_OID_USER}    ${EMPTY}
                             Run Keyword And Expect Error        *
-                            ...  Delete object                  ${SYSTEM_KEY_IR}    ${PRIV_CID}    ${S_OID_USER}    ${EMPTY}
+                            ...  Delete object                  ${NEOFS_IR_WIF}    ${PRIV_CID}    ${S_OID_USER}    ${EMPTY}
                             Run Keyword And Expect Error        *
-                            ...  Delete object                  ${SYSTEM_KEY_SN}    ${PRIV_CID}    ${S_OID_USER}    ${EMPTY}
+                            ...  Delete object                  ${NEOFS_SN_WIF}    ${PRIV_CID}    ${S_OID_USER}    ${EMPTY}
                             Delete object                       ${USER_KEY}         ${PRIV_CID}    ${S_OID_USER}    ${EMPTY}

--- a/robot/testsuites/integration/acl/acl_basic_private_container_storagegroup.robot
+++ b/robot/testsuites/integration/acl/acl_basic_private_container_storagegroup.robot
@@ -18,15 +18,16 @@ Basic ACL Operations for Private Container
 
     [Setup]                 Setup
 
-                            Generate Keys
+    ${WALLET}   ${ADDR}     ${USER_KEY} =   Prepare Wallet And Deposit
+    ${WALLET_OTH}   ${ADDR_OTH}     ${OTHER_KEY} =   Prepare Wallet And Deposit
 
-                            Create Containers
-                            Generate file    ${SIMPLE_OBJ_SIZE}
-                            Check Private Container    Simple
+    ${PRIV_CID} =           Create Private Container    ${USER_KEY}
+    ${FILE_S}    ${FILE_S_HASH} =                        Generate file    ${SIMPLE_OBJ_SIZE}
+                            Check Private Container    Simple    ${USER_KEY}    ${FILE_S}    ${PRIV_CID}    ${OTHER_KEY}
 
-                            Create Containers
-                            Generate file    ${COMPLEX_OBJ_SIZE}
-                            Check Private Container    Complex
+    ${PRIV_CID} =           Create Private Container    ${USER_KEY}
+    ${FILE_S}    ${FILE_S_HASH} =             Generate file    ${COMPLEX_OBJ_SIZE}
+                            Check Private Container    Complex    ${USER_KEY}    ${FILE_S}    ${PRIV_CID}    ${OTHER_KEY}
 
     [Teardown]              Teardown    acl_basic_private_container_storagegroup
 
@@ -34,7 +35,7 @@ Basic ACL Operations for Private Container
 *** Keywords ***
 
 Check Private Container
-    [Arguments]     ${RUN_TYPE}
+    [Arguments]     ${RUN_TYPE}    ${USER_KEY}    ${FILE_S}    ${PRIV_CID}    ${OTHER_KEY}
 
     # Put target object to use in storage groups
     ${S_OID_USER} =         Put object    ${USER_KEY}    ${FILE_S}    ${PRIV_CID}    ${EMPTY}    ${EMPTY}
@@ -63,24 +64,24 @@ Check Private Container
 
 
     # System group key (storage node)
-    ${SG_OID_1} =       Put Storagegroup    ${SYSTEM_KEY_SN}    ${PRIV_CID}   ${EMPTY}    ${S_OID_USER}
-                        List Storagegroup    ${SYSTEM_KEY_SN}    ${PRIV_CID}   ${EMPTY}    ${SG_OID_1}  ${SG_OID_INV}
-    @{EXPECTED_OIDS} =  Run Keyword If    "${RUN_TYPE}" == "Complex"    Get Split objects    ${SYSTEM_KEY_SN}    ${PRIV_CID}   ${S_OID_USER}
+    ${SG_OID_1} =       Put Storagegroup    ${NEOFS_SN_WIF}    ${PRIV_CID}   ${EMPTY}    ${S_OID_USER}
+                        List Storagegroup    ${NEOFS_SN_WIF}    ${PRIV_CID}   ${EMPTY}    ${SG_OID_1}  ${SG_OID_INV}
+    @{EXPECTED_OIDS} =  Run Keyword If    "${RUN_TYPE}" == "Complex"    Get Split objects    ${NEOFS_SN_WIF}    ${PRIV_CID}   ${S_OID_USER}
                         ...    ELSE IF    "${RUN_TYPE}" == "Simple"    Create List    ${S_OID_USER}
-                        Get Storagegroup    ${SYSTEM_KEY_SN}    ${PRIV_CID}    ${SG_OID_1}   ${EMPTY}    ${EMPTY}    @{EXPECTED_OIDS}
+                        Get Storagegroup    ${NEOFS_SN_WIF}    ${PRIV_CID}    ${SG_OID_1}   ${EMPTY}    ${EMPTY}    @{EXPECTED_OIDS}
                         Run Keyword And Expect Error        *
-                        ...  Delete Storagegroup    ${SYSTEM_KEY_SN}    ${PRIV_CID}    ${SG_OID_1}    ${EMPTY}
+                        ...  Delete Storagegroup    ${NEOFS_SN_WIF}    ${PRIV_CID}    ${SG_OID_1}    ${EMPTY}
 
 
     # System group key (Inner ring node)
                         Run Keyword And Expect Error        *
-                        ...  Put Storagegroup    ${SYSTEM_KEY_IR}    ${PRIV_CID}   ${EMPTY}    ${S_OID_USER}
+                        ...  Put Storagegroup    ${NEOFS_IR_WIF}    ${PRIV_CID}   ${EMPTY}    ${S_OID_USER}
                         Run Keyword And Expect Error        *
-                        ...  List Storagegroup    ${SYSTEM_KEY_IR}    ${PRIV_CID}   ${EMPTY}    ${SG_OID_INV}
+                        ...  List Storagegroup    ${NEOFS_IR_WIF}    ${PRIV_CID}   ${EMPTY}    ${SG_OID_INV}
 
                         @{EXPECTED_OIDS} =  Run Keyword If    "${RUN_TYPE}" == "Complex"    Get Split objects    ${USER_KEY}    ${PRIV_CID}   ${S_OID_USER}
                         ...    ELSE IF   "${RUN_TYPE}" == "Simple"    Create List   ${S_OID_USER}
-                        Get Storagegroup    ${SYSTEM_KEY_IR}    ${PRIV_CID}    ${SG_OID_INV}   ${EMPTY}    ${EMPTY}    @{EXPECTED_OIDS}
+                        Get Storagegroup    ${NEOFS_IR_WIF}    ${PRIV_CID}    ${SG_OID_INV}   ${EMPTY}    ${EMPTY}    @{EXPECTED_OIDS}
 
                         Run Keyword And Expect Error        *
-                        ...  Delete Storagegroup    ${SYSTEM_KEY_IR}    ${PRIV_CID}    ${SG_OID_INV}    ${EMPTY}
+                        ...  Delete Storagegroup    ${NEOFS_IR_WIF}    ${PRIV_CID}    ${SG_OID_INV}    ${EMPTY}

--- a/robot/testsuites/integration/acl/acl_basic_public_container.robot
+++ b/robot/testsuites/integration/acl/acl_basic_public_container.robot
@@ -16,15 +16,16 @@ Basic ACL Operations for Public Container
 
     [Setup]                 Setup
 
-                            Generate Keys
+    ${WALLET}   ${ADDR}     ${USER_KEY} =   Prepare Wallet And Deposit 
+    ${WALLET_OTH}   ${ADDR_OTH}     ${OTHER_KEY} =   Prepare Wallet And Deposit
 
-                            Create Containers
-                            Generate file    ${SIMPLE_OBJ_SIZE}
-                            Check Public Container
+    ${PUBLIC_CID} =         Create Public Container    ${USER_KEY}
+    ${FILE_S}    ${FILE_S_HASH} =                        Generate file    ${SIMPLE_OBJ_SIZE}
+                            Check Public Container    ${USER_KEY}    ${FILE_S}    ${PUBLIC_CID}    ${OTHER_KEY}
 
-                            Create Containers
-                            Generate file    ${COMPLEX_OBJ_SIZE}
-                            Check Public Container
+    ${PUBLIC_CID} =         Create Public Container    ${USER_KEY}
+    ${FILE_S}    ${FILE_S_HASH} =             Generate file    ${COMPLEX_OBJ_SIZE}
+                            Check Public Container    ${USER_KEY}    ${FILE_S}    ${PUBLIC_CID}    ${OTHER_KEY}
 
     [Teardown]              Teardown    acl_basic_public_container
 
@@ -32,58 +33,59 @@ Basic ACL Operations for Public Container
 *** Keywords ***
 
 Check Public Container
+    [Arguments]    ${USER_KEY}    ${FILE_S}    ${PUBLIC_CID}    ${OTHER_KEY}
 
     # Put
     ${S_OID_USER} =         Put object        ${USER_KEY}         ${FILE_S}    ${PUBLIC_CID}    ${EMPTY}    ${EMPTY}
     ${S_OID_OTHER} =        Put object        ${OTHER_KEY}        ${FILE_S}    ${PUBLIC_CID}    ${EMPTY}    ${EMPTY}
-    ${S_OID_SYS_IR} =       Put object        ${SYSTEM_KEY_IR}    ${FILE_S}    ${PUBLIC_CID}    ${EMPTY}    ${EMPTY}
-    ${S_OID_SYS_SN} =       Put object        ${SYSTEM_KEY_SN}    ${FILE_S}    ${PUBLIC_CID}    ${EMPTY}    ${EMPTY}
+    ${S_OID_SYS_IR} =       Put object        ${NEOFS_IR_WIF}    ${FILE_S}    ${PUBLIC_CID}    ${EMPTY}    ${EMPTY}
+    ${S_OID_SYS_SN} =       Put object        ${NEOFS_SN_WIF}    ${FILE_S}    ${PUBLIC_CID}    ${EMPTY}    ${EMPTY}
 
     # Get
                             Get object        ${USER_KEY}         ${PUBLIC_CID}    ${S_OID_USER}    ${EMPTY}    s_file_read
                             Get object        ${OTHER_KEY}        ${PUBLIC_CID}    ${S_OID_USER}    ${EMPTY}    s_file_read
-                            Get object        ${SYSTEM_KEY_IR}    ${PUBLIC_CID}    ${S_OID_USER}    ${EMPTY}    s_file_read
-                            Get object        ${SYSTEM_KEY_SN}    ${PUBLIC_CID}    ${S_OID_USER}    ${EMPTY}    s_file_read
+                            Get object        ${NEOFS_IR_WIF}    ${PUBLIC_CID}    ${S_OID_USER}    ${EMPTY}    s_file_read
+                            Get object        ${NEOFS_SN_WIF}    ${PUBLIC_CID}    ${S_OID_USER}    ${EMPTY}    s_file_read
 
     # Get Range
                             Get Range         ${USER_KEY}         ${PUBLIC_CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
                             Get Range         ${OTHER_KEY}        ${PUBLIC_CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
-                            Get Range         ${SYSTEM_KEY_IR}    ${PUBLIC_CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
-                            Get Range         ${SYSTEM_KEY_SN}    ${PUBLIC_CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+                            Get Range         ${NEOFS_IR_WIF}    ${PUBLIC_CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+                            Get Range         ${NEOFS_SN_WIF}    ${PUBLIC_CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
 
 
     # Get Range Hash
                             Get Range Hash    ${USER_KEY}         ${PUBLIC_CID}    ${S_OID_USER}    ${EMPTY}    0:256
                             Get Range Hash    ${OTHER_KEY}        ${PUBLIC_CID}    ${S_OID_USER}    ${EMPTY}    0:256
-                            Get Range Hash    ${SYSTEM_KEY_IR}    ${PUBLIC_CID}    ${S_OID_USER}    ${EMPTY}    0:256
-                            Get Range Hash    ${SYSTEM_KEY_SN}    ${PUBLIC_CID}    ${S_OID_USER}    ${EMPTY}    0:256
+                            Get Range Hash    ${NEOFS_IR_WIF}    ${PUBLIC_CID}    ${S_OID_USER}    ${EMPTY}    0:256
+                            Get Range Hash    ${NEOFS_SN_WIF}    ${PUBLIC_CID}    ${S_OID_USER}    ${EMPTY}    0:256
 
     # Search
     @{S_OBJ_PRIV} =	    Create List	      ${S_OID_USER}       ${S_OID_OTHER}    ${S_OID_SYS_SN}    ${S_OID_SYS_IR}
                             Search object     ${USER_KEY}         ${PUBLIC_CID}     --root    ${EMPTY}    ${EMPTY}    ${S_OBJ_PRIV}
                             Search object     ${OTHER_KEY}        ${PUBLIC_CID}     --root    ${EMPTY}    ${EMPTY}    ${S_OBJ_PRIV}
-                            Search object     ${SYSTEM_KEY_IR}    ${PUBLIC_CID}     --root    ${EMPTY}    ${EMPTY}    ${S_OBJ_PRIV}
-                            Search object     ${SYSTEM_KEY_SN}    ${PUBLIC_CID}     --root    ${EMPTY}    ${EMPTY}    ${S_OBJ_PRIV}
+                            Search object     ${NEOFS_IR_WIF}    ${PUBLIC_CID}     --root    ${EMPTY}    ${EMPTY}    ${S_OBJ_PRIV}
+                            Search object     ${NEOFS_SN_WIF}    ${PUBLIC_CID}     --root    ${EMPTY}    ${EMPTY}    ${S_OBJ_PRIV}
 
     # Head
                             Head object       ${USER_KEY}         ${PUBLIC_CID}    ${S_OID_USER}    ${EMPTY}    ${EMPTY}
                             Head object       ${OTHER_KEY}        ${PUBLIC_CID}    ${S_OID_USER}    ${EMPTY}    ${EMPTY}
-                            Head object       ${SYSTEM_KEY_IR}    ${PUBLIC_CID}    ${S_OID_USER}    ${EMPTY}    ${EMPTY}
-                            Head object       ${SYSTEM_KEY_SN}    ${PUBLIC_CID}    ${S_OID_USER}    ${EMPTY}    ${EMPTY}
+                            Head object       ${NEOFS_IR_WIF}    ${PUBLIC_CID}    ${S_OID_USER}    ${EMPTY}    ${EMPTY}
+                            Head object       ${NEOFS_SN_WIF}    ${PUBLIC_CID}    ${S_OID_USER}    ${EMPTY}    ${EMPTY}
 
                             Head object       ${USER_KEY}         ${PUBLIC_CID}    ${S_OID_OTHER}    ${EMPTY}    ${EMPTY}
                             Head object       ${OTHER_KEY}        ${PUBLIC_CID}    ${S_OID_OTHER}    ${EMPTY}    ${EMPTY}
-                            Head object       ${SYSTEM_KEY_IR}    ${PUBLIC_CID}    ${S_OID_OTHER}    ${EMPTY}    ${EMPTY}
-                            Head object       ${SYSTEM_KEY_SN}    ${PUBLIC_CID}    ${S_OID_OTHER}    ${EMPTY}    ${EMPTY}
+                            Head object       ${NEOFS_IR_WIF}    ${PUBLIC_CID}    ${S_OID_OTHER}    ${EMPTY}    ${EMPTY}
+                            Head object       ${NEOFS_SN_WIF}    ${PUBLIC_CID}    ${S_OID_OTHER}    ${EMPTY}    ${EMPTY}
 
                             Head object       ${USER_KEY}         ${PUBLIC_CID}    ${S_OID_SYS_SN}    ${EMPTY}    ${EMPTY}
                             Head object       ${OTHER_KEY}        ${PUBLIC_CID}    ${S_OID_SYS_SN}    ${EMPTY}    ${EMPTY}
-                            Head object       ${SYSTEM_KEY_IR}    ${PUBLIC_CID}    ${S_OID_SYS_SN}    ${EMPTY}    ${EMPTY}
-                            Head object       ${SYSTEM_KEY_SN}    ${PUBLIC_CID}    ${S_OID_SYS_SN}    ${EMPTY}    ${EMPTY}
+                            Head object       ${NEOFS_IR_WIF}    ${PUBLIC_CID}    ${S_OID_SYS_SN}    ${EMPTY}    ${EMPTY}
+                            Head object       ${NEOFS_SN_WIF}    ${PUBLIC_CID}    ${S_OID_SYS_SN}    ${EMPTY}    ${EMPTY}
 
 
     # Delete
                             Delete object     ${USER_KEY}         ${PUBLIC_CID}    ${S_OID_SYS_IR}    ${EMPTY}
                             Delete object     ${OTHER_KEY}        ${PUBLIC_CID}    ${S_OID_SYS_SN}    ${EMPTY}
-                            Delete object     ${SYSTEM_KEY_IR}    ${PUBLIC_CID}    ${S_OID_USER}      ${EMPTY}
-                            Delete object     ${SYSTEM_KEY_SN}    ${PUBLIC_CID}    ${S_OID_OTHER}     ${EMPTY}
+                            Delete object     ${NEOFS_IR_WIF}    ${PUBLIC_CID}    ${S_OID_USER}      ${EMPTY}
+                            Delete object     ${NEOFS_SN_WIF}    ${PUBLIC_CID}    ${S_OID_OTHER}     ${EMPTY}

--- a/robot/testsuites/integration/acl/acl_basic_public_container_storagegroup.robot
+++ b/robot/testsuites/integration/acl/acl_basic_public_container_storagegroup.robot
@@ -17,15 +17,16 @@ Basic ACL Operations for Public Container
 
     [Setup]                 Setup
 
-                            Generate Keys
+    ${WALLET}   ${ADDR}     ${USER_KEY} =   Prepare Wallet And Deposit  
+    ${WALLET_OTH}   ${ADDR_OTH}     ${OTHER_KEY} =   Prepare Wallet And Deposit
 
-                            Create Containers
-                            Generate file    ${SIMPLE_OBJ_SIZE}
-                            Check Public Container    Simple
+    ${PUBLIC_CID} =         Create Public Container    ${USER_KEY}
+    ${FILE_S}    ${FILE_S_HASH} =                        Generate file    ${SIMPLE_OBJ_SIZE}
+                            Check Public Container    Simple    ${USER_KEY}    ${FILE_S}    ${PUBLIC_CID}    ${OTHER_KEY}
 
-                            Create Containers
-                            Generate file    ${COMPLEX_OBJ_SIZE}
-                            Check Public Container    Complex
+    ${PUBLIC_CID} =         Create Public Container    ${USER_KEY}
+    ${FILE_S}    ${FILE_S_HASH} =             Generate file    ${COMPLEX_OBJ_SIZE}
+                            Check Public Container    Complex    ${USER_KEY}    ${FILE_S}    ${PUBLIC_CID}    ${OTHER_KEY}
 
     [Teardown]              Teardown    acl_basic_public_container_storagegroup
 
@@ -33,7 +34,7 @@ Basic ACL Operations for Public Container
 *** Keywords ***
 
 Check Public Container
-    [Arguments]     ${RUN_TYPE}
+    [Arguments]     ${RUN_TYPE}    ${USER_KEY}    ${FILE_S}    ${PUBLIC_CID}    ${OTHER_KEY}
 
     # Storage group Operations (Put, List, Get, Delete)
                             Log    Storage group Operations for each Role keys
@@ -41,7 +42,7 @@ Check Public Container
     # Put target object to use in storage groups
     ${S_OID} =              Put object    ${USER_KEY}    ${FILE_S}    ${PUBLIC_CID}    ${EMPTY}    ${EMPTY}
 
-    @{Roles_keys} =	        Create List    ${USER_KEY}    ${OTHER_KEY}    ${SYSTEM_KEY_IR}    ${SYSTEM_KEY_SN}
+    @{Roles_keys} =	        Create List    ${USER_KEY}    ${OTHER_KEY}    ${NEOFS_IR_WIF}    ${NEOFS_SN_WIF}
 
     FOR	${role_key}	IN	@{Roles_keys}
         ${SG_OID_1} =       Put Storagegroup    ${role_key}    ${PUBLIC_CID}   ${EMPTY}    ${S_OID}

--- a/robot/testsuites/integration/acl/acl_basic_readonly_container.robot
+++ b/robot/testsuites/integration/acl/acl_basic_readonly_container.robot
@@ -16,15 +16,16 @@ Basic ACL Operations for Read-Only Container
 
     [Setup]                 Setup
 
-                            Generate Keys
+    ${WALLET}   ${ADDR}     ${USER_KEY} =   Prepare Wallet And Deposit
+    ${WALLET_OTH}   ${ADDR_OTH}     ${OTHER_KEY} =   Prepare Wallet And Deposit
 
-                            Create Containers
-                            Generate file    ${SIMPLE_OBJ_SIZE}
-                            Check Read-Only Container    Simple
+    ${READONLY_CID} =       Create Read-Only Container    ${USER_KEY}
+    ${FILE_S}    ${FILE_S_HASH} =                        Generate file    ${SIMPLE_OBJ_SIZE}
+                            Check Read-Only Container    Simple    ${USER_KEY}    ${FILE_S}    ${READONLY_CID}    ${OTHER_KEY}
 
-                            Create Containers
-                            Generate file    ${COMPLEX_OBJ_SIZE}
-                            Check Read-Only Container    Complex
+    ${READONLY_CID} =       Create Read-Only Container    ${USER_KEY}
+    ${FILE_S}    ${FILE_S_HASH} =             Generate file    ${COMPLEX_OBJ_SIZE}
+                            Check Read-Only Container    Complex    ${USER_KEY}    ${FILE_S}    ${READONLY_CID}    ${OTHER_KEY}
 
     [Teardown]              Teardown    acl_basic_readonly_container
 
@@ -33,15 +34,15 @@ Basic ACL Operations for Read-Only Container
 
 
 Check Read-Only Container
-    [Arguments]     ${RUN_TYPE}
+    [Arguments]     ${RUN_TYPE}    ${USER_KEY}    ${FILE_S}    ${READONLY_CID}    ${OTHER_KEY}
 
     # Put
     ${S_OID_USER} =         Put object                 ${USER_KEY}         ${FILE_S}    ${READONLY_CID}    ${EMPTY}    ${EMPTY}
                             Run Keyword And Expect Error        *
                             ...  Put object            ${OTHER_KEY}        ${FILE_S}    ${READONLY_CID}    ${EMPTY}    ${EMPTY}
                             Run Keyword And Expect Error        *
-                            ...  Put object            ${SYSTEM_KEY_IR}    ${FILE_S}    ${READONLY_CID}    ${EMPTY}    ${EMPTY}
-    ${S_OID_SYS_SN} =       Put object                 ${SYSTEM_KEY_SN}    ${FILE_S}    ${READONLY_CID}    ${EMPTY}    ${EMPTY}
+                            ...  Put object            ${NEOFS_IR_WIF}    ${FILE_S}    ${READONLY_CID}    ${EMPTY}    ${EMPTY}
+    ${S_OID_SYS_SN} =       Put object                 ${NEOFS_SN_WIF}    ${FILE_S}    ${READONLY_CID}    ${EMPTY}    ${EMPTY}
 
 
     # Storage group Operations (Put, List, Get, Delete)
@@ -63,52 +64,52 @@ Check Read-Only Container
                         ...  Delete Storagegroup    ${OTHER_KEY}    ${READONLY_CID}    ${SG_OID_INV}    ${EMPTY}
 
                         Run Keyword And Expect Error        *
-                        ...  Put Storagegroup    ${SYSTEM_KEY_IR}    ${READONLY_CID}   ${EMPTY}    ${S_OID_USER}
-                        List Storagegroup    ${SYSTEM_KEY_IR}    ${READONLY_CID}   ${EMPTY}    ${SG_OID_INV}
+                        ...  Put Storagegroup    ${NEOFS_IR_WIF}    ${READONLY_CID}   ${EMPTY}    ${S_OID_USER}
+                        List Storagegroup    ${NEOFS_IR_WIF}    ${READONLY_CID}   ${EMPTY}    ${SG_OID_INV}
     @{EXPECTED_OIDS} =  Run Keyword If    "${RUN_TYPE}" == "Complex"    Get Split objects    ${USER_KEY}    ${READONLY_CID}   ${S_OID_USER}
                         ...    ELSE IF   "${RUN_TYPE}" == "Simple"    Create List   ${S_OID_USER}
-                        Get Storagegroup    ${SYSTEM_KEY_IR}    ${READONLY_CID}    ${SG_OID_INV}   ${EMPTY}    ${EMPTY}    @{EXPECTED_OIDS}
+                        Get Storagegroup    ${NEOFS_IR_WIF}    ${READONLY_CID}    ${SG_OID_INV}   ${EMPTY}    ${EMPTY}    @{EXPECTED_OIDS}
                         Run Keyword And Expect Error        *
-                        ...  Delete Storagegroup    ${SYSTEM_KEY_IR}    ${READONLY_CID}    ${SG_OID_INV}    ${EMPTY}
+                        ...  Delete Storagegroup    ${NEOFS_IR_WIF}    ${READONLY_CID}    ${SG_OID_INV}    ${EMPTY}
 
     # Get
                             Get object               ${USER_KEY}         ${READONLY_CID}    ${S_OID_USER}    ${EMPTY}    s_file_read
                             Get object               ${OTHER_KEY}        ${READONLY_CID}    ${S_OID_USER}    ${EMPTY}    s_file_read
-                            Get object               ${SYSTEM_KEY_IR}    ${READONLY_CID}    ${S_OID_USER}    ${EMPTY}    s_file_read
-                            Get object               ${SYSTEM_KEY_SN}    ${READONLY_CID}    ${S_OID_USER}    ${EMPTY}    s_file_read
+                            Get object               ${NEOFS_IR_WIF}    ${READONLY_CID}    ${S_OID_USER}    ${EMPTY}    s_file_read
+                            Get object               ${NEOFS_SN_WIF}    ${READONLY_CID}    ${S_OID_USER}    ${EMPTY}    s_file_read
 
     # Get Range
                             Get Range                           ${USER_KEY}         ${READONLY_CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
                             Get Range                           ${OTHER_KEY}        ${READONLY_CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
-                            Get Range                           ${SYSTEM_KEY_IR}    ${READONLY_CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
-                            Get Range                           ${SYSTEM_KEY_SN}    ${READONLY_CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+                            Get Range                           ${NEOFS_IR_WIF}    ${READONLY_CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+                            Get Range                           ${NEOFS_SN_WIF}    ${READONLY_CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
 
 
     # Get Range Hash
                             Get Range Hash                      ${USER_KEY}         ${READONLY_CID}    ${S_OID_USER}    ${EMPTY}    0:256
                             Get Range Hash                      ${OTHER_KEY}        ${READONLY_CID}    ${S_OID_USER}    ${EMPTY}    0:256
-                            Get Range Hash                      ${SYSTEM_KEY_IR}    ${READONLY_CID}    ${S_OID_USER}    ${EMPTY}    0:256
-                            Get Range Hash                      ${SYSTEM_KEY_SN}    ${READONLY_CID}    ${S_OID_USER}    ${EMPTY}    0:256
+                            Get Range Hash                      ${NEOFS_IR_WIF}    ${READONLY_CID}    ${S_OID_USER}    ${EMPTY}    0:256
+                            Get Range Hash                      ${NEOFS_SN_WIF}    ${READONLY_CID}    ${S_OID_USER}    ${EMPTY}    0:256
 
     # Search
     @{S_OBJ_RO} =	        Create List	                        ${S_OID_USER}       ${S_OID_SYS_SN}
                             Search object                       ${USER_KEY}         ${READONLY_CID}    --root    ${EMPTY}    ${EMPTY}    ${S_OBJ_RO}
                             Search object                       ${OTHER_KEY}        ${READONLY_CID}    --root    ${EMPTY}    ${EMPTY}    ${S_OBJ_RO}
-                            Search object                       ${SYSTEM_KEY_IR}    ${READONLY_CID}    --root    ${EMPTY}    ${EMPTY}    ${S_OBJ_RO}
-                            Search object                       ${SYSTEM_KEY_SN}    ${READONLY_CID}    --root    ${EMPTY}    ${EMPTY}    ${S_OBJ_RO}
+                            Search object                       ${NEOFS_IR_WIF}    ${READONLY_CID}    --root    ${EMPTY}    ${EMPTY}    ${S_OBJ_RO}
+                            Search object                       ${NEOFS_SN_WIF}    ${READONLY_CID}    --root    ${EMPTY}    ${EMPTY}    ${S_OBJ_RO}
 
 
     # Head
                             Head object                         ${USER_KEY}         ${READONLY_CID}    ${S_OID_USER}    ${EMPTY}    ${EMPTY}
                             Head object                         ${OTHER_KEY}        ${READONLY_CID}    ${S_OID_USER}    ${EMPTY}    ${EMPTY}
-                            Head object                         ${SYSTEM_KEY_IR}    ${READONLY_CID}    ${S_OID_USER}    ${EMPTY}    ${EMPTY}
-                            Head object                         ${SYSTEM_KEY_SN}    ${READONLY_CID}    ${S_OID_USER}    ${EMPTY}    ${EMPTY}
+                            Head object                         ${NEOFS_IR_WIF}    ${READONLY_CID}    ${S_OID_USER}    ${EMPTY}    ${EMPTY}
+                            Head object                         ${NEOFS_SN_WIF}    ${READONLY_CID}    ${S_OID_USER}    ${EMPTY}    ${EMPTY}
 
     # Delete
                             Run Keyword And Expect Error        *
                             ...  Delete object                  ${OTHER_KEY}        ${READONLY_CID}    ${S_OID_USER}    ${EMPTY}
                             Run Keyword And Expect Error        *
-                            ...  Delete object                  ${SYSTEM_KEY_IR}    ${READONLY_CID}    ${S_OID_USER}    ${EMPTY}
+                            ...  Delete object                  ${NEOFS_IR_WIF}    ${READONLY_CID}    ${S_OID_USER}    ${EMPTY}
                             Run Keyword And Expect Error        *
-                            ...  Delete object                  ${SYSTEM_KEY_SN}    ${READONLY_CID}    ${S_OID_USER}    ${EMPTY}
+                            ...  Delete object                  ${NEOFS_SN_WIF}    ${READONLY_CID}    ${S_OID_USER}    ${EMPTY}
                             Delete object                       ${USER_KEY}         ${READONLY_CID}    ${S_OID_USER}    ${EMPTY}

--- a/robot/testsuites/integration/acl/acl_basic_readonly_container_storagegroup.robot
+++ b/robot/testsuites/integration/acl/acl_basic_readonly_container_storagegroup.robot
@@ -17,15 +17,17 @@ Basic ACL Operations for Read-Only Container
 
     [Setup]                 Setup
 
-                            Generate Keys
+    ${WALLET}   ${ADDR}     ${USER_KEY} =   Prepare Wallet And Deposit 
+    ${WALLET_OTH}   ${ADDR_OTH}     ${OTHER_KEY} =   Prepare Wallet And Deposit
+    
+    ${READONLY_CID} =       Create Read-Only Container    ${USER_KEY}
+    ${FILE_S}    ${FILE_S_HASH} =                        Generate file    ${SIMPLE_OBJ_SIZE}
+                            Check Read-Only Container    Simple    ${USER_KEY}    ${FILE_S}    ${READONLY_CID}    ${OTHER_KEY}
 
-                            Create Containers
-                            Generate file    ${SIMPLE_OBJ_SIZE}
-                            Check Read-Only Container    Simple
+    ${READONLY_CID} =       Create Read-Only Container    ${USER_KEY}
+    ${FILE_S}    ${FILE_S_HASH} =             Generate file    ${COMPLEX_OBJ_SIZE}
+                            Check Read-Only Container    Complex    ${USER_KEY}    ${FILE_S}    ${READONLY_CID}    ${OTHER_KEY}
 
-                            Create Containers
-                            Generate file    ${COMPLEX_OBJ_SIZE}
-                            Check Read-Only Container    Complex
 
     [Teardown]              Teardown    acl_basic_readonly_container_storagegroup
 
@@ -34,7 +36,7 @@ Basic ACL Operations for Read-Only Container
 
 
 Check Read-Only Container
-    [Arguments]     ${RUN_TYPE}
+    [Arguments]     ${RUN_TYPE}    ${USER_KEY}    ${FILE_S}    ${READONLY_CID}    ${OTHER_KEY}
 
     # Put target object to use in storage groups
     ${S_OID_USER} =         Put object    ${USER_KEY}    ${FILE_S}    ${READONLY_CID}    ${EMPTY}    ${EMPTY}
@@ -61,10 +63,10 @@ Check Read-Only Container
 
 
                         Run Keyword And Expect Error        *
-                        ...  Put Storagegroup    ${SYSTEM_KEY_IR}    ${READONLY_CID}   ${EMPTY}    ${S_OID_USER}
-                        List Storagegroup    ${SYSTEM_KEY_IR}    ${READONLY_CID}   ${EMPTY}    ${SG_OID_INV}
+                        ...  Put Storagegroup    ${NEOFS_IR_WIF}    ${READONLY_CID}   ${EMPTY}    ${S_OID_USER}
+                        List Storagegroup    ${NEOFS_IR_WIF}    ${READONLY_CID}   ${EMPTY}    ${SG_OID_INV}
     @{EXPECTED_OIDS} =  Run Keyword If    "${RUN_TYPE}" == "Complex"    Get Split objects    ${USER_KEY}    ${READONLY_CID}   ${S_OID_USER}
                         ...    ELSE IF   "${RUN_TYPE}" == "Simple"    Create List   ${S_OID_USER}
-                        Get Storagegroup    ${SYSTEM_KEY_IR}    ${READONLY_CID}    ${SG_OID_INV}   ${EMPTY}    ${EMPTY}    @{EXPECTED_OIDS}
+                        Get Storagegroup    ${NEOFS_IR_WIF}    ${READONLY_CID}    ${SG_OID_INV}   ${EMPTY}    ${EMPTY}    @{EXPECTED_OIDS}
                         Run Keyword And Expect Error        *
-                        ...  Delete Storagegroup    ${SYSTEM_KEY_IR}    ${READONLY_CID}    ${SG_OID_INV}    ${EMPTY}
+                        ...  Delete Storagegroup    ${NEOFS_IR_WIF}    ${READONLY_CID}    ${SG_OID_INV}    ${EMPTY}

--- a/robot/testsuites/integration/acl/acl_bearer_allow.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_allow.robot
@@ -20,16 +20,16 @@ BearerToken Operations
 
     [Setup]                 Setup
 
-                            Generate Keys
+    ${WALLET}   ${ADDR}     ${USER_KEY} =   Prepare Wallet And Deposit 
                             Prepare eACL Role rules
 
                             Log    Check Bearer token with simple object
-                            Generate file    ${SIMPLE_OBJ_SIZE}
-                            Check eACL Deny and Allow All Bearer
+    ${FILE_S} =             Generate file    ${SIMPLE_OBJ_SIZE}
+                            Check eACL Deny and Allow All Bearer    ${USER_KEY}    ${FILE_S}
 
                             Log    Check Bearer token with complex object
-                            Generate file    ${COMPLEX_OBJ_SIZE}
-                            Check eACL Deny and Allow All Bearer
+    ${FILE_S} =             Generate file    ${COMPLEX_OBJ_SIZE}
+                            Check eACL Deny and Allow All Bearer    ${USER_KEY}    ${FILE_S}
 
 
     [Teardown]              Teardown    acl_bearer_allow
@@ -39,8 +39,9 @@ BearerToken Operations
 *** Keywords ***
 
 Check eACL Deny and Allow All Bearer
+    [Arguments]    ${USER_KEY}    ${FILE_S}
 
-    ${CID} =            Create Container Public
+    ${CID} =            Create Container Public    ${USER_KEY}
     ${S_OID_USER} =     Put object        ${USER_KEY}    ${FILE_S}    ${CID}    ${EMPTY}    ${FILE_USR_HEADER}
     ${D_OID_USER} =     Put object        ${USER_KEY}    ${FILE_S}    ${CID}    ${EMPTY}    ${FILE_USR_HEADER_DEL}
     @{S_OBJ_H} =	Create List	      ${S_OID_USER}
@@ -89,3 +90,4 @@ Check eACL Deny and Allow All Bearer
                         Head object         ${USER_KEY}    ${CID}       ${S_OID_USER}    ${EACL_TOKEN}
                         Get Range           ${USER_KEY}    ${CID}       ${S_OID_USER}    s_get_range      ${EACL_TOKEN}    0:256
                         Delete object       ${USER_KEY}    ${CID}       ${S_OID_USER}    ${EACL_TOKEN}
+                        

--- a/robot/testsuites/integration/acl/acl_bearer_allow_storagegroup.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_allow_storagegroup.robot
@@ -20,16 +20,16 @@ BearerToken Operations
 
     [Setup]                 Setup
 
-                            Generate Keys
+    ${WALLET}   ${ADDR}     ${USER_KEY} =   Prepare Wallet And Deposit 
                             Prepare eACL Role rules
 
                             Log    Check Bearer token with simple object
-                            Generate file    ${SIMPLE_OBJ_SIZE}
-                            Check eACL Deny and Allow All Bearer    Simple
+    ${FILE_S} =             Generate file    ${SIMPLE_OBJ_SIZE}
+                            Check eACL Deny and Allow All Bearer    Simple    ${USER_KEY}    ${FILE_S}
 
                             Log    Check Bearer token with complex object
-                            Generate file    ${COMPLEX_OBJ_SIZE}
-                            Check eACL Deny and Allow All Bearer    Complex
+    ${FILE_S} =             Generate file    ${COMPLEX_OBJ_SIZE}
+                            Check eACL Deny and Allow All Bearer    Complex    ${USER_KEY}    ${FILE_S}
 
 
     [Teardown]              Teardown    acl_bearer_allow_storagegroup
@@ -39,8 +39,9 @@ BearerToken Operations
 *** Keywords ***
 
 Check eACL Deny and Allow All Bearer
-    [Arguments]     ${RUN_TYPE}
-    ${CID} =                Create Container Public
+    [Arguments]     ${RUN_TYPE}    ${USER_KEY}    ${FILE_S}
+    
+    ${CID} =                Create Container Public    ${USER_KEY}
     ${S_OID_USER} =         Put object    ${USER_KEY}    ${FILE_S}    ${CID}    ${EMPTY}    ${FILE_USR_HEADER}
 
 

--- a/robot/testsuites/integration/acl/acl_bearer_compound.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_compound.robot
@@ -21,17 +21,18 @@ BearerToken Operations for Сompound Operations
     [Timeout]               20 min
 
     [Setup]                 Setup
-
-                            Generate Keys
+    
+    ${WALLET}   ${ADDR}     ${USER_KEY} =   Prepare Wallet And Deposit 
+    ${WALLET_OTH}   ${ADDR_OTH}     ${OTHER_KEY} =   Prepare Wallet And Deposit 
                             Prepare eACL Role rules
 
                             Log    Check Bearer token with simple object
-                            Generate file    ${SIMPLE_OBJ_SIZE}
-                            Check Сompound Operations
+    ${FILE_S} =             Generate file    ${SIMPLE_OBJ_SIZE}
+                            Check Сompound Operations    ${USER_KEY}    ${OTHER_KEY}    ${FILE_S}
 
                             Log    Check Bearer token with complex object
-                            Generate file    ${COMPLEX_OBJ_SIZE}
-                            Check Сompound Operations
+    ${FILE_S} =             Generate file    ${COMPLEX_OBJ_SIZE}
+                            Check Сompound Operations    ${USER_KEY}    ${OTHER_KEY}    ${FILE_S}
 
     [Teardown]              Teardown    acl_bearer_compound
 
@@ -39,25 +40,24 @@ BearerToken Operations for Сompound Operations
 *** Keywords ***
 
 Check Сompound Operations
-    Check Bearer Сompound Get    ${OTHER_KEY}     OTHERS    ${EACL_DENY_ALL_OTHERS}
-    Check Bearer Сompound Get    ${USER_KEY}      USER      ${EACL_DENY_ALL_USER}
-    Check Bearer Сompound Get    ${SYSTEM_KEY}    SYSTEM    ${EACL_DENY_ALL_SYSTEM}
+    [Arguments]    ${USER_KEY}    ${OTHER_KEY}    ${FILE_S}
+                            Check Bearer Сompound Get    ${OTHER_KEY}     OTHERS    ${EACL_DENY_ALL_OTHERS}    ${FILE_S}    ${USER_KEY} 
+                            Check Bearer Сompound Get    ${USER_KEY}      USER      ${EACL_DENY_ALL_USER}    ${FILE_S}     ${USER_KEY}
+                            Check Bearer Сompound Get    ${SYSTEM_KEY}    SYSTEM    ${EACL_DENY_ALL_SYSTEM}    ${FILE_S}     ${USER_KEY}
 
-    Check Bearer Сompound Delete    ${OTHER_KEY}     OTHERS    ${EACL_DENY_ALL_OTHERS}
-    Check Bearer Сompound Delete    ${USER_KEY}      USER      ${EACL_DENY_ALL_USER}
-    Check Bearer Сompound Delete    ${SYSTEM_KEY}    SYSTEM    ${EACL_DENY_ALL_SYSTEM}
+                            Check Bearer Сompound Delete    ${OTHER_KEY}     OTHERS    ${EACL_DENY_ALL_OTHERS}    ${FILE_S}     ${USER_KEY}
+                            Check Bearer Сompound Delete    ${USER_KEY}      USER      ${EACL_DENY_ALL_USER}    ${FILE_S}     ${USER_KEY}
+                            Check Bearer Сompound Delete    ${SYSTEM_KEY}    SYSTEM    ${EACL_DENY_ALL_SYSTEM}    ${FILE_S}    ${USER_KEY} 
 
-    Check Bearer Сompound Get Range Hash    ${OTHER_KEY}     OTHERS    ${EACL_DENY_ALL_OTHERS}
-    Check Bearer Сompound Get Range Hash    ${USER_KEY}      USER      ${EACL_DENY_ALL_USER}
-    Check Bearer Сompound Get Range Hash    ${SYSTEM_KEY}    SYSTEM    ${EACL_DENY_ALL_SYSTEM}
-
-
+                            Check Bearer Сompound Get Range Hash    ${OTHER_KEY}     OTHERS    ${EACL_DENY_ALL_OTHERS}    ${FILE_S}    ${USER_KEY}    
+                            Check Bearer Сompound Get Range Hash    ${USER_KEY}      USER      ${EACL_DENY_ALL_USER}    ${FILE_S}    ${USER_KEY}
+                            Check Bearer Сompound Get Range Hash    ${SYSTEM_KEY}    SYSTEM    ${EACL_DENY_ALL_SYSTEM}    ${FILE_S}    ${USER_KEY}
 Check Bearer Сompound Get
-    [Arguments]             ${KEY}    ${DENY_GROUP}    ${DENY_EACL}
+    [Arguments]             ${KEY}    ${DENY_GROUP}    ${DENY_EACL}    ${FILE_S}    ${USER_KEY}
 
-    ${CID} =            Create Container Public
-    ${S_OID_USER} =     Put object     ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${FILE_USR_HEADER}
-    @{S_OBJ_H} =        Create List    ${S_OID_USER}
+    ${CID} =                Create Container Public    ${USER_KEY}
+    ${S_OID_USER} =         Put object                 ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${FILE_USR_HEADER}
+    @{S_OBJ_H} =	        Create List	                        ${S_OID_USER}
 
     ${S_OID_USER} =     Put object     ${USER_KEY}    ${FILE_S}    ${CID}           ${EMPTY}    ${FILE_USR_HEADER}
                         Put object     ${KEY}         ${FILE_S}    ${CID}           ${EMPTY}    ${FILE_OTH_HEADER}
@@ -82,10 +82,9 @@ Check Bearer Сompound Get
 
 
 Check Bearer Сompound Delete
-    [Arguments]             ${KEY}    ${DENY_GROUP}    ${DENY_EACL}
+    [Arguments]             ${KEY}    ${DENY_GROUP}    ${DENY_EACL}    ${FILE_S}    ${USER_KEY}    
 
-    ${CID} =            Create Container Public
-
+    ${CID} =                Create Container Public    ${USER_KEY}
     ${S_OID_USER} =     Put object         ${USER_KEY}    ${FILE_S}    ${CID}           ${EMPTY}    ${FILE_USR_HEADER}
     ${D_OID_USER} =     Put object         ${USER_KEY}    ${FILE_S}    ${CID}           ${EMPTY}    ${EMPTY}
                         Put object         ${KEY}         ${FILE_S}    ${CID}           ${EMPTY}    ${FILE_OTH_HEADER}
@@ -112,14 +111,13 @@ Check Bearer Сompound Delete
 
 
 Check Bearer Сompound Get Range Hash
-    [Arguments]            ${KEY}    ${DENY_GROUP}    ${DENY_EACL}
+    [Arguments]             ${KEY}    ${DENY_GROUP}    ${DENY_EACL}    ${FILE_S}    ${USER_KEY}
 
-    ${CID} =            Create Container Public
+    ${CID} =                Create Container Public    ${USER_KEY}
 
-    ${S_OID_USER} =     Put object         ${USER_KEY}         ${FILE_S}    ${CID}           ${EMPTY}    ${FILE_USR_HEADER}
-                        Put object         ${KEY}              ${FILE_S}    ${CID}           ${EMPTY}    ${FILE_OTH_HEADER}
-                        Get Range Hash     ${SYSTEM_KEY_SN}    ${CID}       ${S_OID_USER}    ${EMPTY}    0:256
-
+    ${S_OID_USER} =         Put object             ${USER_KEY}         ${FILE_S}    ${CID}           ${EMPTY}    ${FILE_USR_HEADER}
+                            Put object             ${KEY}              ${FILE_S}    ${CID}           ${EMPTY}    ${FILE_OTH_HEADER}
+                            Get Range Hash                  ${NEOFS_SN_WIF}    ${CID}       ${S_OID_USER}    ${EMPTY}    0:256
                         Set eACL           ${USER_KEY}         ${CID}       ${DENY_EACL}
 
                         # The current ACL cache lifetime is 30 sec

--- a/robot/testsuites/integration/acl/acl_bearer_filter_oid_equal.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_filter_oid_equal.robot
@@ -19,17 +19,18 @@ BearerToken Operations with Filter OID Equal
     [Timeout]               20 min
 
     [Setup]                 Setup
-
-                            Generate Keys
-
+    
+    ${WALLET}   ${ADDR}     ${USER_KEY} =   Prepare Wallet And Deposit
+    ${WALLET_OTH}   ${ADDR_OTH}     ${OTHER_KEY} =   Prepare Wallet And Deposit 
+                            Prepare eACL Role rules
                             Log    Check Bearer token with simple object
-                            Generate file    ${SIMPLE_OBJ_SIZE}
-                            Check eACL Deny and Allow All Bearer Filter OID Equal
+    ${FILE_S} =             Generate file    ${SIMPLE_OBJ_SIZE}
+                            Check eACL Deny and Allow All Bearer Filter OID Equal    ${USER_KEY}    ${FILE_S}
 
                             Log    Check Bearer token with complex object
 
-                            Generate file    ${COMPLEX_OBJ_SIZE}
-                            Check eACL Deny and Allow All Bearer Filter OID Equal
+    ${FILE_S} =             Generate file    ${COMPLEX_OBJ_SIZE}
+                            Check eACL Deny and Allow All Bearer Filter OID Equal    ${USER_KEY}    ${FILE_S}
 
     [Teardown]              Teardown    acl_bearer_filter_oid_equal
 
@@ -38,7 +39,9 @@ BearerToken Operations with Filter OID Equal
 *** Keywords ***
 
 Check eACL Deny and Allow All Bearer Filter OID Equal
-    ${CID} =                Create Container Public
+    [Arguments]    ${USER_KEY}    ${FILE_S}
+
+    ${CID} =                Create Container Public    ${USER_KEY}
     ${S_OID_USER} =         Put object         ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${FILE_USR_HEADER}
     ${S_OID_USER_2} =       Put object         ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${EMPTY}
     ${D_OID_USER} =         Put object         ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${FILE_USR_HEADER_DEL}

--- a/robot/testsuites/integration/acl/acl_bearer_filter_oid_not_equal.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_filter_oid_not_equal.robot
@@ -19,16 +19,17 @@ BearerToken Operations with Filter OID NotEqual
     [Timeout]               20 min
 
     [Setup]                 Setup
-
-                            Generate Keys
+    
+    ${WALLET}   ${ADDR}     ${USER_KEY} =   Prepare Wallet And Deposit 
+                            Prepare eACL Role rules
 
                             Log    Check Bearer token with simple object
-                            Generate file    ${SIMPLE_OBJ_SIZE}
-                            Check eACL Deny and Allow All Bearer Filter OID NotEqual
+    ${FILE_S} =             Generate file    ${SIMPLE_OBJ_SIZE}
+                            Check eACL Deny and Allow All Bearer Filter OID NotEqual    ${USER_KEY}    ${FILE_S}
 
                             Log    Check Bearer token with complex object
-                            Generate file    ${COMPLEX_OBJ_SIZE}
-                            Check eACL Deny and Allow All Bearer Filter OID NotEqual
+    ${FILE_S} =             Generate file    ${COMPLEX_OBJ_SIZE}
+                            Check eACL Deny and Allow All Bearer Filter OID NotEqual    ${USER_KEY}    ${FILE_S}
 
     [Teardown]              Teardown    acl_bearer_filter_oid_not_equal
 
@@ -37,11 +38,13 @@ BearerToken Operations with Filter OID NotEqual
 *** Keywords ***
 
 Check eACL Deny and Allow All Bearer Filter OID NotEqual
-    ${CID} =                Create Container Public
-    ${S_OID_USER} =         Put object          ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${FILE_USR_HEADER}
-    ${S_OID_USER_2} =       Put object          ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${EMPTY}
-    ${D_OID_USER} =         Put object          ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${FILE_USR_HEADER_DEL}
-    @{S_OBJ_H} =	    Create List	        ${S_OID_USER}
+    [Arguments]    ${USER_KEY}    ${FILE_S}
+
+    ${CID} =                Create Container Public    ${USER_KEY}
+    ${S_OID_USER} =         Put object                 ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${FILE_USR_HEADER}
+    ${S_OID_USER_2} =       Put object                 ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${EMPTY}
+    ${D_OID_USER} =         Put object                 ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${FILE_USR_HEADER_DEL}
+    @{S_OBJ_H} =	        Create List	                        ${S_OID_USER}
 
                             Put object          ${USER_KEY}    ${FILE_S}     ${CID}           ${EMPTY}       ${FILE_OTH_HEADER}
                             Get object          ${USER_KEY}    ${CID}        ${S_OID_USER}    ${EMPTY}       local_file_eacl

--- a/robot/testsuites/integration/acl/acl_bearer_filter_userheader_equal.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_filter_userheader_equal.robot
@@ -19,28 +19,28 @@ BearerToken Operations with Filter UserHeader Equal
 
     [Setup]                 Setup
 
-                            Generate Keys
+    ${WALLET}   ${ADDR}     ${USER_KEY} =   Prepare Wallet And Deposit 
                             Prepare eACL Role rules
 
                             Log    Check Bearer token with simple object
-                            Generate file    ${SIMPLE_OBJ_SIZE}
-                            Check eACL Deny and Allow All Bearer Filter UserHeader Equal
+    ${FILE_S} =             Generate file    ${SIMPLE_OBJ_SIZE}
+                            Check eACL Deny and Allow All Bearer Filter UserHeader Equal    ${USER_KEY}    ${FILE_S}
 
 
                             Log    Check Bearer token with complex object
-                            Generate file    ${COMPLEX_OBJ_SIZE}
-                            Check eACL Deny and Allow All Bearer Filter UserHeader Equal
+    ${FILE_S} =             Generate file    ${COMPLEX_OBJ_SIZE}
+                            Check eACL Deny and Allow All Bearer Filter UserHeader Equal    ${USER_KEY}    ${FILE_S}
 
     [Teardown]              Teardown    acl_bearer_filter_userheader_equal
 
 *** Keywords ***
-
 Check eACL Deny and Allow All Bearer Filter UserHeader Equal
-    ${CID} =                Create Container Public
-    ${S_OID_USER} =         Put object       ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${FILE_USR_HEADER}
-    ${S_OID_USER_2} =       Put object       ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${EMPTY}
-    ${D_OID_USER} =         Put object       ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${FILE_USR_HEADER_DEL}
-    @{S_OBJ_H} =	    Create List	     ${S_OID_USER}
+    [Arguments]    ${USER_KEY}    ${FILE_S}
+    ${CID} =                Create Container Public    ${USER_KEY} 
+    ${S_OID_USER} =         Put object                 ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${FILE_USR_HEADER}
+    ${S_OID_USER_2} =       Put object                 ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${EMPTY}
+    ${D_OID_USER} =         Put object                 ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${FILE_USR_HEADER_DEL}
+    @{S_OBJ_H} =	        Create List	                        ${S_OID_USER}
 
                             Put object       ${USER_KEY}    ${FILE_S}    ${CID}               ${EMPTY}      ${FILE_OTH_HEADER}
                             Get object       ${USER_KEY}    ${CID}       ${S_OID_USER}        ${EMPTY}      local_file_eacl

--- a/robot/testsuites/integration/acl/acl_bearer_filter_userheader_not_equal.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_filter_userheader_not_equal.robot
@@ -19,22 +19,25 @@ BearerToken Operations Filter UserHeader NotEqual
 
     [Setup]                 Setup
 
-                            Generate Keys
+    ${WALLET}   ${ADDR}     ${USER_KEY} =   Prepare Wallet And Deposit
+                            Prepare eACL Role rules
 
                             Log    Check Bearer token with simple object
-                            Generate file    ${SIMPLE_OBJ_SIZE}
-                            Check eACL Deny and Allow All Bearer Filter UserHeader NotEqual
+    ${FILE_S} =             Generate file    ${SIMPLE_OBJ_SIZE}
+                            Check eACL Deny and Allow All Bearer Filter UserHeader NotEqual    ${USER_KEY}    ${FILE_S}
 
                             Log    Check Bearer token with complex object
-                            Generate file    ${COMPLEX_OBJ_SIZE}
-                            Check eACL Deny and Allow All Bearer Filter UserHeader NotEqual
+    ${FILE_S} =             Generate file    ${COMPLEX_OBJ_SIZE}
+                            Check eACL Deny and Allow All Bearer Filter UserHeader NotEqual    ${USER_KEY}    ${FILE_S}
 
     [Teardown]              Teardown    acl_bearer_filter_userheader_not_equal
 
 *** Keywords ***
 
 Check eACL Deny and Allow All Bearer Filter UserHeader NotEqual
-    ${CID} =            Create Container Public
+    [Arguments]    ${USER_KEY}    ${FILE_S}
+
+    ${CID} =            Create Container Public    ${USER_KEY}
     ${S_OID_USER} =     Put object         ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${FILE_OTH_HEADER}
     ${S_OID_USER_2} =   Put object         ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${FILE_USR_HEADER}
     ${D_OID_USER} =     Put object         ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${FILE_USR_HEADER_DEL}

--- a/robot/testsuites/integration/acl/acl_bearer_inaccessible.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_inaccessible.robot
@@ -20,22 +20,25 @@ BearerToken Operations for Inaccessible Container
 
     [Setup]                 Setup
 
-                            Generate Keys
+    ${WALLET}   ${ADDR}     ${USER_KEY} =   Prepare Wallet And Deposit 
+                            Prepare eACL Role rules
 
                             Log    Check Bearer token with simple object
-                            Generate file    ${SIMPLE_OBJ_SIZE}
-                            Check Container Inaccessible and Allow All Bearer
+    ${FILE_S} =             Generate file    ${SIMPLE_OBJ_SIZE}
+                            Check Container Inaccessible and Allow All Bearer    ${USER_KEY}    ${FILE_S}
 
                             Log    Check Bearer token with complex object
-                            Generate file    ${COMPLEX_OBJ_SIZE}
-                            Check Container Inaccessible and Allow All Bearer
+    ${FILE_S} =             Generate file    ${COMPLEX_OBJ_SIZE}
+                            Check Container Inaccessible and Allow All Bearer    ${USER_KEY}    ${FILE_S}
 
     [Teardown]              Teardown    acl_bearer_inaccessible
 
 *** Keywords ***
 
 Check Container Inaccessible and Allow All Bearer
-    ${CID} =    Create Container Inaccessible
+    [Arguments]    ${USER_KEY}    ${FILE_S}
+
+    ${CID} =    Create Container Inaccessible    ${USER_KEY}
 
                 Run Keyword And Expect Error        *
                 ...  Put object        ${USER_KEY}    ${FILE_S}     ${CID}           ${EMPTY}       ${FILE_USR_HEADER}

--- a/robot/testsuites/integration/acl/acl_bearer_request_filter_xheader_deny.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_request_filter_xheader_deny.robot
@@ -19,16 +19,16 @@ BearerToken Operations
 
     [Setup]                 Setup
 
-                            Generate Keys
+    ${WALLET}   ${ADDR}     ${USER_KEY} =   Prepare Wallet And Deposit
                             Prepare eACL Role rules
 
                             Log    Check Bearer token with simple object
-                            Generate file    ${SIMPLE_OBJ_SIZE}
-                            Check eACL Allow All Bearer Filter Requst Equal Deny
+    ${FILE_S} =             Generate file    ${SIMPLE_OBJ_SIZE}
+                            Check eACL Allow All Bearer Filter Requst Equal Deny    ${USER_KEY}    ${FILE_S}
 
                             Log    Check Bearer token with complex object
-                            Generate file    ${COMPLEX_OBJ_SIZE}
-                            Check eACL Allow All Bearer Filter Requst Equal Deny
+    ${FILE_S} =             Generate file    ${COMPLEX_OBJ_SIZE}
+                            Check eACL Allow All Bearer Filter Requst Equal Deny    ${USER_KEY}    ${FILE_S}
 
     [Teardown]              Teardown    acl_bearer_request_filter_xheader_deny
 
@@ -37,11 +37,13 @@ BearerToken Operations
 *** Keywords ***
 
 Check eACL Allow All Bearer Filter Requst Equal Deny
-    ${CID} =                Create Container Public
-    ${S_OID_USER} =         Put object         ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${FILE_USR_HEADER}
-    ${S_OID_USER_2} =       Put object         ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${EMPTY}
-    ${D_OID_USER} =         Put object         ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${FILE_USR_HEADER_DEL}
-    @{S_OBJ_H} =	    Create List	       ${S_OID_USER}
+    [Arguments]    ${USER_KEY}    ${FILE_S}
+
+    ${CID} =                Create Container Public    ${USER_KEY}
+    ${S_OID_USER} =         Put object                 ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${FILE_USR_HEADER}
+    ${S_OID_USER_2} =       Put object                 ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${EMPTY}
+    ${D_OID_USER} =         Put object                 ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${FILE_USR_HEADER_DEL}
+    @{S_OBJ_H} =	    Create List	               ${S_OID_USER}
 
 
     ${filters}=             Create Dictionary    headerType=REQUEST    matchType=STRING_EQUAL    key=a    value=256

--- a/robot/testsuites/integration/acl/acl_bearer_request_filter_xheader_equal.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_request_filter_xheader_equal.robot
@@ -19,17 +19,17 @@ BearerToken Operations with Filter Requst Equal
     [Timeout]               20 min
 
     [Setup]                 Setup
-
-                            Generate Keys
+    
+    ${WALLET}   ${ADDR}     ${USER_KEY} =   Prepare Wallet And Deposit 
                             Prepare eACL Role rules
 
                             Log    Check Bearer token with simple object
-                            Generate file    ${SIMPLE_OBJ_SIZE}
-                            Check eACL Deny and Allow All Bearer Filter Requst Equal
+    ${FILE_S} =             Generate file    ${SIMPLE_OBJ_SIZE}
+                            Check eACL Deny and Allow All Bearer Filter Requst Equal    ${USER_KEY}    ${FILE_S}
 
                             Log    Check Bearer token with complex object
-                            Generate file    ${COMPLEX_OBJ_SIZE}
-                            Check eACL Deny and Allow All Bearer Filter Requst Equal
+    ${FILE_S} =             Generate file    ${COMPLEX_OBJ_SIZE}
+                            Check eACL Deny and Allow All Bearer Filter Requst Equal    ${USER_KEY}    ${FILE_S}
 
     [Teardown]              Teardown    acl_bearer_request_filter_xheader_equal
 
@@ -38,11 +38,13 @@ BearerToken Operations with Filter Requst Equal
 *** Keywords ***
 
 Check eACL Deny and Allow All Bearer Filter Requst Equal
-    ${CID} =                Create Container Public
-    ${S_OID_USER} =         Put object         ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${FILE_USR_HEADER}
-    ${S_OID_USER_2} =       Put object         ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${EMPTY}
-    ${D_OID_USER} =         Put object         ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${FILE_USR_HEADER_DEL}
-    @{S_OBJ_H} =	    Create List	       ${S_OID_USER}
+    [Arguments]    ${USER_KEY}    ${FILE_S}
+
+    ${CID} =                Create Container Public    ${USER_KEY}
+    ${S_OID_USER} =         Put object                 ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${FILE_USR_HEADER}
+    ${S_OID_USER_2} =       Put object                 ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${EMPTY}
+    ${D_OID_USER} =         Put object                 ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${FILE_USR_HEADER_DEL}
+    @{S_OBJ_H} =	    Create List	               ${S_OID_USER}
 
                             Put object         ${USER_KEY}    ${FILE_S}     ${CID}               ${EMPTY}      ${FILE_OTH_HEADER}
                             Get object         ${USER_KEY}    ${CID}        ${S_OID_USER}        ${EMPTY}      local_file_eacl

--- a/robot/testsuites/integration/acl/acl_bearer_request_filter_xheader_not_equal.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_request_filter_xheader_not_equal.robot
@@ -20,15 +20,16 @@ BearerToken Operations with Filter Requst NotEqual
 
     [Setup]                 Setup
 
-                            Generate Keys
+    ${WALLET}   ${ADDR}     ${USER_KEY} =   Prepare Wallet And Deposit
+                            Prepare eACL Role rules
 
                             Log    Check Bearer token with simple object
-                            Generate file    ${SIMPLE_OBJ_SIZE}
-                            Check eACL Deny and Allow All Bearer Filter Requst NotEqual
+    ${FILE_S} =             Generate file    ${SIMPLE_OBJ_SIZE}
+                            Check eACL Deny and Allow All Bearer Filter Requst NotEqual    ${USER_KEY}    ${FILE_S}
 
                             Log    Check Bearer token with complex object
-                            Generate file    ${COMPLEX_OBJ_SIZE}
-                            Check eACL Deny and Allow All Bearer Filter Requst NotEqual
+    ${FILE_S} =             Generate file    ${COMPLEX_OBJ_SIZE}
+                            Check eACL Deny and Allow All Bearer Filter Requst NotEqual    ${USER_KEY}    ${FILE_S}
 
     [Teardown]              Teardown    acl_bearer_request_filter_xheader_not_equal
 
@@ -36,11 +37,13 @@ BearerToken Operations with Filter Requst NotEqual
 *** Keywords ***
 
 Check eACL Deny and Allow All Bearer Filter Requst NotEqual
-    ${CID} =                Create Container Public
-    ${S_OID_USER} =         Put object         ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${FILE_USR_HEADER}
-    ${S_OID_USER_2} =       Put object         ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${EMPTY}
-    ${D_OID_USER} =         Put object         ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${FILE_USR_HEADER_DEL}
-    @{S_OBJ_H} =	    Create List	       ${S_OID_USER}
+    [Arguments]    ${USER_KEY}    ${FILE_S}
+
+    ${CID} =                Create Container Public    ${USER_KEY}
+    ${S_OID_USER} =         Put object                 ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${FILE_USR_HEADER}
+    ${S_OID_USER_2} =       Put object                 ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${EMPTY}
+    ${D_OID_USER} =         Put object                 ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${FILE_USR_HEADER_DEL}
+    @{S_OBJ_H} =	    Create List	               ${S_OID_USER}
 
                             Put object         ${USER_KEY}    ${FILE_S}     ${CID}           ${EMPTY}      ${FILE_OTH_HEADER}
                             Get object         ${USER_KEY}    ${CID}        ${S_OID_USER}    ${EMPTY}      local_file_eacl

--- a/robot/testsuites/integration/acl/acl_extended_actions_other.robot
+++ b/robot/testsuites/integration/acl/acl_extended_actions_other.robot
@@ -19,15 +19,16 @@ Extended ACL Operations
 
     [Setup]                 Setup
 
-                            Generate Keys
+    ${WALLET}   ${ADDR}     ${USER_KEY} =   Prepare Wallet And Deposit  
+    ${WALLET_OTH}   ${ADDR_OTH}     ${OTHER_KEY} =   Prepare Wallet And Deposit
 
                             Log    Check extended ACL with simple object
                             Generate files    ${SIMPLE_OBJ_SIZE}
-                            Check eACL Deny and Allow All Other
+                            Check eACL Deny and Allow All Other    ${USER_KEY}    ${OTHER_KEY}
 
                             Log    Check extended ACL with complex object
                             Generate files    ${COMPLEX_OBJ_SIZE}
-                            Check eACL Deny and Allow All Other
+                            Check eACL Deny and Allow All Other    ${USER_KEY}    ${OTHER_KEY}
 
     [Teardown]              Teardown    acl_extended_actions_other
 
@@ -35,4 +36,5 @@ Extended ACL Operations
 *** Keywords ***
 
 Check eACL Deny and Allow All Other
-                            Check eACL Deny and Allow All    ${OTHER_KEY}    ${EACL_DENY_ALL_OTHER}    ${EACL_ALLOW_ALL_OTHER}
+    [Arguments]    ${USER_KEY}    ${OTHER_KEY}
+                            Check eACL Deny and Allow All    ${OTHER_KEY}    ${EACL_DENY_ALL_OTHER}    ${EACL_ALLOW_ALL_OTHER}    ${USER_KEY} 

--- a/robot/testsuites/integration/acl/acl_extended_actions_pubkey.robot
+++ b/robot/testsuites/integration/acl/acl_extended_actions_pubkey.robot
@@ -23,15 +23,16 @@ Extended ACL Operations
 
     [Setup]                 Setup
 
-                            Generate Keys
+    ${WALLET}   ${ADDR}     ${USER_KEY} =   Prepare Wallet And Deposit  
+    ${WALLET_OTH}   ${ADDR_OTH}     ${OTHER_KEY} =   Prepare Wallet And Deposit
 
                             Log    Check extended ACL with simple object
                             Generate files    ${SIMPLE_OBJ_SIZE}
-                            Check eACL Deny All Other and Allow All Pubkey
+                            Check eACL Deny All Other and Allow All Pubkey    ${USER_KEY}    ${FILE_S}    ${OTHER_KEY}
 
                             Log    Check extended ACL with complex object
                             Generate files    ${COMPLEX_OBJ_SIZE}
-                            Check eACL Deny All Other and Allow All Pubkey
+                            Check eACL Deny All Other and Allow All Pubkey    ${USER_KEY}    ${FILE_S}    ${OTHER_KEY}
 
 
     [Teardown]              Teardown    acl_extended_actions_pubkey
@@ -40,8 +41,9 @@ Extended ACL Operations
 *** Keywords ***
 
 Check eACL Deny All Other and Allow All Pubkey
+    [Arguments]    ${USER_KEY}    ${FILE_S}    ${OTHER_KEY}
 
-    ${CID} =                Create Container Public
+    ${CID} =                Create Container Public    ${USER_KEY} 
     ${S_OID_USER} =         Put object                 ${USER_KEY}     ${FILE_S}            ${CID}            ${EMPTY}            ${FILE_USR_HEADER}
     ${D_OID_USER} =         Put object                 ${USER_KEY}     ${FILE_S}            ${CID}            ${EMPTY}            ${FILE_USR_HEADER_DEL}
     @{S_OBJ_H} =	        Create List	               ${S_OID_USER}

--- a/robot/testsuites/integration/acl/acl_extended_actions_system.robot
+++ b/robot/testsuites/integration/acl/acl_extended_actions_system.robot
@@ -23,15 +23,15 @@ Extended ACL Operations
 
     [Setup]                 Setup
 
-                            Generate Keys
+    ${WALLET}   ${ADDR}     ${USER_KEY} =   Prepare Wallet And Deposit    
 
                             Log    Check extended ACL with simple object
                             Generate files    ${SIMPLE_OBJ_SIZE}
-                            Check eACL Deny and Allow All System
+                            Check eACL Deny and Allow All System    ${USER_KEY}    ${FILE_S}
 
                             Log    Check extended ACL with complex object
                             Generate files    ${COMPLEX_OBJ_SIZE}
-                            Check eACL Deny and Allow All System
+                            Check eACL Deny and Allow All System    ${USER_KEY}    ${FILE_S}
 
     [Teardown]              Teardown    acl_extended_actions_system
 
@@ -39,7 +39,9 @@ Extended ACL Operations
 *** Keywords ***
 
 Check eACL Deny and Allow All System
-    ${CID} =                Create Container Public
+    [Arguments]    ${USER_KEY}    ${FILE_S}
+
+    ${CID} =                Create Container Public    ${USER_KEY} 
 
     ${S_OID_USER} =         Put object      ${USER_KEY}    ${FILE_S}    ${CID}    ${EMPTY}    ${FILE_USR_HEADER}
     ${D_OID_USER_S} =       Put object      ${USER_KEY}    ${FILE_S}    ${CID}    ${EMPTY}    ${FILE_USR_HEADER_DEL}
@@ -48,25 +50,25 @@ Check eACL Deny and Allow All System
     @{S_OBJ_H} =	        Create List	             ${S_OID_USER}
 
     Put object      ${SYSTEM_KEY}       ${FILE_S}    ${CID}    ${EMPTY}    ${FILE_OTH_HEADER}
-    Put object      ${SYSTEM_KEY_SN}    ${FILE_S}    ${CID}    ${EMPTY}    ${FILE_OTH_HEADER}
+    Put object      ${NEOFS_SN_WIF}    ${FILE_S}    ${CID}    ${EMPTY}    ${FILE_OTH_HEADER}
 
     Get object    ${SYSTEM_KEY}       ${CID}    ${S_OID_USER}    ${EMPTY}    local_file_eacl
-    Get object    ${SYSTEM_KEY_SN}    ${CID}    ${S_OID_USER}    ${EMPTY}    local_file_eacl
+    Get object    ${NEOFS_SN_WIF}    ${CID}    ${S_OID_USER}    ${EMPTY}    local_file_eacl
 
     Search object            ${SYSTEM_KEY}       ${CID}    ${EMPTY}    ${EMPTY}    ${FILE_USR_HEADER}    ${S_OBJ_H}
-    Search object            ${SYSTEM_KEY_SN}    ${CID}    ${EMPTY}    ${EMPTY}    ${FILE_USR_HEADER}    ${S_OBJ_H}
+    Search object            ${NEOFS_SN_WIF}    ${CID}    ${EMPTY}    ${EMPTY}    ${FILE_USR_HEADER}    ${S_OBJ_H}
 
     Head object              ${SYSTEM_KEY}       ${CID}    ${S_OID_USER}    ${EMPTY}
-    Head object              ${SYSTEM_KEY_SN}    ${CID}    ${S_OID_USER}    ${EMPTY}
+    Head object              ${NEOFS_SN_WIF}    ${CID}    ${S_OID_USER}    ${EMPTY}
 
     Get Range                ${SYSTEM_KEY}       ${CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
-    Get Range                ${SYSTEM_KEY_SN}    ${CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+    Get Range                ${NEOFS_SN_WIF}    ${CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
 
     Get Range Hash           ${SYSTEM_KEY}       ${CID}    ${S_OID_USER}    ${EMPTY}    0:256
-    Get Range Hash           ${SYSTEM_KEY_SN}    ${CID}    ${S_OID_USER}    ${EMPTY}    0:256
+    Get Range Hash           ${NEOFS_SN_WIF}    ${CID}    ${S_OID_USER}    ${EMPTY}    0:256
 
     Delete object            ${SYSTEM_KEY}       ${CID}    ${D_OID_USER_S}     ${EMPTY}
-    Delete object            ${SYSTEM_KEY_SN}    ${CID}    ${D_OID_USER_SN}    ${EMPTY}
+    Delete object            ${NEOFS_SN_WIF}    ${CID}    ${D_OID_USER_SN}    ${EMPTY}
 
     Set eACL                 ${USER_KEY}     ${CID}        ${EACL_DENY_ALL_SYSTEM}
 
@@ -76,17 +78,17 @@ Check eACL Deny and Allow All System
     Run Keyword And Expect Error    *
     ...  Put object        ${SYSTEM_KEY}       ${FILE_S}    ${CID}    ${EMPTY}    ${FILE_OTH_HEADER}
     Run Keyword And Expect Error    *
-    ...  Put object        ${SYSTEM_KEY_SN}    ${FILE_S}    ${CID}    ${EMPTY}    ${FILE_OTH_HEADER}
+    ...  Put object        ${NEOFS_SN_WIF}    ${FILE_S}    ${CID}    ${EMPTY}    ${FILE_OTH_HEADER}
 
     Run Keyword And Expect Error    *
     ...  Get object      ${SYSTEM_KEY}       ${CID}    ${S_OID_USER}    ${EMPTY}    local_file_eacl
     Run Keyword And Expect Error    *
-    ...  Get object      ${SYSTEM_KEY_SN}    ${CID}    ${S_OID_USER}    ${EMPTY}    local_file_eacl
+    ...  Get object      ${NEOFS_SN_WIF}    ${CID}    ${S_OID_USER}    ${EMPTY}    local_file_eacl
 
     Run Keyword And Expect Error    *
     ...  Search object              ${SYSTEM_KEY}       ${CID}    ${EMPTY}    ${EMPTY}    ${FILE_USR_HEADER}    ${S_OBJ_H}
     Run Keyword And Expect Error    *
-    ...  Search object              ${SYSTEM_KEY_SN}    ${CID}    ${EMPTY}    ${EMPTY}    ${FILE_USR_HEADER}    ${S_OBJ_H}
+    ...  Search object              ${NEOFS_SN_WIF}    ${CID}    ${EMPTY}    ${EMPTY}    ${FILE_USR_HEADER}    ${S_OBJ_H}
 
 
     Run Keyword And Expect Error        *

--- a/robot/testsuites/integration/acl/acl_extended_actions_user.robot
+++ b/robot/testsuites/integration/acl/acl_extended_actions_user.robot
@@ -1,5 +1,6 @@
 *** Settings ***
 Variables    ../../../variables/common.py
+
 Library     Collections
 Library     neofs.py
 Library     payment_neogo.py
@@ -18,15 +19,15 @@ Extended ACL Operations
 
     [Setup]                 Setup
 
-                            Generate Keys
+    ${WALLET}   ${ADDR}     ${USER_KEY} =   Prepare Wallet And Deposit  
 
                             Log    Check extended ACL with simple object
                             Generate files    ${SIMPLE_OBJ_SIZE}
-                            Check eACL Deny and Allow All User
+                            Check eACL Deny and Allow All User    ${USER_KEY}
 
                             Log    Check extended ACL with complex object
                             Generate files    ${COMPLEX_OBJ_SIZE}
-                            Check eACL Deny and Allow All User
+                            Check eACL Deny and Allow All User    ${USER_KEY}
 
     [Teardown]              Teardown    acl_extended_action_user
 
@@ -34,4 +35,5 @@ Extended ACL Operations
 *** Keywords ***
 
 Check eACL Deny and Allow All User
-                            Check eACL Deny and Allow All    ${USER_KEY}    ${EACL_DENY_ALL_USER}    ${EACL_ALLOW_ALL_USER}
+    [Arguments]             ${USER_KEY}
+                            Check eACL Deny and Allow All    ${USER_KEY}    ${EACL_DENY_ALL_USER}    ${EACL_ALLOW_ALL_USER}    ${USER_KEY}

--- a/robot/testsuites/integration/acl/acl_extended_compound.robot
+++ b/robot/testsuites/integration/acl/acl_extended_compound.robot
@@ -1,5 +1,6 @@
 *** Settings ***
 Variables    ../../../variables/common.py
+
 Library     Collections
 Library     neofs.py
 Library     payment_neogo.py
@@ -22,15 +23,16 @@ Extended ACL Operations
 
     [Setup]                 Setup
 
-                            Generate Keys
+    ${WALLET}   ${ADDR}     ${USER_KEY} =   Prepare Wallet And Deposit  
+    ${WALLET_OTH}   ${ADDR_OTH}     ${OTHER_KEY} =   Prepare Wallet And Deposit
 
                             Log    Check extended ACL with simple object
                             Generate files    ${SIMPLE_OBJ_SIZE}
-                            Check Сompound Operations
+                            Check Сompound Operations    ${USER_KEY}    ${OTHER_KEY}
 
                             Log    Check extended ACL with complex object
                             Generate files    ${COMPLEX_OBJ_SIZE}
-                            Check Сompound Operations
+                            Check Сompound Operations    ${USER_KEY}    ${OTHER_KEY}
 
     [Teardown]              Teardown    acl_extended_compound
 
@@ -40,22 +42,23 @@ Extended ACL Operations
 
 
 Check Сompound Operations
-                            Check eACL Сompound Get    ${OTHER_KEY}     ${EACL_COMPOUND_GET_OTHERS}
-                            Check eACL Сompound Get    ${USER_KEY}      ${EACL_COMPOUND_GET_USER}
-                            Check eACL Сompound Get    ${SYSTEM_KEY}    ${EACL_COMPOUND_GET_SYSTEM}
+    [Arguments]             ${USER_KEY}    ${OTHER_KEY}
+                            Check eACL Сompound Get    ${OTHER_KEY}     ${EACL_COMPOUND_GET_OTHERS}    ${USER_KEY}
+                            Check eACL Сompound Get    ${USER_KEY}      ${EACL_COMPOUND_GET_USER}    ${USER_KEY}
+                            Check eACL Сompound Get    ${SYSTEM_KEY}    ${EACL_COMPOUND_GET_SYSTEM}    ${USER_KEY}
 
-                            Check eACL Сompound Delete    ${OTHER_KEY}     ${EACL_COMPOUND_DELETE_OTHERS}
-                            Check eACL Сompound Delete    ${USER_KEY}      ${EACL_COMPOUND_DELETE_USER}
-                            Check eACL Сompound Delete    ${SYSTEM_KEY}    ${EACL_COMPOUND_DELETE_SYSTEM}
+                            Check eACL Сompound Delete    ${OTHER_KEY}     ${EACL_COMPOUND_DELETE_OTHERS}    ${USER_KEY}
+                            Check eACL Сompound Delete    ${USER_KEY}      ${EACL_COMPOUND_DELETE_USER}    ${USER_KEY} 
+                            Check eACL Сompound Delete    ${SYSTEM_KEY}    ${EACL_COMPOUND_DELETE_SYSTEM}    ${USER_KEY}
 
-                            Check eACL Сompound Get Range Hash    ${OTHER_KEY}     ${EACL_COMPOUND_GET_HASH_OTHERS}
-                            Check eACL Сompound Get Range Hash    ${USER_KEY}      ${EACL_COMPOUND_GET_HASH_USER}
-                            Check eACL Сompound Get Range Hash    ${SYSTEM_KEY}    ${EACL_COMPOUND_GET_HASH_SYSTEM}
+                            Check eACL Сompound Get Range Hash    ${OTHER_KEY}     ${EACL_COMPOUND_GET_HASH_OTHERS}    ${USER_KEY}
+                            Check eACL Сompound Get Range Hash    ${USER_KEY}      ${EACL_COMPOUND_GET_HASH_USER}    ${USER_KEY}
+                            Check eACL Сompound Get Range Hash    ${SYSTEM_KEY}    ${EACL_COMPOUND_GET_HASH_SYSTEM}    ${USER_KEY}
 
 Check eACL Сompound Get
-    [Arguments]             ${KEY}    ${DENY_EACL}
+    [Arguments]             ${KEY}    ${DENY_EACL}    ${USER_KEY}   
 
-    ${CID} =                Create Container Public
+    ${CID} =                Create Container Public    ${USER_KEY}
 
     ${S_OID_USER} =         Put object             ${USER_KEY}    ${FILE_S}    ${CID}           ${EMPTY}    ${FILE_USR_HEADER}
                             Put object             ${KEY}         ${FILE_S}    ${CID}           ${EMPTY}    ${FILE_OTH_HEADER}
@@ -74,9 +77,9 @@ Check eACL Сompound Get
 
 
 Check eACL Сompound Delete
-    [Arguments]             ${KEY}    ${DENY_EACL}
+    [Arguments]             ${KEY}    ${DENY_EACL}    ${USER_KEY}
 
-    ${CID} =                Create Container Public
+    ${CID} =                Create Container Public    ${USER_KEY}
 
     ${S_OID_USER} =         Put object             ${USER_KEY}    ${FILE_S}    ${CID}           ${EMPTY}    ${FILE_USR_HEADER}
     ${D_OID_USER} =         Put object             ${USER_KEY}    ${FILE_S}    ${CID}           ${EMPTY}    ${EMPTY}
@@ -98,13 +101,13 @@ Check eACL Сompound Delete
 
 
 Check eACL Сompound Get Range Hash
-    [Arguments]             ${KEY}    ${DENY_EACL}
+    [Arguments]             ${KEY}    ${DENY_EACL}    ${USER_KEY}
 
-    ${CID} =                Create Container Public
+    ${CID} =                Create Container Public    ${USER_KEY}
 
     ${S_OID_USER} =         Put object             ${USER_KEY}         ${FILE_S}    ${CID}           ${EMPTY}    ${FILE_USR_HEADER}
                             Put object             ${KEY}              ${FILE_S}    ${CID}           ${EMPTY}    ${FILE_OTH_HEADER}
-                            Get Range Hash                  ${SYSTEM_KEY_SN}    ${CID}       ${S_OID_USER}    ${EMPTY}    0:256
+                            Get Range Hash                  ${NEOFS_SN_WIF}    ${CID}       ${S_OID_USER}    ${EMPTY}    0:256
 
                             Set eACL                        ${USER_KEY}         ${CID}       ${DENY_EACL}
 

--- a/robot/testsuites/integration/acl/acl_extended_filters.robot
+++ b/robot/testsuites/integration/acl/acl_extended_filters.robot
@@ -19,15 +19,16 @@ Extended ACL Operations
 
     [Setup]                 Setup
 
-                            Generate Keys
+    ${WALLET}   ${ADDR}     ${USER_KEY} =   Prepare Wallet And Deposit  
+    ${WALLET_OTH}   ${ADDR_OTH}     ${OTHER_KEY} =   Prepare Wallet And Deposit
 
                             Log    Check extended ACL with simple object
                             Generate files    ${SIMPLE_OBJ_SIZE}
-                            Check Filters
+                            Check Filters    ${USER_KEY}    ${OTHER_KEY}
 
                             Log    Check extended ACL with complex object
                             Generate files    ${COMPLEX_OBJ_SIZE}
-                            Check Filters
+                            Check Filters    ${USER_KEY}    ${OTHER_KEY}
 
     [Teardown]              Teardown    acl_extended_filters
 
@@ -35,13 +36,16 @@ Extended ACL Operations
 *** Keywords ***
 
 Check Filters
-                            Check eACL MatchType String Equal Object
-                            Check eACL MatchType String Not Equal Object
-                            Check eACL MatchType String Equal Request Deny
-                            Check eACL MatchType String Equal Request Allow
+    [Arguments]    ${USER_KEY}    ${OTHER_KEY}
+    
+                            Check eACL MatchType String Equal Object    ${USER_KEY}    ${OTHER_KEY}
+                            Check eACL MatchType String Not Equal Object    ${USER_KEY}    ${OTHER_KEY}
+                            Check eACL MatchType String Equal Request Deny    ${USER_KEY}    ${OTHER_KEY}
+                            Check eACL MatchType String Equal Request Allow    ${USER_KEY}    ${OTHER_KEY}
 
 Check eACL MatchType String Equal Request Deny
-    ${CID} =                Create Container Public
+    [Arguments]    ${USER_KEY}    ${OTHER_KEY}
+    ${CID} =                Create Container Public    ${USER_KEY} 
     ${S_OID_USER} =         Put object             ${USER_KEY}     ${FILE_S}    ${CID}           ${EMPTY}    ${FILE_USR_HEADER}
 
     ${HEADER} =             Head object                     ${USER_KEY}     ${CID}       ${S_OID_USER}    ${EMPTY}    json_output=True
@@ -85,7 +89,9 @@ Check eACL MatchType String Equal Request Deny
 
 
 Check eACL MatchType String Equal Request Allow
-    ${CID} =                Create Container Public
+    [Arguments]    ${USER_KEY}    ${OTHER_KEY}
+
+    ${CID} =                Create Container Public    ${USER_KEY} 
     ${S_OID_USER} =         Put object             ${USER_KEY}     ${FILE_S}    ${CID}           ${EMPTY}    ${FILE_USR_HEADER}
 
     ${HEADER} =             Head object                     ${USER_KEY}     ${CID}       ${S_OID_USER}    ${EMPTY}    json_output=True
@@ -129,7 +135,9 @@ Check eACL MatchType String Equal Request Allow
 
 
 Check eACL MatchType String Equal Object
-    ${CID} =                Create Container Public
+    [Arguments]    ${USER_KEY}    ${OTHER_KEY}
+
+    ${CID} =                Create Container Public    ${USER_KEY} 
     ${S_OID_USER} =         Put object                      ${USER_KEY}     ${FILE_S}    ${CID}           ${EMPTY}    ${FILE_USR_HEADER}
 
     ${HEADER} =             Head object                     ${USER_KEY}     ${CID}       ${S_OID_USER}    ${EMPTY}    json_output=True
@@ -167,7 +175,9 @@ Check eACL MatchType String Equal Object
 
 
 Check eACL MatchType String Not Equal Object
-    ${CID} =                Create Container Public
+    [Arguments]    ${USER_KEY}    ${OTHER_KEY}
+
+    ${CID} =                Create Container Public    ${USER_KEY} 
 
     ${S_OID_USER} =         Put object             ${USER_KEY}     ${FILE_S}      ${CID}    ${EMPTY}    ${FILE_USR_HEADER}
     ${S_OID_OTHER} =        Put object             ${OTHER_KEY}    ${FILE_S_2}    ${CID}    ${EMPTY}    ${FILE_OTH_HEADER}

--- a/robot/testsuites/integration/acl/common_steps_acl_basic.robot
+++ b/robot/testsuites/integration/acl/common_steps_acl_basic.robot
@@ -7,30 +7,33 @@ ${CONTAINER_WAIT_INTERVAL} =    1 min
 
 *** Keywords ***
 
-Create Containers
+Create Private Container
+    [Arguments]    ${USER_KEY}
                             Log	                   Create Private Container
     ${PRIV_CID_GEN} =       Create container       ${USER_KEY}        ${PRIVATE_ACL}            ${COMMON_PLACEMENT_RULE}
                             Wait Until Keyword Succeeds               ${MORPH_BLOCK_TIME}       ${CONTAINER_WAIT_INTERVAL}
                             ...     Container Existing     ${USER_KEY}        ${PRIV_CID_GEN}
+    [Return]    ${PRIV_CID_GEN}
 
+Create Public Container
+    [Arguments]    ${USER_KEY}
                             Log	                   Create Public Container
     ${PUBLIC_CID_GEN} =     Create container       ${USER_KEY}        ${PUBLIC_ACL}             ${COMMON_PLACEMENT_RULE}
                             Wait Until Keyword Succeeds               ${MORPH_BLOCK_TIME}       ${CONTAINER_WAIT_INTERVAL}
                             ...     Container Existing     ${USER_KEY}        ${PUBLIC_CID_GEN}
+    [Return]    ${PUBLIC_CID_GEN}                           
 
+Create Read-Only Container
+    [Arguments]    ${USER_KEY}
                             Log	                   Create Read-Only Container
     ${READONLY_CID_GEN} =   Create container       ${USER_KEY}        ${READONLY_ACL}           ${COMMON_PLACEMENT_RULE}
                             Wait Until Keyword Succeeds               ${MORPH_BLOCK_TIME}       ${CONTAINER_WAIT_INTERVAL}
                             ...     Container Existing     ${USER_KEY}        ${READONLY_CID_GEN}
+    [Return]    ${READONLY_CID_GEN}
 
-                            Set Global Variable    ${PRIV_CID}        ${PRIV_CID_GEN}
-                            Set Global Variable    ${PUBLIC_CID}      ${PUBLIC_CID_GEN}
-                            Set Global Variable    ${READONLY_CID}    ${READONLY_CID_GEN}
 
 Generate file
     [Arguments]             ${SIZE}
     ${FILE_S_GEN} =         Generate file of bytes    ${SIZE}
     ${FILE_S_HASH_GEN} =    Get file hash             ${FILE_S_GEN}
-
-                            Set Global Variable       ${FILE_S}         ${FILE_S_GEN}
-                            Set Global Variable       ${FILE_S_HASH}    ${FILE_S_HASH_GEN}
+    [Return]     ${FILE_S_GEN}    ${FILE_S_HASH_GEN}

--- a/robot/testsuites/integration/acl/common_steps_acl_bearer.robot
+++ b/robot/testsuites/integration/acl/common_steps_acl_bearer.robot
@@ -9,8 +9,8 @@ ${FILE_OTH_HEADER} =        key1=oth,key2=oth
 ${CONTAINER_WAIT_INTERVAL} =    1 min
 
 *** Keywords ***
-
 Create Container Public
+    [Arguments]    ${USER_KEY}
     ${PUBLIC_CID_GEN} =     Create container      ${USER_KEY}    0x0FFFFFFF     ${COMMON_PLACEMENT_RULE}
                             Wait Until Keyword Succeeds    ${MORPH_BLOCK_TIME}       ${CONTAINER_WAIT_INTERVAL}
                             ...     Container Existing     ${USER_KEY}        ${PUBLIC_CID_GEN}
@@ -18,6 +18,7 @@ Create Container Public
 
 
 Create Container Inaccessible
+    [Arguments]    ${USER_KEY}
     ${INACCESSIBLE_CID_GEN} =     Create container      ${USER_KEY}     ${INACCESSIBLE_ACL}     ${COMMON_PLACEMENT_RULE}
                             Wait Until Keyword Succeeds    ${MORPH_BLOCK_TIME}       ${CONTAINER_WAIT_INTERVAL}
                             ...     Container Existing     ${USER_KEY}        ${INACCESSIBLE_CID_GEN}
@@ -28,7 +29,7 @@ Generate file
     [Arguments]             ${SIZE}
 
     ${FILE_S_GEN} =         Generate file of bytes    ${SIZE}
-                            Set Global Variable       ${FILE_S}    ${FILE_S_GEN}
+    [Return]                ${FILE_S_GEN}
 
 
 Prepare eACL Role rules
@@ -49,3 +50,4 @@ Prepare eACL Role rules
                                 Form eACL json common file    gen_eacl_deny_all_${role}    ${eACL_gen}
                                 Set Global Variable    ${EACL_DENY_ALL_${role}}       gen_eacl_deny_all_${role}
     END
+    [Return]    gen_eacl_deny_all_${role}

--- a/robot/testsuites/integration/acl/common_steps_acl_extended.robot
+++ b/robot/testsuites/integration/acl/common_steps_acl_extended.robot
@@ -10,6 +10,7 @@ ${CONTAINER_WAIT_INTERVAL} =    1 min
 *** Keywords ***
 
 Create Container Public
+    [Arguments]             ${USER_KEY}
                             Log	                Create Public Container
     ${PUBLIC_CID_GEN} =     Create container    ${USER_KEY}    0x4FFFFFFF    ${COMMON_PLACEMENT_RULE}
                             Wait Until Keyword Succeeds        ${MORPH_BLOCK_TIME}       ${CONTAINER_WAIT_INTERVAL}
@@ -19,6 +20,7 @@ Create Container Public
 
 Generate files
     [Arguments]             ${SIZE}
+    
     ${FILE_S_GEN_1} =       Generate file of bytes    ${SIZE}
     ${FILE_S_GEN_2} =       Generate file of bytes    ${SIZE}
                             Set Global Variable       ${FILE_S}      ${FILE_S_GEN_1}
@@ -27,9 +29,9 @@ Generate files
 
 
 Check eACL Deny and Allow All
-    [Arguments]     ${KEY}       ${DENY_EACL}    ${ALLOW_EACL}
+    [Arguments]     ${KEY}    ${DENY_EACL}    ${ALLOW_EACL}    ${USER_KEY}
 
-    ${CID} =                Create Container Public
+    ${CID} =                Create Container Public    ${USER_KEY}
     ${S_OID_USER} =         Put object                 ${USER_KEY}     ${FILE_S}            ${CID}            ${EMPTY}            ${FILE_USR_HEADER}
     ${D_OID_USER} =         Put object                 ${USER_KEY}     ${FILE_S}            ${CID}            ${EMPTY}            ${FILE_USR_HEADER_DEL}
     @{S_OBJ_H} =	    Create List	               ${S_OID_USER}


### PR DESCRIPTION
I changed `Generate Keys` keyword, which used to set global variables, with the new `Prepare Wallet And Deposit` keyword. It has led to numerous changes in acl tests.

Signed-off-by: EliChin <elizaveta@nspcc.ru>