### PR TITLE
(#116): fixed eACL tests; refactored acl keywords

### DIFF
--- a/robot/resources/lib/acl.py
+++ b/robot/resources/lib/acl.py
@@ -1,0 +1,199 @@
+#!/usr/bin/python3.8
+
+from enum import Enum, auto
+import json
+import os
+import re
+import uuid
+
+import base64
+import base58
+from cli_helpers import _cmd_run
+from common import ASSETS_DIR, NEOFS_ENDPOINT
+from robot.api.deco import keyword
+from robot.api import logger
+
+
+"""
+Robot Keywords and helper functions for work with NeoFS ACL.
+"""
+
+
+ROBOT_AUTO_KEYWORDS = False
+
+# path to neofs-cli executable
+NEOFS_CLI_EXEC = os.getenv('NEOFS_CLI_EXEC', 'neofs-cli')
+EACL_LIFETIME = 100500
+
+class AutoName(Enum):
+    def _generate_next_value_(name, start, count, last_values):
+        return name
+
+class Role(AutoName):
+    USER = auto()
+    SYSTEM = auto()
+    OTHERS = auto()
+
+
+@keyword('Get eACL')
+def get_eacl(wif: str, cid: str):
+    cmd = (
+        f'{NEOFS_CLI_EXEC} --rpc-endpoint {NEOFS_ENDPOINT} --wif {wif} '
+        f'container get-eacl --cid {cid}'
+    )
+    logger.info(f"cmd: {cmd}")
+    try:
+        output = _cmd_run(cmd)
+        if re.search(r'extended ACL table is not set for this container', output):
+            return None
+        return output
+    except RuntimeError as exc:
+        logger.info("Extended ACL table is not set for this container")
+        logger.info(f"Got exception while getting eacl: {exc}")
+        return None
+
+
+@keyword('Set eACL')
+def set_eacl(wif: str, cid: str, eacl_table_path: str):
+    cmd = (
+        f'{NEOFS_CLI_EXEC} --rpc-endpoint {NEOFS_ENDPOINT} --wif {wif} '
+        f'container set-eacl --cid {cid} --table {eacl_table_path} --await'
+    )
+    logger.info(f"cmd: {cmd}")
+    _cmd_run(cmd)
+
+
+def _encode_cid_for_eacl(cid: str) -> str:
+    cid_base58 = base58.b58decode(cid)
+    return base64.b64encode(cid_base58).decode("utf-8")
+
+
+@keyword('Form BearerToken File')
+def form_bearertoken_file(wif: str, cid: str, eacl_records: list) -> str:
+    """
+    This function fetches eACL for given <cid> on behalf of <wif>,
+    then extends it with filters taken from <eacl_records>, signs
+    with bearer token and writes to file
+    """
+    enc_cid = _encode_cid_for_eacl(cid)
+    file_path = f"{os.getcwd()}/{ASSETS_DIR}/{str(uuid.uuid4())}"
+
+    eacl = get_eacl(wif, cid)
+    json_eacl = dict()
+    if eacl:
+        eacl = eacl.replace('eACL: ', '')
+        eacl = eacl.split('Signature')[0]
+        json_eacl = json.loads(eacl)
+    logger.info(json_eacl)
+    eacl_result = {
+                    "body":
+                    {
+                        "eaclTable":
+                        {
+                            "containerID":
+                            {
+                                "value": enc_cid
+                            },
+                            "records": []
+                        },
+                        "lifetime":
+                        {
+                            "exp": EACL_LIFETIME,
+                            "nbf": "1",
+                            "iat": "0"
+                        }
+                    }
+                }
+
+    if not eacl_records:
+        raise(f"Got empty eacl_records list: {eacl_records}")
+    for record in eacl_records:
+        op_data = {
+                "operation": record['Operation'],
+                "action":   record['Access'],
+                "filters":  [],
+                "targets":  []
+            }
+
+        if Role(record['Role']):
+            op_data['targets'] = [
+                                    {
+                                        "role": record['Role']
+                                    }
+                                ]
+        else:
+            op_data['targets'] = [
+                                    {
+                                        "keys": [ record['Role'] ]
+                                    }
+                                ]
+
+        if 'Filters' in record.keys():
+            op_data["filters"].append(record['Filters'])
+
+        eacl_result["body"]["eaclTable"]["records"].append(op_data)
+
+    # Add records from current eACL
+    if "records" in json_eacl.keys():
+        for record in json_eacl["records"]:
+            eacl_result["body"]["eaclTable"]["records"].append(record)
+
+    with open(file_path, 'w', encoding='utf-8') as eacl_file:
+        json.dump(eacl_result, eacl_file, ensure_ascii=False, indent=4)
+
+    logger.info(f"Got these extended ACL records: {eacl_result}")
+    sign_bearer_token(wif, file_path)
+    return file_path
+
+
+def sign_bearer_token(wif: str, eacl_rules_file: str):
+    cmd = (
+        f'{NEOFS_CLI_EXEC} util sign bearer-token --from {eacl_rules_file} '
+        f'--to {eacl_rules_file} --wif {wif} --json'
+    )
+    logger.info(f"cmd: {cmd}")
+    _cmd_run(cmd)
+
+
+@keyword('Form eACL json common file')
+def form_eacl_json_common_file(file_path: str, eacl_records: list) -> str:
+    # Input role can be Role (USER, SYSTEM, OTHERS) or public key.
+    eacl = {"records":[]}
+
+    for record in eacl_records:
+        op_data = dict()
+
+        if record['Role'] == "USER" or record['Role'] == "SYSTEM" or record['Role'] == "OTHERS":
+            op_data = {
+                        "operation": record['Operation'],
+                        "action":    record['Access'],
+                        "filters":   [],
+                        "targets": [
+                            {
+                                "role": record['Role']
+                            }
+                        ]
+                    }
+        else:
+            op_data = {
+                        "operation": record['Operation'],
+                        "action":    record['Access'],
+                        "filters":   [],
+                        "targets": [
+                            {
+                                "keys": [ record['Role'] ]
+                            }
+                        ]
+                    }
+
+        if 'Filters' in record.keys():
+            op_data["filters"].append(record['Filters'])
+
+        eacl["records"].append(op_data)
+
+    logger.info(f"Got these extended ACL records: {eacl}")
+
+    with open(file_path, 'w', encoding='utf-8') as eacl_file:
+        json.dump(eacl, eacl_file, ensure_ascii=False, indent=4)
+
+    return file_path

--- a/robot/resources/lib/cli_helpers.py
+++ b/robot/resources/lib/cli_helpers.py
@@ -1,0 +1,29 @@
+#!/usr/bin/python3.8
+
+"""
+Helper functions to use with `neofs-cli`, `neo-go`
+and other CLIs.
+"""
+
+import subprocess
+
+from robot.api import logger
+
+ROBOT_AUTO_KEYWORDS = False
+
+
+def _cmd_run(cmd):
+    """
+    Runs given shell command <cmd>, in case of success returns its stdout,
+    in case of failure returns error message.
+    """
+    try:
+        compl_proc = subprocess.run(cmd, check=True, universal_newlines=True,
+                    stdout=subprocess.PIPE, stderr=subprocess.STDOUT, timeout=30,
+                    shell=True)
+        output = compl_proc.stdout
+        logger.info(f"Output: {output}")
+        return output
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(f"Error:\nreturn code: {exc.returncode} "
+                f"\nOutput: {exc.output}") from exc

--- a/robot/testsuites/integration/acl/acl_bearer_allow.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_allow.robot
@@ -1,9 +1,12 @@
 *** Settings ***
 Variables   ../../../variables/common.py
-Library     ../${RESOURCES}/neofs.py
-Library     ../${RESOURCES}/payment_neogo.py
-Library     Collections
 
+Library     Collections
+Library     neofs.py
+Library     acl.py
+Library     payment_neogo.py
+
+Resource    ../../../variables/eacl_tables.robot
 Resource    common_steps_acl_bearer.robot
 Resource    ../${RESOURCES}/payment_operations.robot
 Resource    ../${RESOURCES}/setup_teardown.robot
@@ -37,52 +40,52 @@ BearerToken Operations
 
 Check eACL Deny and Allow All Bearer
 
-    ${CID} =                Create Container Public
-    ${S_OID_USER} =         Put object        ${USER_KEY}    ${FILE_S}    ${CID}    ${EMPTY}    ${FILE_USR_HEADER}
-    ${D_OID_USER} =         Put object        ${USER_KEY}    ${FILE_S}    ${CID}    ${EMPTY}    ${FILE_USR_HEADER_DEL}
-    @{S_OBJ_H} =	    Create List	      ${S_OID_USER}
+    ${CID} =            Create Container Public
+    ${S_OID_USER} =     Put object        ${USER_KEY}    ${FILE_S}    ${CID}    ${EMPTY}    ${FILE_USR_HEADER}
+    ${D_OID_USER} =     Put object        ${USER_KEY}    ${FILE_S}    ${CID}    ${EMPTY}    ${FILE_USR_HEADER_DEL}
+    @{S_OBJ_H} =	Create List	      ${S_OID_USER}
 
-                            Put object        ${USER_KEY}    ${FILE_S}     ${CID}           ${EMPTY}       ${FILE_OTH_HEADER}
-                            Get object        ${USER_KEY}    ${CID}        ${S_OID_USER}    ${EMPTY}       local_file_eacl
-                            Search object     ${USER_KEY}    ${CID}        ${EMPTY}         ${EMPTY}       ${FILE_USR_HEADER}    ${S_OBJ_H}
-                            Head object       ${USER_KEY}    ${CID}        ${S_OID_USER}    ${EMPTY}
-                            Get Range         ${USER_KEY}    ${CID}        ${S_OID_USER}    s_get_range    ${EMPTY}              0:256
-                            Delete object     ${USER_KEY}    ${CID}        ${D_OID_USER}    ${EMPTY}
+                        Put object        ${USER_KEY}    ${FILE_S}     ${CID}           ${EMPTY}       ${FILE_OTH_HEADER}
+                        Get object        ${USER_KEY}    ${CID}        ${S_OID_USER}    ${EMPTY}       local_file_eacl
+                        Search object     ${USER_KEY}    ${CID}        ${EMPTY}         ${EMPTY}       ${FILE_USR_HEADER}    ${S_OBJ_H}
+                        Head object       ${USER_KEY}    ${CID}        ${S_OID_USER}    ${EMPTY}
+                        Get Range         ${USER_KEY}    ${CID}        ${S_OID_USER}    s_get_range    ${EMPTY}      0:256
+                        Delete object     ${USER_KEY}    ${CID}        ${D_OID_USER}    ${EMPTY}
 
-                            Set eACL          ${USER_KEY}    ${CID}        ${EACL_DENY_ALL_USER}
+                        Set eACL          ${USER_KEY}    ${CID}        ${EACL_DENY_ALL_USER}
 
-                            # The current ACL cache lifetime is 30 sec
-                            Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}
+                        # The current ACL cache lifetime is 30 sec
+                        Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}
 
-    ${rule1}=               Create Dictionary    Operation=GET             Access=ALLOW    Role=USER
-    ${rule2}=               Create Dictionary    Operation=HEAD            Access=ALLOW    Role=USER
-    ${rule3}=               Create Dictionary    Operation=PUT             Access=ALLOW    Role=USER
-    ${rule4}=               Create Dictionary    Operation=DELETE          Access=ALLOW    Role=USER
-    ${rule5}=               Create Dictionary    Operation=SEARCH          Access=ALLOW    Role=USER
-    ${rule6}=               Create Dictionary    Operation=GETRANGE        Access=ALLOW    Role=USER
-    ${rule7}=               Create Dictionary    Operation=GETRANGEHASH    Access=ALLOW    Role=USER
+    ${rule1}=           Create Dictionary    Operation=GET             Access=ALLOW    Role=USER
+    ${rule2}=           Create Dictionary    Operation=HEAD            Access=ALLOW    Role=USER
+    ${rule3}=           Create Dictionary    Operation=PUT             Access=ALLOW    Role=USER
+    ${rule4}=           Create Dictionary    Operation=DELETE          Access=ALLOW    Role=USER
+    ${rule5}=           Create Dictionary    Operation=SEARCH          Access=ALLOW    Role=USER
+    ${rule6}=           Create Dictionary    Operation=GETRANGE        Access=ALLOW    Role=USER
+    ${rule7}=           Create Dictionary    Operation=GETRANGEHASH    Access=ALLOW    Role=USER
 
-    ${eACL_gen}=            Create List    ${rule1}    ${rule2}    ${rule3}    ${rule4}    ${rule5}    ${rule6}    ${rule7}
+    ${eACL_gen}=        Create List    ${rule1}    ${rule2}    ${rule3}    ${rule4}    ${rule5}    ${rule6}    ${rule7}
 
-                            Form BearerToken file           ${USER_KEY}    ${CID}    bearer_allow_all_user   ${eACL_gen}   100500
+    ${EACL_TOKEN} =     Form BearerToken File       ${USER_KEY}    ${CID}    ${eACL_gen}
 
-                            Run Keyword And Expect Error    *
-                            ...  Put object                 ${USER_KEY}    ${FILE_S}    ${CID}           ${EMPTY}       ${FILE_USR_HEADER}
-                            Run Keyword And Expect Error    *
-                            ...  Get object                 ${USER_KEY}    ${CID}       ${S_OID_USER}    ${EMPTY}       local_file_eacl
-                            Run Keyword And Expect Error    *
-                            ...  Search object              ${USER_KEY}    ${CID}       ${EMPTY}         ${EMPTY}       ${FILE_USR_HEADER}    ${S_OBJ_H}
-                            Run Keyword And Expect Error    *
-                            ...  Head object                ${USER_KEY}    ${CID}       ${S_OID_USER}    ${EMPTY}
-                            Run Keyword And Expect Error    *
-                            ...  Get Range                  ${USER_KEY}    ${CID}       ${S_OID_USER}    s_get_range    ${EMPTY}              0:256
-                            Run Keyword And Expect Error    *
-                            ...  Delete object              ${USER_KEY}    ${CID}       ${S_OID_USER}    ${EMPTY}
+                        Run Keyword And Expect Error    *
+                        ...  Put object     ${USER_KEY}    ${FILE_S}    ${CID}           ${EMPTY}       ${FILE_USR_HEADER}
+                        Run Keyword And Expect Error    *
+                        ...  Get object     ${USER_KEY}    ${CID}       ${S_OID_USER}    ${EMPTY}       local_file_eacl
+                        Run Keyword And Expect Error    *
+                        ...  Search object  ${USER_KEY}    ${CID}       ${EMPTY}         ${EMPTY}       ${FILE_USR_HEADER}    ${S_OBJ_H}
+                        Run Keyword And Expect Error    *
+                        ...  Head object    ${USER_KEY}    ${CID}       ${S_OID_USER}    ${EMPTY}
+                        Run Keyword And Expect Error    *
+                        ...  Get Range      ${USER_KEY}    ${CID}       ${S_OID_USER}    s_get_range    ${EMPTY}      0:256
+                        Run Keyword And Expect Error    *
+                        ...  Delete object  ${USER_KEY}    ${CID}       ${S_OID_USER}    ${EMPTY}
 
-                            # All operations on object should be passed with bearer token
-                            Put object          ${USER_KEY}    ${FILE_S}    ${CID}           bearer_allow_all_user    ${FILE_OTH_HEADER}
-                            Get object          ${USER_KEY}    ${CID}       ${S_OID_USER}    bearer_allow_all_user    local_file_eacl
-                            Search object       ${USER_KEY}    ${CID}       ${EMPTY}         bearer_allow_all_user    ${FILE_USR_HEADER}       ${S_OBJ_H}
-                            Head object         ${USER_KEY}    ${CID}       ${S_OID_USER}    bearer_allow_all_user
-                            Get Range           ${USER_KEY}    ${CID}       ${S_OID_USER}    s_get_range              bearer_allow_all_user    0:256
-                            Delete object       ${USER_KEY}    ${CID}       ${S_OID_USER}    bearer_allow_all_user
+                        # All operations on object should be passed with bearer token
+                        Put object          ${USER_KEY}    ${FILE_S}    ${CID}           ${EACL_TOKEN}    ${FILE_OTH_HEADER}
+                        Get object          ${USER_KEY}    ${CID}       ${S_OID_USER}    ${EACL_TOKEN}    local_file_eacl
+                        Search object       ${USER_KEY}    ${CID}       ${EMPTY}         ${EACL_TOKEN}    ${FILE_USR_HEADER}       ${S_OBJ_H}
+                        Head object         ${USER_KEY}    ${CID}       ${S_OID_USER}    ${EACL_TOKEN}
+                        Get Range           ${USER_KEY}    ${CID}       ${S_OID_USER}    s_get_range      ${EACL_TOKEN}    0:256
+                        Delete object       ${USER_KEY}    ${CID}       ${S_OID_USER}    ${EACL_TOKEN}

--- a/robot/testsuites/integration/acl/acl_bearer_allow_storagegroup.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_allow_storagegroup.robot
@@ -1,9 +1,12 @@
 *** Settings ***
 Variables   ../../../variables/common.py
-Library     ../${RESOURCES}/neofs.py
-Library     ../${RESOURCES}/payment_neogo.py
 
 Library     Collections
+Library     acl.py
+Library     neofs.py
+Library     payment_neogo.py
+
+Resource    ../../../variables/eacl_tables.robot
 Resource    common_steps_acl_bearer.robot
 Resource    ../${RESOURCES}/payment_operations.robot
 Resource    ../${RESOURCES}/setup_teardown.robot
@@ -42,43 +45,43 @@ Check eACL Deny and Allow All Bearer
 
 
     # Storage group Operations (Put, List, Get, Delete)
-    ${SG_OID_INV} =         Put Storagegroup    ${USER_KEY}    ${CID}   ${EMPTY}    ${S_OID_USER}
-    ${SG_OID_1} =           Put Storagegroup    ${USER_KEY}    ${CID}   ${EMPTY}    ${S_OID_USER}
-                            List Storagegroup    ${USER_KEY}    ${CID}   ${EMPTY}    ${SG_OID_1}  ${SG_OID_INV}
-    @{EXPECTED_OIDS} =      Run Keyword If    "${RUN_TYPE}" == "Complex"    Get Split objects    ${USER_KEY}    ${CID}   ${S_OID_USER}
-                            ...    ELSE IF   "${RUN_TYPE}" == "Simple"    Create List   ${S_OID_USER}
-                            Get Storagegroup    ${USER_KEY}    ${CID}    ${SG_OID_1}   ${EMPTY}    ${EMPTY}    @{EXPECTED_OIDS}
-                            Delete Storagegroup    ${USER_KEY}    ${CID}    ${SG_OID_1}    ${EMPTY}
+    ${SG_OID_INV} =     Put Storagegroup    ${USER_KEY}    ${CID}   ${EMPTY}    ${S_OID_USER}
+    ${SG_OID_1} =       Put Storagegroup    ${USER_KEY}    ${CID}   ${EMPTY}    ${S_OID_USER}
+                        List Storagegroup    ${USER_KEY}    ${CID}   ${EMPTY}    ${SG_OID_1}  ${SG_OID_INV}
+    @{EXPECTED_OIDS} =  Run Keyword If      "${RUN_TYPE}" == "Complex"    Get Split objects    ${USER_KEY}    ${CID}   ${S_OID_USER}
+                        ...    ELSE IF      "${RUN_TYPE}" == "Simple"   Create List   ${S_OID_USER}
+                        Get Storagegroup    ${USER_KEY}    ${CID}    ${SG_OID_1}   ${EMPTY}    ${EMPTY}    @{EXPECTED_OIDS}
+                        Delete Storagegroup    ${USER_KEY}    ${CID}    ${SG_OID_1}    ${EMPTY}
 
-                            Set eACL                            ${USER_KEY}    ${CID}        ${EACL_DENY_ALL_USER}
+                        Set eACL            ${USER_KEY}    ${CID}        ${EACL_DENY_ALL_USER}
 
-                            # The current ACL cache lifetime is 30 sec
-                            Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}
+                        # The current ACL cache lifetime is 30 sec
+                        Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}
 
-    ${rule1}=               Create Dictionary    Operation=GET             Access=ALLOW    Role=USER
-    ${rule2}=               Create Dictionary    Operation=HEAD            Access=ALLOW    Role=USER
-    ${rule3}=               Create Dictionary    Operation=PUT             Access=ALLOW    Role=USER
-    ${rule4}=               Create Dictionary    Operation=DELETE          Access=ALLOW    Role=USER
-    ${rule5}=               Create Dictionary    Operation=SEARCH          Access=ALLOW    Role=USER
-    ${rule6}=               Create Dictionary    Operation=GETRANGE        Access=ALLOW    Role=USER
-    ${rule7}=               Create Dictionary    Operation=GETRANGEHASH    Access=ALLOW    Role=USER
+    ${rule1}=           Create Dictionary    Operation=GET             Access=ALLOW    Role=USER
+    ${rule2}=           Create Dictionary    Operation=HEAD            Access=ALLOW    Role=USER
+    ${rule3}=           Create Dictionary    Operation=PUT             Access=ALLOW    Role=USER
+    ${rule4}=           Create Dictionary    Operation=DELETE          Access=ALLOW    Role=USER
+    ${rule5}=           Create Dictionary    Operation=SEARCH          Access=ALLOW    Role=USER
+    ${rule6}=           Create Dictionary    Operation=GETRANGE        Access=ALLOW    Role=USER
+    ${rule7}=           Create Dictionary    Operation=GETRANGEHASH    Access=ALLOW    Role=USER
 
-    ${eACL_gen}=            Create List    ${rule1}    ${rule2}    ${rule3}    ${rule4}    ${rule5}    ${rule6}    ${rule7}
+    ${eACL_gen}=        Create List    ${rule1}    ${rule2}    ${rule3}    ${rule4}    ${rule5}    ${rule6}    ${rule7}
 
-                            Form BearerToken file               ${USER_KEY}    ${CID}    bearer_allow_all_user   ${eACL_gen}   100500
+    ${EACL_TOKEN} =     Form BearerToken File       ${USER_KEY}    ${CID}    ${eACL_gen}
 
-                            # All storage groups should fail without bearer token
-                            Run Keyword And Expect Error        *
-                            ...  Put Storagegroup    ${USER_KEY}    ${CID}   ${EMPTY}    ${S_OID_USER}
-                            Run Keyword And Expect Error        *
-                            ...  List Storagegroup    ${USER_KEY}    ${CID}   ${EMPTY}    ${SG_OID_1}  ${SG_OID_INV}
-                            Run Keyword And Expect Error        *
-                            ...  Get Storagegroup    ${USER_KEY}    ${CID}    ${SG_OID_1}   ${EMPTY}    ${EMPTY}    @{EXPECTED_OIDS}
-                            Run Keyword And Expect Error        *
-                            ...  Delete Storagegroup    ${USER_KEY}    ${CID}    ${SG_OID_1}    ${EMPTY}
+                        # All storage groups should fail without bearer token
+                        Run Keyword And Expect Error        *
+                        ...  Put Storagegroup    ${USER_KEY}    ${CID}   ${EMPTY}    ${S_OID_USER}
+                        Run Keyword And Expect Error        *
+                        ...  List Storagegroup    ${USER_KEY}    ${CID}   ${EMPTY}    ${SG_OID_1}  ${SG_OID_INV}
+                        Run Keyword And Expect Error        *
+                        ...  Get Storagegroup    ${USER_KEY}    ${CID}    ${SG_OID_1}   ${EMPTY}    ${EMPTY}    @{EXPECTED_OIDS}
+                        Run Keyword And Expect Error        *
+                        ...  Delete Storagegroup    ${USER_KEY}    ${CID}    ${SG_OID_1}    ${EMPTY}
 
-                            # Storagegroup should passed with User group key and bearer token
-    ${SG_OID_NEW} =         Put Storagegroup    ${USER_KEY}    ${CID}    bearer_allow_all_user    ${S_OID_USER}
-                            List Storagegroup    ${USER_KEY}    ${CID}    bearer_allow_all_user    ${SG_OID_NEW}  ${SG_OID_INV}
-                            Get Storagegroup    ${USER_KEY}    ${CID}    ${SG_OID_INV}   bearer_allow_all_user    ${EMPTY}    @{EXPECTED_OIDS}
-                            Delete Storagegroup    ${USER_KEY}    ${CID}    ${SG_OID_INV}    bearer_allow_all_user
+    # Storagegroup should passed with User group key and bearer token
+    ${SG_OID_NEW} =     Put Storagegroup        ${USER_KEY}    ${CID}    ${EACL_TOKEN}    ${S_OID_USER}
+                        List Storagegroup       ${USER_KEY}    ${CID}    ${EACL_TOKEN}    ${SG_OID_NEW}     ${SG_OID_INV}
+                        Get Storagegroup        ${USER_KEY}    ${CID}    ${SG_OID_INV}    ${EACL_TOKEN}     ${EMPTY}    @{EXPECTED_OIDS}
+                        Delete Storagegroup     ${USER_KEY}    ${CID}    ${SG_OID_INV}    ${EACL_TOKEN}

--- a/robot/testsuites/integration/acl/acl_bearer_compound.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_compound.robot
@@ -1,10 +1,12 @@
 *** Settings ***
 Variables   ../../../variables/common.py
-Library     ../${RESOURCES}/neofs.py
-Library     ../${RESOURCES}/payment_neogo.py
 
 Library     Collections
+Library     acl.py
+Library     neofs.py
+Library     payment_neogo.py
 
+Resource    ../../../variables/eacl_tables.robot
 Resource    common_steps_acl_bearer.robot
 Resource    ../${RESOURCES}/payment_operations.robot
 Resource    ../${RESOURCES}/setup_teardown.robot
@@ -15,7 +17,7 @@ ${SYSTEM_KEY} =     ${NEOFS_IR_WIF}
 *** Test cases ***
 BearerToken Operations for Сompound Operations
     [Documentation]         Testcase to validate NeoFS operations with BearerToken for Сompound Operations.
-    [Tags]                  ACL  NeoFS  NeoCLI BearerToken
+    [Tags]                  ACL  NeoFSCLI BearerToken
     [Timeout]               20 min
 
     [Setup]                 Setup
@@ -28,7 +30,6 @@ BearerToken Operations for Сompound Operations
                             Check Сompound Operations
 
                             Log    Check Bearer token with complex object
-
                             Generate file    ${COMPLEX_OBJ_SIZE}
                             Check Сompound Operations
 
@@ -38,101 +39,101 @@ BearerToken Operations for Сompound Operations
 *** Keywords ***
 
 Check Сompound Operations
-                            Check Bearer Сompound Get    ${OTHER_KEY}     OTHERS    ${EACL_DENY_ALL_OTHERS}
-                            Check Bearer Сompound Get    ${USER_KEY}      USER      ${EACL_DENY_ALL_USER}
-                            Check Bearer Сompound Get    ${SYSTEM_KEY}    SYSTEM    ${EACL_DENY_ALL_SYSTEM}
+    Check Bearer Сompound Get    ${OTHER_KEY}     OTHERS    ${EACL_DENY_ALL_OTHERS}
+    Check Bearer Сompound Get    ${USER_KEY}      USER      ${EACL_DENY_ALL_USER}
+    Check Bearer Сompound Get    ${SYSTEM_KEY}    SYSTEM    ${EACL_DENY_ALL_SYSTEM}
 
-                            Check Bearer Сompound Delete    ${OTHER_KEY}     OTHERS    ${EACL_DENY_ALL_OTHERS}
-                            Check Bearer Сompound Delete    ${USER_KEY}      USER      ${EACL_DENY_ALL_USER}
-                            Check Bearer Сompound Delete    ${SYSTEM_KEY}    SYSTEM    ${EACL_DENY_ALL_SYSTEM}
+    Check Bearer Сompound Delete    ${OTHER_KEY}     OTHERS    ${EACL_DENY_ALL_OTHERS}
+    Check Bearer Сompound Delete    ${USER_KEY}      USER      ${EACL_DENY_ALL_USER}
+    Check Bearer Сompound Delete    ${SYSTEM_KEY}    SYSTEM    ${EACL_DENY_ALL_SYSTEM}
 
-                            Check Bearer Сompound Get Range Hash    ${OTHER_KEY}     OTHERS    ${EACL_DENY_ALL_OTHERS}
-                            Check Bearer Сompound Get Range Hash    ${USER_KEY}      USER      ${EACL_DENY_ALL_USER}
-                            Check Bearer Сompound Get Range Hash    ${SYSTEM_KEY}    SYSTEM    ${EACL_DENY_ALL_SYSTEM}
+    Check Bearer Сompound Get Range Hash    ${OTHER_KEY}     OTHERS    ${EACL_DENY_ALL_OTHERS}
+    Check Bearer Сompound Get Range Hash    ${USER_KEY}      USER      ${EACL_DENY_ALL_USER}
+    Check Bearer Сompound Get Range Hash    ${SYSTEM_KEY}    SYSTEM    ${EACL_DENY_ALL_SYSTEM}
 
 
 Check Bearer Сompound Get
     [Arguments]             ${KEY}    ${DENY_GROUP}    ${DENY_EACL}
 
-    ${CID} =                Create Container Public
-    ${S_OID_USER} =         Put object                 ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${FILE_USR_HEADER}
-    @{S_OBJ_H} =	        Create List	                        ${S_OID_USER}
+    ${CID} =            Create Container Public
+    ${S_OID_USER} =     Put object     ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${FILE_USR_HEADER}
+    @{S_OBJ_H} =        Create List    ${S_OID_USER}
 
-    ${S_OID_USER} =         Put object             ${USER_KEY}    ${FILE_S}    ${CID}           ${EMPTY}    ${FILE_USR_HEADER}
-                            Put object             ${KEY}         ${FILE_S}    ${CID}           ${EMPTY}    ${FILE_OTH_HEADER}
-                            Get object           ${KEY}         ${CID}       ${S_OID_USER}    ${EMPTY}    local_file_eacl
-                            Set eACL                        ${USER_KEY}    ${CID}       ${DENY_EACL}
+    ${S_OID_USER} =     Put object     ${USER_KEY}    ${FILE_S}    ${CID}           ${EMPTY}    ${FILE_USR_HEADER}
+                        Put object     ${KEY}         ${FILE_S}    ${CID}           ${EMPTY}    ${FILE_OTH_HEADER}
+                        Get object     ${KEY}         ${CID}       ${S_OID_USER}    ${EMPTY}    local_file_eacl
+                        Set eACL       ${USER_KEY}    ${CID}       ${DENY_EACL}
 
-                            # The current ACL cache lifetime is 30 sec
-                            Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}
+                        # The current ACL cache lifetime is 30 sec
+                        Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}
 
-    ${rule1}=               Create Dictionary    Operation=GET             Access=ALLOW    Role=${DENY_GROUP}
-    ${rule2}=               Create Dictionary    Operation=GETRANGE        Access=ALLOW    Role=${DENY_GROUP}
-    ${rule3}=               Create Dictionary    Operation=GETRANGEHASH    Access=ALLOW    Role=${DENY_GROUP}
-    ${eACL_gen}=            Create List    ${rule1}    ${rule2}    ${rule3}
-                            Form BearerToken file           ${USER_KEY}    ${CID}    bearer_allow   ${eACL_gen}   100500
+    ${rule1}=           Create Dictionary    Operation=GET             Access=ALLOW    Role=${DENY_GROUP}
+    ${rule2}=           Create Dictionary    Operation=GETRANGE        Access=ALLOW    Role=${DENY_GROUP}
+    ${rule3}=           Create Dictionary    Operation=GETRANGEHASH    Access=ALLOW    Role=${DENY_GROUP}
+    ${eACL_gen}=        Create List    ${rule1}    ${rule2}    ${rule3}
+    ${EACL_TOKEN} =     Form BearerToken File      ${USER_KEY}    ${CID}    ${eACL_gen}
 
-                            Run Keyword And Expect Error    *
-                            ...  Head object                ${KEY}    ${CID}    ${S_OID_USER}    bearer_allow
+                        Run Keyword And Expect Error    *
+                        ...  Head object     ${KEY}    ${CID}    ${S_OID_USER}    ${EACL_TOKEN}
 
-                            Get object           ${KEY}    ${CID}    ${S_OID_USER}    bearer_allow       local_file_eacl
-                            Get Range                       ${KEY}    ${CID}    ${S_OID_USER}    s_get_range        bearer_allow       0:256
-                            Get Range Hash                  ${KEY}    ${CID}    ${S_OID_USER}    bearer_allow       0:256
+                        Get object           ${KEY}    ${CID}    ${S_OID_USER}    ${EACL_TOKEN}      local_file_eacl
+                        Get Range            ${KEY}    ${CID}    ${S_OID_USER}    s_get_range        ${EACL_TOKEN}       0:256
+                        Get Range Hash       ${KEY}    ${CID}    ${S_OID_USER}    ${EACL_TOKEN}      0:256
 
 
 Check Bearer Сompound Delete
     [Arguments]             ${KEY}    ${DENY_GROUP}    ${DENY_EACL}
 
-    ${CID} =                Create Container Public
+    ${CID} =            Create Container Public
 
-    ${S_OID_USER} =         Put object             ${USER_KEY}    ${FILE_S}    ${CID}           ${EMPTY}    ${FILE_USR_HEADER}
-    ${D_OID_USER} =         Put object             ${USER_KEY}    ${FILE_S}    ${CID}           ${EMPTY}    ${EMPTY}
-                            Put object             ${KEY}         ${FILE_S}    ${CID}           ${EMPTY}    ${FILE_OTH_HEADER}
-                            Delete object                   ${KEY}         ${CID}       ${D_OID_USER}    ${EMPTY}
+    ${S_OID_USER} =     Put object         ${USER_KEY}    ${FILE_S}    ${CID}           ${EMPTY}    ${FILE_USR_HEADER}
+    ${D_OID_USER} =     Put object         ${USER_KEY}    ${FILE_S}    ${CID}           ${EMPTY}    ${EMPTY}
+                        Put object         ${KEY}         ${FILE_S}    ${CID}           ${EMPTY}    ${FILE_OTH_HEADER}
+                        Delete object      ${KEY}         ${CID}       ${D_OID_USER}    ${EMPTY}
 
-                            Set eACL                        ${USER_KEY}    ${CID}       ${DENY_EACL}
+                        Set eACL           ${USER_KEY}    ${CID}       ${DENY_EACL}
 
-                            # The current ACL cache lifetime is 30 sec
-                            Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}
+                        # The current ACL cache lifetime is 30 sec
+                        Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}
 
-    ${rule1} =              Create Dictionary    Operation=DELETE          Access=ALLOW    Role=${DENY_GROUP}
-    ${rule2} =              Create Dictionary    Operation=PUT             Access=DENY     Role=${DENY_GROUP}
-    ${rule3} =              Create Dictionary    Operation=HEAD            Access=DENY     Role=${DENY_GROUP}
-    ${eACL_gen} =           Create List    ${rule1}    ${rule2}    ${rule3}
-                            Form BearerToken file           ${USER_KEY}    ${CID}    bearer_allow   ${eACL_gen}   100500
+    ${rule1} =          Create Dictionary    Operation=DELETE          Access=ALLOW    Role=${DENY_GROUP}
+    ${rule2} =          Create Dictionary    Operation=PUT             Access=DENY     Role=${DENY_GROUP}
+    ${rule3} =          Create Dictionary    Operation=HEAD            Access=DENY     Role=${DENY_GROUP}
+    ${eACL_gen} =       Create List    ${rule1}    ${rule2}    ${rule3}
+    ${EACL_TOKEN} =     Form BearerToken File           ${USER_KEY}    ${CID}    ${eACL_gen}
 
-                            Run Keyword And Expect Error    *
-                            ...  Head object                ${KEY}    ${CID}       ${S_OID_USER}    bearer_allow
-                            Run Keyword And Expect Error    *
-                            ...  Put object        ${KEY}    ${FILE_S}    ${CID}           bearer_allow    ${FILE_OTH_HEADER}
+                        Run Keyword And Expect Error    *
+                        ...  Head object   ${KEY}    ${CID}       ${S_OID_USER}    ${EACL_TOKEN}
+                        Run Keyword And Expect Error    *
+                        ...  Put object    ${KEY}    ${FILE_S}    ${CID}           ${EACL_TOKEN}    ${FILE_OTH_HEADER}
 
-                            Delete object                   ${KEY}    ${CID}       ${S_OID_USER}    bearer_allow
+                        Delete object      ${KEY}    ${CID}       ${S_OID_USER}    ${EACL_TOKEN}
 
 
 
 Check Bearer Сompound Get Range Hash
-    [Arguments]             ${KEY}    ${DENY_GROUP}    ${DENY_EACL}
+    [Arguments]            ${KEY}    ${DENY_GROUP}    ${DENY_EACL}
 
-    ${CID} =                Create Container Public
+    ${CID} =            Create Container Public
 
-    ${S_OID_USER} =         Put object             ${USER_KEY}         ${FILE_S}    ${CID}           ${EMPTY}    ${FILE_USR_HEADER}
-                            Put object             ${KEY}              ${FILE_S}    ${CID}           ${EMPTY}    ${FILE_OTH_HEADER}
-                            Get Range Hash                  ${SYSTEM_KEY_SN}    ${CID}       ${S_OID_USER}    ${EMPTY}    0:256
+    ${S_OID_USER} =     Put object         ${USER_KEY}         ${FILE_S}    ${CID}           ${EMPTY}    ${FILE_USR_HEADER}
+                        Put object         ${KEY}              ${FILE_S}    ${CID}           ${EMPTY}    ${FILE_OTH_HEADER}
+                        Get Range Hash     ${SYSTEM_KEY_SN}    ${CID}       ${S_OID_USER}    ${EMPTY}    0:256
 
-                            Set eACL                        ${USER_KEY}         ${CID}       ${DENY_EACL}
+                        Set eACL           ${USER_KEY}         ${CID}       ${DENY_EACL}
 
-                            # The current ACL cache lifetime is 30 sec
-                            Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}
+                        # The current ACL cache lifetime is 30 sec
+                        Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}
 
-        ${rule1} =          Create Dictionary    Operation=GETRANGEHASH    Access=ALLOW    Role=${DENY_GROUP}
-        ${rule2} =          Create Dictionary    Operation=GETRANGE        Access=DENY     Role=${DENY_GROUP}
-        ${rule3} =          Create Dictionary    Operation=GET             Access=DENY     Role=${DENY_GROUP}
-        ${eACL_gen} =       Create List    ${rule1}    ${rule2}    ${rule3}
-                            Form BearerToken file          ${USER_KEY}    ${CID}    bearer_allow   ${eACL_gen}   100500
+    ${rule1} =          Create Dictionary    Operation=GETRANGEHASH    Access=ALLOW    Role=${DENY_GROUP}
+    ${rule2} =          Create Dictionary    Operation=GETRANGE        Access=DENY     Role=${DENY_GROUP}
+    ${rule3} =          Create Dictionary    Operation=GET             Access=DENY     Role=${DENY_GROUP}
+    ${eACL_gen} =       Create List    ${rule1}    ${rule2}    ${rule3}
+    ${EACL_TOKEN} =     Form BearerToken File      ${USER_KEY}    ${CID}    ${eACL_gen}
 
-                            Run Keyword And Expect Error    *
-                            ...  Get Range                  ${KEY}    ${CID}    ${S_OID_USER}    s_get_range    bearer_allow    0:256
-                            Run Keyword And Expect Error    *
-                            ...  Get object      ${KEY}    ${CID}    ${S_OID_USER}    bearer_allow    local_file_eacl
+                        Run Keyword And Expect Error    *
+                        ...  Get Range      ${KEY}    ${CID}    ${S_OID_USER}    s_get_range    ${EACL_TOKEN}    0:256
+                        Run Keyword And Expect Error    *
+                        ...  Get object     ${KEY}    ${CID}    ${S_OID_USER}    ${EACL_TOKEN}    local_file_eacl
 
-                            Get Range Hash                  ${KEY}    ${CID}    ${S_OID_USER}    bearer_allow    0:256
+                        Get Range Hash      ${KEY}    ${CID}    ${S_OID_USER}    ${EACL_TOKEN}    0:256

--- a/robot/testsuites/integration/acl/acl_bearer_filter_oid_equal.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_filter_oid_equal.robot
@@ -1,12 +1,15 @@
 *** Settings ***
 Variables   ../../../variables/common.py
-Library     ../${RESOURCES}/neofs.py
-Library     ../${RESOURCES}/payment_neogo.py
 
 Library     Collections
+Library     neofs.py
+Library     acl.py
+Library     payment_neogo.py
+
+Resource   ../../../variables/eacl_tables.robot
 Resource    common_steps_acl_bearer.robot
-Resource    ../${RESOURCES}/payment_operations.robot
-Resource    ../${RESOURCES}/setup_teardown.robot
+Resource    payment_operations.robot
+Resource    setup_teardown.robot
 
 
 *** Test cases ***
@@ -18,7 +21,6 @@ BearerToken Operations with Filter OID Equal
     [Setup]                 Setup
 
                             Generate Keys
-                            Prepare eACL Role rules
 
                             Log    Check Bearer token with simple object
                             Generate file    ${SIMPLE_OBJ_SIZE}
@@ -54,43 +56,43 @@ Check eACL Deny and Allow All Bearer Filter OID Equal
                             # The current ACL cache lifetime is 30 sec
                             Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}
 
-    ${filters}=             Create Dictionary    headerType=OBJECT    matchType=STRING_EQUAL    key=$Object:objectID    value=${S_OID_USER}
+    ${filters}=         Create Dictionary    headerType=OBJECT    matchType=STRING_EQUAL    key=$Object:objectID    value=${S_OID_USER}
 
-    ${rule1}=               Create Dictionary    Operation=GET             Access=ALLOW    Role=USER    Filters=${filters}
-    ${rule2}=               Create Dictionary    Operation=HEAD            Access=ALLOW    Role=USER    Filters=${filters}
-    ${rule3}=               Create Dictionary    Operation=PUT             Access=ALLOW    Role=USER    Filters=${filters}
-    ${rule4}=               Create Dictionary    Operation=DELETE          Access=ALLOW    Role=USER    Filters=${filters}
-    ${rule5}=               Create Dictionary    Operation=SEARCH          Access=ALLOW    Role=USER    Filters=${filters}
-    ${rule6}=               Create Dictionary    Operation=GETRANGE        Access=ALLOW    Role=USER    Filters=${filters}
-    ${rule7}=               Create Dictionary    Operation=GETRANGEHASH    Access=ALLOW    Role=USER    Filters=${filters}
+    ${rule1}=           Create Dictionary    Operation=GET             Access=ALLOW    Role=USER    Filters=${filters}
+    ${rule2}=           Create Dictionary    Operation=HEAD            Access=ALLOW    Role=USER    Filters=${filters}
+    ${rule3}=           Create Dictionary    Operation=PUT             Access=ALLOW    Role=USER    Filters=${filters}
+    ${rule4}=           Create Dictionary    Operation=DELETE          Access=ALLOW    Role=USER    Filters=${filters}
+    ${rule5}=           Create Dictionary    Operation=SEARCH          Access=ALLOW    Role=USER    Filters=${filters}
+    ${rule6}=           Create Dictionary    Operation=GETRANGE        Access=ALLOW    Role=USER    Filters=${filters}
+    ${rule7}=           Create Dictionary    Operation=GETRANGEHASH    Access=ALLOW    Role=USER    Filters=${filters}
 
-    ${eACL_gen}=            Create List    ${rule1}    ${rule2}    ${rule3}    ${rule4}    ${rule5}    ${rule6}    ${rule7}
+    ${eACL_gen}=        Create List    ${rule1}    ${rule2}    ${rule3}    ${rule4}    ${rule5}    ${rule6}    ${rule7}
 
-                            Form BearerToken file           ${USER_KEY}    ${CID}    bearer_allow_all_user   ${eACL_gen}   100500
+    ${EACL_TOKEN} =     Form BearerToken File      ${USER_KEY}    ${CID}    ${eACL_gen}
 
-                            Run Keyword And Expect Error        *
-                            ...  Put object    ${USER_KEY}    ${FILE_S}     ${CID}       ${EMPTY}      ${FILE_USR_HEADER}
-                            Run Keyword And Expect Error        *
-                            ...  Get object    ${USER_KEY}    ${CID}        ${S_OID_USER}    ${EMPTY}      local_file_eacl
-                            Run Keyword And Expect Error        *
-                            ...  Search object    ${USER_KEY}    ${CID}    ${EMPTY}     ${EMPTY}      ${FILE_USR_HEADER}      ${S_OBJ_H}
-                            Run Keyword And Expect Error        *
-                            ...  Head object      ${USER_KEY}    ${CID}    ${S_OID_USER}    ${EMPTY}
-                            Run Keyword And Expect Error        *
-                            ...  Get Range        ${USER_KEY}    ${CID}    ${S_OID_USER}    s_get_range    ${EMPTY}      0:256
-                            Run Keyword And Expect Error        *
-                            ...  Delete object      ${USER_KEY}    ${CID}    ${S_OID_USER}    ${EMPTY}
-                            Run Keyword And Expect Error        *
-                            ...  Search object      ${USER_KEY}    ${CID}    ${EMPTY}    bearer_allow_all_user    ${FILE_USR_HEADER}    ${S_OBJ_H}
-                            Run Keyword And Expect Error        *
-                            ...  Put object    ${USER_KEY}    ${FILE_S}     ${CID}     bearer_allow_all_user     ${FILE_OTH_HEADER}
-                            Run Keyword And Expect Error        *
-                            ...  Get object      ${USER_KEY}    ${CID}      ${S_OID_USER_2}    bearer_allow_all_user       local_file_eacl
+                        Run Keyword And Expect Error        *
+                        ...  Put object     ${USER_KEY}    ${FILE_S}     ${CID}       ${EMPTY}      ${FILE_USR_HEADER}
+                        Run Keyword And Expect Error        *
+                        ...  Get object     ${USER_KEY}    ${CID}        ${S_OID_USER}    ${EMPTY}      local_file_eacl
+                        Run Keyword And Expect Error        *
+                        ...  Search object  ${USER_KEY}    ${CID}    ${EMPTY}     ${EMPTY}      ${FILE_USR_HEADER}      ${S_OBJ_H}
+                        Run Keyword And Expect Error        *
+                        ...  Head object    ${USER_KEY}    ${CID}    ${S_OID_USER}    ${EMPTY}
+                        Run Keyword And Expect Error        *
+                        ...  Get Range      ${USER_KEY}    ${CID}    ${S_OID_USER}    s_get_range    ${EMPTY}      0:256
+                        Run Keyword And Expect Error        *
+                        ...  Delete object  ${USER_KEY}    ${CID}    ${S_OID_USER}    ${EMPTY}
+                        Run Keyword And Expect Error        *
+                        ...  Search object  ${USER_KEY}    ${CID}    ${EMPTY}    ${EACL_TOKEN}    ${FILE_USR_HEADER}    ${S_OBJ_H}
+                        Run Keyword And Expect Error        *
+                        ...  Put object     ${USER_KEY}    ${FILE_S}     ${CID}     ${EACL_TOKEN}     ${FILE_OTH_HEADER}
+                        Run Keyword And Expect Error        *
+                        ...  Get object     ${USER_KEY}    ${CID}      ${S_OID_USER_2}    ${EACL_TOKEN}       local_file_eacl
 
-                            Get object       ${USER_KEY}    ${CID}      ${S_OID_USER}      bearer_allow_all_user       local_file_eacl
-                            Get Range        ${USER_KEY}    ${CID}      ${S_OID_USER}      s_get_range     bearer_allow_all_user   0:256
+                        Get object       ${USER_KEY}    ${CID}      ${S_OID_USER}      ${EACL_TOKEN}       local_file_eacl
+                        Get Range        ${USER_KEY}    ${CID}      ${S_OID_USER}      s_get_range     ${EACL_TOKEN}   0:256
 
-                            Head object                         ${USER_KEY}    ${CID}        ${S_OID_USER}        bearer_allow_all_user
-                            Delete object                       ${USER_KEY}    ${CID}        ${S_OID_USER}        bearer_allow_all_user
-                            Run Keyword And Expect Error        *
-                            ...  Delete object                  ${USER_KEY}    ${CID}        ${D_OID_USER}        bearer_allow_all_user
+                        Head object      ${USER_KEY}    ${CID}      ${S_OID_USER}      ${EACL_TOKEN}
+                        Delete object    ${USER_KEY}    ${CID}      ${S_OID_USER}      ${EACL_TOKEN}
+                        Run Keyword And Expect Error        *
+                        ...  Delete object              ${USER_KEY}    ${CID}        ${D_OID_USER}        ${EACL_TOKEN}

--- a/robot/testsuites/integration/acl/acl_bearer_filter_oid_not_equal.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_filter_oid_not_equal.robot
@@ -1,10 +1,12 @@
 *** Settings ***
 Variables   ../../../variables/common.py
-Library     ../${RESOURCES}/neofs.py
-Library     ../${RESOURCES}/payment_neogo.py
 
 Library     Collections
+Library     neofs.py
+Library     acl.py
+Library     payment_neogo.py
 
+Resource   ../../../variables/eacl_tables.robot
 Resource    common_steps_acl_bearer.robot
 Resource    ../${RESOURCES}/payment_operations.robot
 Resource    ../${RESOURCES}/setup_teardown.robot
@@ -13,20 +15,18 @@ Resource    ../${RESOURCES}/setup_teardown.robot
 *** Test cases ***
 BearerToken Operations with Filter OID NotEqual
     [Documentation]         Testcase to validate NeoFS operations with BearerToken with Filter OID NotEqual.
-    [Tags]                  ACL  NeoFS  NeoCLI BearerToken
+    [Tags]                  ACL    NeoFSCLI BearerToken
     [Timeout]               20 min
 
     [Setup]                 Setup
 
                             Generate Keys
-                            Prepare eACL Role rules
 
                             Log    Check Bearer token with simple object
                             Generate file    ${SIMPLE_OBJ_SIZE}
                             Check eACL Deny and Allow All Bearer Filter OID NotEqual
 
                             Log    Check Bearer token with complex object
-
                             Generate file    ${COMPLEX_OBJ_SIZE}
                             Check eACL Deny and Allow All Bearer Filter OID NotEqual
 
@@ -36,90 +36,70 @@ BearerToken Operations with Filter OID NotEqual
 
 *** Keywords ***
 
-
-Prepare eACL Role rules
-                            Log	                    Set eACL for different Role cases
-
-    # eACL rules for all operations and similar permissions
-    @{Roles} =	        Create List    OTHERS    USER    SYSTEM
-    FOR	${role}	IN	@{Roles}
-        ${rule1} =              Create Dictionary    Operation=GET             Access=DENY    Role=${role}
-        ${rule2} =              Create Dictionary    Operation=HEAD            Access=DENY    Role=${role}
-        ${rule3} =              Create Dictionary    Operation=PUT             Access=DENY    Role=${role}
-        ${rule4} =              Create Dictionary    Operation=DELETE          Access=DENY    Role=${role}
-        ${rule5} =              Create Dictionary    Operation=SEARCH          Access=DENY    Role=${role}
-        ${rule6} =              Create Dictionary    Operation=GETRANGE        Access=DENY    Role=${role}
-        ${rule7} =              Create Dictionary    Operation=GETRANGEHASH    Access=DENY    Role=${role}
-
-        ${eACL_gen} =           Create List    ${rule1}    ${rule2}    ${rule3}    ${rule4}    ${rule5}    ${rule6}    ${rule7}
-                                Form eACL json common file    gen_eacl_deny_all_${role}    ${eACL_gen}
-                                Set Global Variable    ${EACL_DENY_ALL_${role}}       gen_eacl_deny_all_${role}
-    END
-
 Check eACL Deny and Allow All Bearer Filter OID NotEqual
     ${CID} =                Create Container Public
-    ${S_OID_USER} =         Put object                 ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${FILE_USR_HEADER}
-    ${S_OID_USER_2} =       Put object                 ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${EMPTY}
-    ${D_OID_USER} =         Put object                 ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${FILE_USR_HEADER_DEL}
-    @{S_OBJ_H} =	        Create List	                        ${S_OID_USER}
+    ${S_OID_USER} =         Put object          ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${FILE_USR_HEADER}
+    ${S_OID_USER_2} =       Put object          ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${EMPTY}
+    ${D_OID_USER} =         Put object          ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${FILE_USR_HEADER_DEL}
+    @{S_OBJ_H} =	    Create List	        ${S_OID_USER}
 
+                            Put object          ${USER_KEY}    ${FILE_S}     ${CID}           ${EMPTY}       ${FILE_OTH_HEADER}
+                            Get object          ${USER_KEY}    ${CID}        ${S_OID_USER}    ${EMPTY}       local_file_eacl
+                            Search object       ${USER_KEY}    ${CID}        ${EMPTY}         ${EMPTY}       ${FILE_USR_HEADER}     ${S_OBJ_H}
+                            Head object         ${USER_KEY}    ${CID}        ${S_OID_USER}    ${EMPTY}
+                            Get Range           ${USER_KEY}    ${CID}        ${S_OID_USER}    s_get_range    ${EMPTY}      0:256
+                            Delete object       ${USER_KEY}    ${CID}        ${D_OID_USER}    ${EMPTY}
 
-                            Put object                 ${USER_KEY}    ${FILE_S}     ${CID}                   ${EMPTY}              ${FILE_OTH_HEADER}
-                            Get object               ${USER_KEY}    ${CID}        ${S_OID_USER}            ${EMPTY}              local_file_eacl
-                            Search object                       ${USER_KEY}    ${CID}        ${EMPTY}                 ${EMPTY}              ${FILE_USR_HEADER}         ${S_OBJ_H}
-                            Head object                         ${USER_KEY}    ${CID}        ${S_OID_USER}            ${EMPTY}
-                            Get Range                           ${USER_KEY}    ${CID}        ${S_OID_USER}            s_get_range            ${EMPTY}              0:256
-                            Delete object                       ${USER_KEY}    ${CID}        ${D_OID_USER}            ${EMPTY}
-
-                            Set eACL                            ${USER_KEY}    ${CID}        ${EACL_DENY_ALL_USER}
+                            Set eACL            ${USER_KEY}    ${CID}        ${EACL_DENY_ALL_USER}
 
                             # The current ACL cache lifetime is 30 sec
                             Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}
 
-    ${filters}=             Create Dictionary    headerType=OBJECT    matchType=STRING_NOT_EQUAL    key=$Object:objectID    value=${S_OID_USER_2}
+    ${filters}=         Create Dictionary    headerType=OBJECT    matchType=STRING_NOT_EQUAL    key=$Object:objectID    value=${S_OID_USER_2}
 
-    ${rule1}=               Create Dictionary    Operation=GET             Access=ALLOW    Role=USER    Filters=${filters}
-    ${rule2}=               Create Dictionary    Operation=HEAD            Access=ALLOW    Role=USER    Filters=${filters}
-    ${rule3}=               Create Dictionary    Operation=PUT             Access=ALLOW    Role=USER    Filters=${filters}
-    ${rule4}=               Create Dictionary    Operation=DELETE          Access=ALLOW    Role=USER    Filters=${filters}
-    ${rule5}=               Create Dictionary    Operation=SEARCH          Access=ALLOW    Role=USER    Filters=${filters}
-    ${rule6}=               Create Dictionary    Operation=GETRANGE        Access=ALLOW    Role=USER    Filters=${filters}
-    ${rule7}=               Create Dictionary    Operation=GETRANGEHASH    Access=ALLOW    Role=USER    Filters=${filters}
+    ${rule1}=           Create Dictionary    Operation=GET             Access=ALLOW    Role=USER    Filters=${filters}
+    ${rule2}=           Create Dictionary    Operation=HEAD            Access=ALLOW    Role=USER    Filters=${filters}
+    ${rule3}=           Create Dictionary    Operation=PUT             Access=ALLOW    Role=USER    Filters=${filters}
+    ${rule4}=           Create Dictionary    Operation=DELETE          Access=ALLOW    Role=USER    Filters=${filters}
+    ${rule5}=           Create Dictionary    Operation=SEARCH          Access=ALLOW    Role=USER    Filters=${filters}
+    ${rule6}=           Create Dictionary    Operation=GETRANGE        Access=ALLOW    Role=USER    Filters=${filters}
+    ${rule7}=           Create Dictionary    Operation=GETRANGEHASH    Access=ALLOW    Role=USER    Filters=${filters}
 
-    ${eACL_gen}=            Create List    ${rule1}    ${rule2}    ${rule3}    ${rule4}    ${rule5}    ${rule6}    ${rule7}
+    ${eACL_gen}=        Create List    ${rule1}    ${rule2}    ${rule3}    ${rule4}    ${rule5}    ${rule6}    ${rule7}
 
-                            Form BearerToken file               ${USER_KEY}    ${CID}    bearer_allow_all_user   ${eACL_gen}   100500
+    ${EACL_TOKEN} =     Form BearerToken File   ${USER_KEY}    ${CID}      ${eACL_gen}
 
-                            Run Keyword And Expect Error        *
-                            ...  Put object            ${USER_KEY}    ${FILE_S}     ${CID}                   ${EMPTY}              ${FILE_USR_HEADER}
-                            Run Keyword And Expect Error        *
-                            ...  Get object          ${USER_KEY}    ${CID}        ${S_OID_USER}            ${EMPTY}              local_file_eacl
-                            Run Keyword And Expect Error        *
-                            ...  Search object                  ${USER_KEY}    ${CID}        ${EMPTY}                 ${EMPTY}              ${FILE_USR_HEADER}          ${S_OBJ_H}
-                            Run Keyword And Expect Error        *
-                            ...  Head object                    ${USER_KEY}    ${CID}        ${S_OID_USER}            ${EMPTY}
-                            Run Keyword And Expect Error        *
-                            ...  Get Range                      ${USER_KEY}    ${CID}        ${S_OID_USER}            s_get_range            ${EMPTY}              0:256
-                            Run Keyword And Expect Error        *
-                            ...  Delete object                  ${USER_KEY}    ${CID}        ${S_OID_USER}            ${EMPTY}
-                            Run Keyword And Expect Error        *
-                            ...  Search object                  ${USER_KEY}    ${CID}        ${EMPTY}                 bearer_allow_all_user               ${FILE_USR_HEADER}             ${S_OBJ_H}
+                        Run Keyword And Expect Error        *
+                        ...  Put object      ${USER_KEY}    ${FILE_S}     ${CID}       ${EMPTY}         ${FILE_USR_HEADER}
+                        Run Keyword And Expect Error        *
+                        ...  Get object      ${USER_KEY}    ${CID}        ${S_OID_USER}        ${EMPTY}         local_file_eacl
+                        Run Keyword And Expect Error        *
+                        ...  Search object   ${USER_KEY}    ${CID}        ${EMPTY}     ${EMPTY}      ${FILE_USR_HEADER}          ${S_OBJ_H}
+                        Run Keyword And Expect Error        *
+                        ...  Head object     ${USER_KEY}    ${CID}        ${S_OID_USER}        ${EMPTY}
+                        Run Keyword And Expect Error        *
+                        ...  Get Range       ${USER_KEY}    ${CID}        ${S_OID_USER}        s_get_range        ${EMPTY}      0:256
+                        Run Keyword And Expect Error        *
+                        ...  Delete object   ${USER_KEY}    ${CID}        ${S_OID_USER}        ${EMPTY}
 
-                            Put object                 ${USER_KEY}    ${FILE_S}     ${CID}                   bearer_allow_all_user               ${FILE_OTH_HEADER}
+                        Put object     ${USER_KEY}    ${FILE_S}     ${CID}       ${EACL_TOKEN}      ${FILE_OTH_HEADER}
 
-                            Get object               ${USER_KEY}    ${CID}        ${S_OID_USER}            bearer_allow_all_user               local_file_eacl
-                            Run Keyword And Expect Error        *
-                            ...  Get object          ${USER_KEY}    ${CID}        ${S_OID_USER_2}          bearer_allow_all_user               local_file_eacl
+                        Get object     ${USER_KEY}    ${CID}        ${S_OID_USER}        ${EACL_TOKEN}       local_file_eacl
+                        Run Keyword And Expect Error        *
+                        ...  Get object      ${USER_KEY}    ${CID}     ${S_OID_USER_2}      ${EACL_TOKEN}       local_file_eacl
 
-                            Get Range                           ${USER_KEY}    ${CID}        ${S_OID_USER}            s_get_range            bearer_allow_all_user               0:256
-                            Run Keyword And Expect Error        *
-                            ...  Get Range                      ${USER_KEY}    ${CID}        ${S_OID_USER_2}          s_get_range            bearer_allow_all_user               0:256
+                        Get Range      ${USER_KEY}    ${CID}        ${S_OID_USER}        s_get_range        ${EACL_TOKEN}       0:256
+                        Run Keyword And Expect Error        *
+                        ...  Get Range      ${USER_KEY}    ${CID}        ${S_OID_USER_2}      s_get_range        ${EACL_TOKEN}       0:256
 
-                            Head object                         ${USER_KEY}    ${CID}        ${S_OID_USER}            bearer_allow_all_user
-                            Run Keyword And Expect Error        *
-                            ...  Head object                    ${USER_KEY}    ${CID}        ${S_OID_USER_2}          bearer_allow_all_user
+                        Head object         ${USER_KEY}    ${CID}        ${S_OID_USER}        ${EACL_TOKEN}
+                        Run Keyword And Expect Error        *
+                        ...  Head object    ${USER_KEY}    ${CID}        ${S_OID_USER_2}      ${EACL_TOKEN}
 
-                            Delete object                       ${USER_KEY}    ${CID}        ${S_OID_USER}            bearer_allow_all_user
+                        Run Keyword And Expect Error        *
+                        ...  Search object      ${USER_KEY}    ${CID}        ${EMPTY}     ${EACL_TOKEN}       ${FILE_USR_HEADER}     ${S_OBJ_H}
 
-                            Run Keyword And Expect Error        *
-                            ...  Delete object                  ${USER_KEY}    ${CID}        ${D_OID_USER_2}          bearer_allow_all_user
+                        Delete object       ${USER_KEY}    ${CID}        ${S_OID_USER}        ${EACL_TOKEN}
+
+                        Run Keyword And Expect Error        *
+                        ...  Delete object      ${USER_KEY}    ${CID}        ${D_OID_USER_2}      ${EACL_TOKEN}

--- a/robot/testsuites/integration/acl/acl_bearer_filter_userheader_equal.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_filter_userheader_equal.robot
@@ -1,10 +1,12 @@
 *** Settings ***
 Variables   ../../../variables/common.py
-Library     ../${RESOURCES}/neofs.py
-Library     ../${RESOURCES}/payment_neogo.py
 
 Library     Collections
+Library     acl.py
+Library     neofs.py
+Library     payment_neogo.py
 
+Resource    ../../../variables/eacl_tables.robot
 Resource    common_steps_acl_bearer.robot
 Resource    ../${RESOURCES}/payment_operations.robot
 Resource    ../${RESOURCES}/setup_teardown.robot
@@ -12,7 +14,7 @@ Resource    ../${RESOURCES}/setup_teardown.robot
 *** Test cases ***
 BearerToken Operations with Filter UserHeader Equal
     [Documentation]         Testcase to validate NeoFS operations with BearerToken with Filter UserHeader Equal.
-    [Tags]                  ACL  NeoFS  NeoCLI BearerToken
+    [Tags]                  ACL  NeoFSCLI BearerToken
     [Timeout]               20 min
 
     [Setup]                 Setup
@@ -33,91 +35,73 @@ BearerToken Operations with Filter UserHeader Equal
 
 *** Keywords ***
 
-Prepare eACL Role rules
-    Log	                    Set eACL for different Role cases
-    # eACL rules for all operations and similar permissions
-    @{Roles} =	        Create List    OTHERS    USER    SYSTEM
-    FOR	${role}	IN	@{Roles}
-        ${rule1} =              Create Dictionary    Operation=GET             Access=DENY    Role=${role}
-        ${rule2} =              Create Dictionary    Operation=HEAD            Access=DENY    Role=${role}
-        ${rule3} =              Create Dictionary    Operation=PUT             Access=DENY    Role=${role}
-        ${rule4} =              Create Dictionary    Operation=DELETE          Access=DENY    Role=${role}
-        ${rule5} =              Create Dictionary    Operation=SEARCH          Access=DENY    Role=${role}
-        ${rule6} =              Create Dictionary    Operation=GETRANGE        Access=DENY    Role=${role}
-        ${rule7} =              Create Dictionary    Operation=GETRANGEHASH    Access=DENY    Role=${role}
-
-        ${eACL_gen} =           Create List    ${rule1}    ${rule2}    ${rule3}    ${rule4}    ${rule5}    ${rule6}    ${rule7}
-                                Form eACL json common file    gen_eacl_deny_all_${role}    ${eACL_gen}
-                                Set Global Variable    ${EACL_DENY_ALL_${role}}       gen_eacl_deny_all_${role}
-    END
-
 Check eACL Deny and Allow All Bearer Filter UserHeader Equal
     ${CID} =                Create Container Public
-    ${S_OID_USER} =         Put object                 ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${FILE_USR_HEADER}
-    ${S_OID_USER_2} =       Put object                 ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${EMPTY}
-    ${D_OID_USER} =         Put object                 ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${FILE_USR_HEADER_DEL}
-    @{S_OBJ_H} =	        Create List	                        ${S_OID_USER}
+    ${S_OID_USER} =         Put object       ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${FILE_USR_HEADER}
+    ${S_OID_USER_2} =       Put object       ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${EMPTY}
+    ${D_OID_USER} =         Put object       ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${FILE_USR_HEADER_DEL}
+    @{S_OBJ_H} =	    Create List	     ${S_OID_USER}
 
-                            Put object                 ${USER_KEY}    ${FILE_S}     ${CID}                   ${EMPTY}              ${FILE_OTH_HEADER}
-                            Get object               ${USER_KEY}    ${CID}        ${S_OID_USER}            ${EMPTY}              local_file_eacl
-                            Search object                       ${USER_KEY}    ${CID}        ${EMPTY}                 ${EMPTY}              ${FILE_USR_HEADER}         ${S_OBJ_H}
-                            Head object                         ${USER_KEY}    ${CID}        ${S_OID_USER}            ${EMPTY}
-                            Get Range                           ${USER_KEY}    ${CID}        ${S_OID_USER}            s_get_range            ${EMPTY}              0:256
-                            Delete object                       ${USER_KEY}    ${CID}        ${D_OID_USER}            ${EMPTY}
+                            Put object       ${USER_KEY}    ${FILE_S}    ${CID}               ${EMPTY}      ${FILE_OTH_HEADER}
+                            Get object       ${USER_KEY}    ${CID}       ${S_OID_USER}        ${EMPTY}      local_file_eacl
+                            Search object    ${USER_KEY}    ${CID}       ${EMPTY}             ${EMPTY}      ${FILE_USR_HEADER}     ${S_OBJ_H}
+                            Head object      ${USER_KEY}    ${CID}       ${S_OID_USER}        ${EMPTY}
+                            Get Range        ${USER_KEY}    ${CID}       ${S_OID_USER}        s_get_range       ${EMPTY}      0:256
+                            Delete object    ${USER_KEY}    ${CID}       ${D_OID_USER}        ${EMPTY}
 
-                            Set eACL                            ${USER_KEY}    ${CID}        ${EACL_DENY_ALL_USER}
+                            Set eACL         ${USER_KEY}    ${CID}       ${EACL_DENY_ALL_USER}
 
                             # The current ACL cache lifetime is 30 sec
                             Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}
 
-    ${filters}=             Create Dictionary    headerType=OBJECT    matchType=STRING_EQUAL    key=key2    value=abc
+    ${filters}=         Create Dictionary    headerType=OBJECT    matchType=STRING_EQUAL    key=key2    value=abc
 
-    ${rule1}=               Create Dictionary    Operation=GET             Access=ALLOW    Role=USER    Filters=${filters}
-    ${rule2}=               Create Dictionary    Operation=HEAD            Access=ALLOW    Role=USER    Filters=${filters}
-    ${rule3}=               Create Dictionary    Operation=PUT             Access=ALLOW    Role=USER    Filters=${filters}
-    ${rule4}=               Create Dictionary    Operation=DELETE          Access=ALLOW    Role=USER    Filters=${filters}
-    ${rule5}=               Create Dictionary    Operation=SEARCH          Access=ALLOW    Role=USER    Filters=${filters}
-    ${rule6}=               Create Dictionary    Operation=GETRANGE        Access=ALLOW    Role=USER    Filters=${filters}
-    ${rule7}=               Create Dictionary    Operation=GETRANGEHASH    Access=ALLOW    Role=USER    Filters=${filters}
+    ${rule1}=           Create Dictionary    Operation=GET             Access=ALLOW    Role=USER    Filters=${filters}
+    ${rule2}=           Create Dictionary    Operation=HEAD            Access=ALLOW    Role=USER    Filters=${filters}
+    ${rule3}=           Create Dictionary    Operation=PUT             Access=ALLOW    Role=USER    Filters=${filters}
+    ${rule4}=           Create Dictionary    Operation=DELETE          Access=ALLOW    Role=USER    Filters=${filters}
+    ${rule5}=           Create Dictionary    Operation=SEARCH          Access=ALLOW    Role=USER    Filters=${filters}
+    ${rule6}=           Create Dictionary    Operation=GETRANGE        Access=ALLOW    Role=USER    Filters=${filters}
+    ${rule7}=           Create Dictionary    Operation=GETRANGEHASH    Access=ALLOW    Role=USER    Filters=${filters}
 
-    ${eACL_gen}=            Create List    ${rule1}    ${rule2}    ${rule3}    ${rule4}    ${rule5}    ${rule6}    ${rule7}
+    ${eACL_gen}=        Create List    ${rule1}    ${rule2}    ${rule3}    ${rule4}    ${rule5}    ${rule6}    ${rule7}
 
-                            Form BearerToken file               ${USER_KEY}    ${CID}    bearer_allow_all_user   ${eACL_gen}   100500
+    ${EACL_TOKEN} =     Form BearerToken File      ${USER_KEY}    ${CID}    ${eACL_gen}
 
-                            Run Keyword And Expect Error        *
-                            ...  Put object            ${USER_KEY}    ${FILE_S}     ${CID}                   ${EMPTY}              ${FILE_USR_HEADER}
-                            Run Keyword And Expect Error        *
-                            ...  Get object          ${USER_KEY}    ${CID}        ${S_OID_USER}            ${EMPTY}              local_file_eacl
-                            Run Keyword And Expect Error        *
-                            ...  Search object                  ${USER_KEY}    ${CID}        ${EMPTY}                 ${EMPTY}              ${FILE_USR_HEADER}          ${S_OBJ_H}
-                            Run Keyword And Expect Error        *
-                            ...  Head object                    ${USER_KEY}    ${CID}        ${S_OID_USER}            ${EMPTY}
-                            Run Keyword And Expect Error        *
-                            ...  Get Range                      ${USER_KEY}    ${CID}        ${S_OID_USER}            s_get_range            ${EMPTY}              0:256
-                            Run Keyword And Expect Error        *
-                            ...  Delete object                  ${USER_KEY}    ${CID}        ${S_OID_USER}            ${EMPTY}
-                            Run Keyword And Expect Error        *
-                            ...  Search object                  ${USER_KEY}    ${CID}        ${EMPTY}                 bearer_allow_all_user               ${FILE_USR_HEADER}             ${S_OBJ_H}
+                        Run Keyword And Expect Error        *
+                        ...  Put object    ${USER_KEY}    ${FILE_S}    ${CID}           ${EMPTY}      ${FILE_USR_HEADER}
+                        Run Keyword And Expect Error        *
+                        ...  Get object    ${USER_KEY}    ${CID}       ${S_OID_USER}    ${EMPTY}      local_file_eacl
+                        Run Keyword And Expect Error        *
+                        ...  Search object  ${USER_KEY}   ${CID}       ${EMPTY}         ${EMPTY}      ${FILE_USR_HEADER}      ${S_OBJ_H}
+                        Run Keyword And Expect Error        *
+                        ...  Head object    ${USER_KEY}    ${CID}      ${S_OID_USER}    ${EMPTY}
+                        Run Keyword And Expect Error        *
+                        ...  Get Range      ${USER_KEY}    ${CID}      ${S_OID_USER}    s_get_range    ${EMPTY}      0:256
+                        Run Keyword And Expect Error        *
+                        ...  Delete object  ${USER_KEY}    ${CID}      ${S_OID_USER}    ${EMPTY}
+                        Run Keyword And Expect Error        *
+                        ...  Search object  ${USER_KEY}    ${CID}      ${EMPTY}         ${EACL_TOKEN}   ${FILE_USR_HEADER}     ${S_OBJ_H}
 
-                            Run Keyword And Expect Error        *
-                            ...  Put object            ${USER_KEY}    ${FILE_S}     ${CID}                   bearer_allow_all_user               ${FILE_OTH_HEADER}
+                        Run Keyword And Expect Error        *
+                        ...  Put object     ${USER_KEY}    ${FILE_S}     ${CID}               ${EACL_TOKEN}       ${FILE_OTH_HEADER}
 
-                            Get object               ${USER_KEY}    ${CID}        ${S_OID_USER}            bearer_allow_all_user               local_file_eacl
-                            Run Keyword And Expect Error        *
-                            ...  Get object          ${USER_KEY}    ${CID}        ${S_OID_USER_2}          bearer_allow_all_user               local_file_eacl
+                        Get object          ${USER_KEY}    ${CID}        ${S_OID_USER}        ${EACL_TOKEN}       local_file_eacl
+                        Run Keyword And Expect Error        *
+                        ...  Get object     ${USER_KEY}    ${CID}        ${S_OID_USER_2}      ${EACL_TOKEN}       local_file_eacl
 
-                            Run Keyword And Expect Error        *
-                            ...  Get Range                      ${USER_KEY}    ${CID}        ${S_OID_USER}            s_get_range                         bearer_allow_all_user               0:256
+                        Run Keyword And Expect Error        *
+                        ...  Get Range      ${USER_KEY}    ${CID}        ${S_OID_USER}        s_get_range         ${EACL_TOKEN}       0:256
 
-                            Run Keyword And Expect Error        *
-                            ...  Get Range Hash                 ${USER_KEY}    ${CID}        ${S_OID_USER}            bearer_allow_all_user               0:256
+                        Run Keyword And Expect Error        *
+                        ...  Get Range Hash     ${USER_KEY}    ${CID}    ${S_OID_USER}        ${EACL_TOKEN}   0:256
 
-                            Head object                         ${USER_KEY}    ${CID}        ${S_OID_USER}            bearer_allow_all_user
-                            Run Keyword And Expect Error        *
-                            ...  Head object                    ${USER_KEY}    ${CID}        ${S_OID_USER_2}          bearer_allow_all_user
+                        Head object         ${USER_KEY}    ${CID}        ${S_OID_USER}        ${EACL_TOKEN}
+                        Run Keyword And Expect Error        *
+                        ...  Head object    ${USER_KEY}    ${CID}        ${S_OID_USER_2}      ${EACL_TOKEN}
 
-                            # Delete can not be filtered by UserHeader.
-                            Run Keyword And Expect Error        *
-                            ...  Delete object                  ${USER_KEY}    ${CID}        ${S_OID_USER}            bearer_allow_all_user
-                            Run Keyword And Expect Error        *
-                            ...  Delete object                  ${USER_KEY}    ${CID}        ${S_OID_USER_2}          bearer_allow_all_user
+                        # Delete can not be filtered by UserHeader.
+                        Run Keyword And Expect Error        *
+                        ...  Delete object      ${USER_KEY}    ${CID}    ${S_OID_USER}        ${EACL_TOKEN}
+                        Run Keyword And Expect Error        *
+                        ...  Delete object      ${USER_KEY}    ${CID}    ${S_OID_USER_2}      ${EACL_TOKEN}

--- a/robot/testsuites/integration/acl/acl_bearer_filter_userheader_not_equal.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_filter_userheader_not_equal.robot
@@ -1,30 +1,31 @@
 *** Settings ***
 Variables   ../../../variables/common.py
-Library     ../${RESOURCES}/neofs.py
-Library     ../${RESOURCES}/payment_neogo.py
 
 Library     Collections
+Library     neofs.py
+Library     acl.py
+Library     payment_neogo.py
+
 Resource    common_steps_acl_bearer.robot
+Resource    ../../../variables/eacl_tables.robot
 Resource    ../${RESOURCES}/payment_operations.robot
 Resource    ../${RESOURCES}/setup_teardown.robot
 
 *** Test cases ***
 BearerToken Operations Filter UserHeader NotEqual
     [Documentation]         Testcase to validate NeoFS operations with BearerToken Filter UserHeader NotEqual.
-    [Tags]                  ACL  NeoFS  NeoCLI BearerToken
+    [Tags]                  ACL    NeoFSCLI BearerToken
     [Timeout]               20 min
 
     [Setup]                 Setup
 
                             Generate Keys
-                            Prepare eACL Role rules
 
                             Log    Check Bearer token with simple object
                             Generate file    ${SIMPLE_OBJ_SIZE}
                             Check eACL Deny and Allow All Bearer Filter UserHeader NotEqual
 
                             Log    Check Bearer token with complex object
-
                             Generate file    ${COMPLEX_OBJ_SIZE}
                             Check eACL Deny and Allow All Bearer Filter UserHeader NotEqual
 
@@ -33,77 +34,76 @@ BearerToken Operations Filter UserHeader NotEqual
 *** Keywords ***
 
 Check eACL Deny and Allow All Bearer Filter UserHeader NotEqual
-    ${CID} =                Create Container Public
-    ${S_OID_USER} =         Put object                 ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${FILE_OTH_HEADER}
-    ${S_OID_USER_2} =       Put object                 ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${FILE_USR_HEADER}
-    ${D_OID_USER} =         Put object                 ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${FILE_USR_HEADER_DEL}
-    @{S_OBJ_H} =	        Create List	                        ${S_OID_USER_2}
+    ${CID} =            Create Container Public
+    ${S_OID_USER} =     Put object         ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${FILE_OTH_HEADER}
+    ${S_OID_USER_2} =   Put object         ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${FILE_USR_HEADER}
+    ${D_OID_USER} =     Put object         ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${FILE_USR_HEADER_DEL}
+    @{S_OBJ_H} =	Create List        ${S_OID_USER_2}
 
+                        Put object          ${USER_KEY}    ${FILE_S}     ${CID}               ${EMPTY}      ${FILE_OTH_HEADER}
+                        Get object          ${USER_KEY}    ${CID}        ${S_OID_USER}        ${EMPTY}      local_file_eacl
+                        Search object       ${USER_KEY}    ${CID}        ${EMPTY}             ${EMPTY}      ${FILE_USR_HEADER}     ${S_OBJ_H}
+                        Head object         ${USER_KEY}    ${CID}        ${S_OID_USER}        ${EMPTY}
+                        Get Range           ${USER_KEY}    ${CID}        ${S_OID_USER}        s_get_range    ${EMPTY}      0:256
+                        Delete object       ${USER_KEY}    ${CID}        ${D_OID_USER}        ${EMPTY}
 
-                            Put object                 ${USER_KEY}    ${FILE_S}     ${CID}                   ${EMPTY}              ${FILE_OTH_HEADER}
-                            Get object               ${USER_KEY}    ${CID}        ${S_OID_USER}            ${EMPTY}              local_file_eacl
-                            Search object                       ${USER_KEY}    ${CID}        ${EMPTY}                 ${EMPTY}              ${FILE_USR_HEADER}         ${S_OBJ_H}
-                            Head object                         ${USER_KEY}    ${CID}        ${S_OID_USER}            ${EMPTY}
-                            Get Range                           ${USER_KEY}    ${CID}        ${S_OID_USER}            s_get_range            ${EMPTY}              0:256
-                            Delete object                       ${USER_KEY}    ${CID}        ${D_OID_USER}            ${EMPTY}
+                        Set eACL            ${USER_KEY}    ${CID}        ${EACL_DENY_ALL_USER}
 
-                            Set eACL                            ${USER_KEY}    ${CID}        ${EACL_DENY_ALL_USER}
+                        # The current ACL cache lifetime is 30 sec
+                        Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}
 
-                            # The current ACL cache lifetime is 30 sec
-                            Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}
+    ${filters}=     Create Dictionary    headerType=OBJECT    matchType=STRING_NOT_EQUAL    key=key2    value=abc
 
-    ${filters}=             Create Dictionary    headerType=OBJECT    matchType=STRING_NOT_EQUAL    key=key2    value=abc
+    ${rule1}=       Create Dictionary    Operation=GET             Access=ALLOW    Role=USER    Filters=${filters}
+    ${rule2}=       Create Dictionary    Operation=HEAD            Access=ALLOW    Role=USER    Filters=${filters}
+    ${rule3}=       Create Dictionary    Operation=PUT             Access=ALLOW    Role=USER    Filters=${filters}
+    ${rule4}=       Create Dictionary    Operation=DELETE          Access=ALLOW    Role=USER    Filters=${filters}
+    ${rule5}=       Create Dictionary    Operation=SEARCH          Access=ALLOW    Role=USER    Filters=${filters}
+    ${rule6}=       Create Dictionary    Operation=GETRANGE        Access=ALLOW    Role=USER    Filters=${filters}
+    ${rule7}=       Create Dictionary    Operation=GETRANGEHASH    Access=ALLOW    Role=USER    Filters=${filters}
 
-    ${rule1}=               Create Dictionary    Operation=GET             Access=ALLOW    Role=USER    Filters=${filters}
-    ${rule2}=               Create Dictionary    Operation=HEAD            Access=ALLOW    Role=USER    Filters=${filters}
-    ${rule3}=               Create Dictionary    Operation=PUT             Access=ALLOW    Role=USER    Filters=${filters}
-    ${rule4}=               Create Dictionary    Operation=DELETE          Access=ALLOW    Role=USER    Filters=${filters}
-    ${rule5}=               Create Dictionary    Operation=SEARCH          Access=ALLOW    Role=USER    Filters=${filters}
-    ${rule6}=               Create Dictionary    Operation=GETRANGE        Access=ALLOW    Role=USER    Filters=${filters}
-    ${rule7}=               Create Dictionary    Operation=GETRANGEHASH    Access=ALLOW    Role=USER    Filters=${filters}
+    ${eACL_gen}=    Create List    ${rule1}    ${rule2}    ${rule3}    ${rule4}      ${rule6}    ${rule7}
 
-    ${eACL_gen}=            Create List    ${rule1}    ${rule2}    ${rule3}    ${rule4}      ${rule6}    ${rule7}
+    ${EACL_TOKEN} =     Form BearerToken File       ${USER_KEY}    ${CID}   ${eACL_gen}
 
-                            Form BearerToken file               ${USER_KEY}    ${CID}    bearer_allow_all_user   ${eACL_gen}   100500
+                    Run Keyword And Expect Error        *
+                    ...  Put object        ${USER_KEY}    ${FILE_S}     ${CID}             ${EMPTY}    ${FILE_USR_HEADER}
+                    Run Keyword And Expect Error        *
+                    ...  Get object        ${USER_KEY}    ${CID}        ${S_OID_USER}      ${EMPTY}    local_file_eacl
+                    Run Keyword And Expect Error        *
+                    ...  Search object     ${USER_KEY}    ${CID}        ${EMPTY}           ${EMPTY}    ${FILE_USR_HEADER}    ${S_OBJ_H}
+                    Run Keyword And Expect Error        *
+                    ...  Head object       ${USER_KEY}    ${CID}        ${S_OID_USER}      ${EMPTY}
+                    Run Keyword And Expect Error        *
+                    ...  Get Range         ${USER_KEY}    ${CID}        ${S_OID_USER}      s_get_range    ${EMPTY}    0:256
+                    Run Keyword And Expect Error        *
+                    ...  Delete object     ${USER_KEY}    ${CID}        ${S_OID_USER}      ${EMPTY}
 
-                            Run Keyword And Expect Error        *
-                            ...  Put object            ${USER_KEY}    ${FILE_S}     ${CID}             ${EMPTY}    ${FILE_USR_HEADER}
-                            Run Keyword And Expect Error        *
-                            ...  Get object          ${USER_KEY}    ${CID}        ${S_OID_USER}      ${EMPTY}    local_file_eacl
-                            Run Keyword And Expect Error        *
-                            ...  Search object                  ${USER_KEY}    ${CID}        ${EMPTY}           ${EMPTY}    ${FILE_USR_HEADER}    ${S_OBJ_H}
-                            Run Keyword And Expect Error        *
-                            ...  Head object                    ${USER_KEY}    ${CID}        ${S_OID_USER}      ${EMPTY}
-                            Run Keyword And Expect Error        *
-                            ...  Get Range                      ${USER_KEY}    ${CID}        ${S_OID_USER}      s_get_range    ${EMPTY}    0:256
-                            Run Keyword And Expect Error        *
-                            ...  Delete object                  ${USER_KEY}    ${CID}        ${S_OID_USER}      ${EMPTY}
+                    # Search can not use filter by headers
+                    Run Keyword And Expect Error        *
+                    ...  Search object     ${USER_KEY}    ${CID}        ${EMPTY}       ${EACL_TOKEN}    ${FILE_USR_HEADER}    ${S_OBJ_H}
 
-                            # Search can not use filter by headers
-                            Run Keyword And Expect Error        *
-                            ...  Search object                  ${USER_KEY}    ${CID}        ${EMPTY}           bearer_allow_all_user    ${FILE_USR_HEADER}    ${S_OBJ_H}
+                    # Different behaviour for big and small objects!
+                    # Put object                 ${USER_KEY}    ${FILE_S}     ${CID}             ${EACL_TOKEN}    ${FILE_OTH_HEADER}
+                    Run Keyword And Expect Error        *
+                    ...  Put object        ${USER_KEY}    ${FILE_S}     ${CID}             ${EACL_TOKEN}    ${EMPTY}
 
-                            # Different behaviour for big and small objects!
-                            # Put object                 ${USER_KEY}    ${FILE_S}     ${CID}             bearer_allow_all_user    ${FILE_OTH_HEADER}
-                            Run Keyword And Expect Error        *
-                            ...  Put object            ${USER_KEY}    ${FILE_S}     ${CID}             bearer_allow_all_user    ${EMPTY}
+                    Get object             ${USER_KEY}    ${CID}        ${S_OID_USER}      ${EACL_TOKEN}    local_file_eacl
+                    Run Keyword And Expect Error        *
+                    ...  Get object        ${USER_KEY}    ${CID}        ${S_OID_USER_2}    ${EACL_TOKEN}    local_file_eacl
 
-                            Get object               ${USER_KEY}    ${CID}        ${S_OID_USER}      bearer_allow_all_user    local_file_eacl
-                            Run Keyword And Expect Error        *
-                            ...  Get object          ${USER_KEY}    ${CID}        ${S_OID_USER_2}    bearer_allow_all_user    local_file_eacl
+                    Run Keyword And Expect Error        *
+                    ...  Get Range         ${USER_KEY}    ${CID}        ${S_OID_USER}      s_get_range    ${EACL_TOKEN}    0:256
 
-                            Run Keyword And Expect Error        *
-                            ...  Get Range                      ${USER_KEY}    ${CID}        ${S_OID_USER}      s_get_range    bearer_allow_all_user    0:256
+                    Run Keyword And Expect Error        *
+                    ...  Get Range Hash    ${USER_KEY}    ${CID}        ${S_OID_USER}      ${EACL_TOKEN}    0:256
 
-                            Run Keyword And Expect Error        *
-                            ...  Get Range Hash                 ${USER_KEY}    ${CID}        ${S_OID_USER}      bearer_allow_all_user    0:256
+                    Head object            ${USER_KEY}    ${CID}        ${S_OID_USER}      ${EACL_TOKEN}
+                    Run Keyword And Expect Error        *
+                    ...  Head object       ${USER_KEY}    ${CID}        ${S_OID_USER_2}    ${EACL_TOKEN}
 
-                            Head object                         ${USER_KEY}    ${CID}        ${S_OID_USER}      bearer_allow_all_user
-                            Run Keyword And Expect Error        *
-                            ...  Head object                    ${USER_KEY}    ${CID}        ${S_OID_USER_2}    bearer_allow_all_user
-
-                            # Delete can not be filtered by UserHeader.
-                            Run Keyword And Expect Error        *
-                            ...  Delete object                  ${USER_KEY}    ${CID}        ${S_OID_USER}      bearer_allow_all_user
-                            Run Keyword And Expect Error        *
-                            ...  Delete object                  ${USER_KEY}    ${CID}        ${S_OID_USER_2}    bearer_allow_all_user
+                    # Delete can not be filtered by UserHeader.
+                    Run Keyword And Expect Error        *
+                    ...  Delete object     ${USER_KEY}    ${CID}        ${S_OID_USER}      ${EACL_TOKEN}
+                    Run Keyword And Expect Error        *
+                    ...  Delete object     ${USER_KEY}    ${CID}        ${S_OID_USER_2}    ${EACL_TOKEN}

--- a/robot/testsuites/integration/acl/acl_bearer_inaccessible.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_inaccessible.robot
@@ -1,10 +1,13 @@
 *** Settings ***
 
 Variables   ../../../variables/common.py
-Library     ../${RESOURCES}/neofs.py
-Library     ../${RESOURCES}/payment_neogo.py
 
 Library     Collections
+Library     neofs.py
+Library     acl.py
+Library     payment_neogo.py
+
+Resource    ../../../variables/eacl_tables.robot
 Resource    common_steps_acl_bearer.robot
 Resource    ../${RESOURCES}/payment_operations.robot
 Resource    ../${RESOURCES}/setup_teardown.robot
@@ -12,20 +15,18 @@ Resource    ../${RESOURCES}/setup_teardown.robot
 *** Test cases ***
 BearerToken Operations for Inaccessible Container
     [Documentation]         Testcase to validate NeoFS operations with BearerToken for Inaccessible Container.
-    [Tags]                  ACL  NeoFS  NeoCLI BearerToken
+    [Tags]                  ACL  NeoFSCLI BearerToken
     [Timeout]               20 min
 
     [Setup]                 Setup
 
                             Generate Keys
-                            Prepare eACL Role rules
 
                             Log    Check Bearer token with simple object
                             Generate file    ${SIMPLE_OBJ_SIZE}
                             Check Container Inaccessible and Allow All Bearer
 
                             Log    Check Bearer token with complex object
-
                             Generate file    ${COMPLEX_OBJ_SIZE}
                             Check Container Inaccessible and Allow All Bearer
 
@@ -34,29 +35,28 @@ BearerToken Operations for Inaccessible Container
 *** Keywords ***
 
 Check Container Inaccessible and Allow All Bearer
-    ${CID} =                Create Container Inaccessible
+    ${CID} =    Create Container Inaccessible
 
-                            Run Keyword And Expect Error        *
-                            ...  Put object            ${USER_KEY}    ${FILE_S}     ${CID}           ${EMPTY}       ${FILE_USR_HEADER}
-                            Run Keyword And Expect Error        *
-                            ...  Get object          ${USER_KEY}    ${CID}        ${S_OID_USER}    ${EMPTY}       local_file_eacl
-                            Run Keyword And Expect Error        *
-                            ...  Search object                  ${USER_KEY}    ${CID}        ${EMPTY}         ${EMPTY}       ${FILE_USR_HEADER}
-                            Run Keyword And Expect Error        *
-                            ...  Head object                    ${USER_KEY}    ${CID}        ${S_OID_USER}    ${EMPTY}
-                            Run Keyword And Expect Error        *
-                            ...  Get Range                      ${USER_KEY}    ${CID}        ${S_OID_USER}    s_get_range    ${EMPTY}              0:256
-                            Run Keyword And Expect Error        *
-                            ...  Delete object                  ${USER_KEY}    ${CID}        ${S_OID_USER}    ${EMPTY}
+                Run Keyword And Expect Error        *
+                ...  Put object        ${USER_KEY}    ${FILE_S}     ${CID}           ${EMPTY}       ${FILE_USR_HEADER}
+                Run Keyword And Expect Error        *
+                ...  Get object        ${USER_KEY}    ${CID}        ${S_OID_USER}    ${EMPTY}       local_file_eacl
+                Run Keyword And Expect Error        *
+                ...  Search object     ${USER_KEY}    ${CID}        ${EMPTY}         ${EMPTY}       ${FILE_USR_HEADER}
+                Run Keyword And Expect Error        *
+                ...  Head object       ${USER_KEY}    ${CID}        ${S_OID_USER}    ${EMPTY}
+                Run Keyword And Expect Error        *
+                ...  Get Range         ${USER_KEY}    ${CID}        ${S_OID_USER}    s_get_range    ${EMPTY}      0:256
+                Run Keyword And Expect Error        *
+                ...  Delete object     ${USER_KEY}    ${CID}        ${S_OID_USER}    ${EMPTY}
 
-    ${rule1}=               Create Dictionary    Operation=PUT             Access=ALLOW    Role=USER
-    ${rule2}=               Create Dictionary    Operation=SEARCH          Access=ALLOW    Role=USER
+    ${rule1} =          Create Dictionary       Operation=PUT           Access=ALLOW    Role=USER
+    ${rule2} =          Create Dictionary       Operation=SEARCH        Access=ALLOW    Role=USER
+    ${eACL_gen} =       Create List             ${rule1}    ${rule2}
 
-    ${eACL_gen}=            Create List    ${rule1}    ${rule2}
+    ${EACL_TOKEN} =     Form BearerToken File       ${USER_KEY}    ${CID}   ${eACL_gen}
 
-                            Form BearerToken file               ${USER_KEY}    ${CID}    bearer_allow_all_user   ${eACL_gen}   100500
-
-                            Run Keyword And Expect Error        *
-                            ...  Put object            ${USER_KEY}    ${FILE_S}     ${CID}           bearer_allow_all_user       ${FILE_USR_HEADER}
-                            Run Keyword And Expect Error        *
-                            ...  Search object                  ${USER_KEY}    ${CID}        ${EMPTY}         bearer_allow_all_user       ${FILE_USR_HEADER}
+                Run Keyword And Expect Error        *
+                ...  Put object        ${USER_KEY}    ${FILE_S}     ${CID}       ${EACL_TOKEN}       ${FILE_USR_HEADER}
+                Run Keyword And Expect Error        *
+                ...  Search object     ${USER_KEY}    ${CID}        ${EMPTY}     ${EACL_TOKEN}       ${FILE_USR_HEADER}

--- a/robot/testsuites/integration/acl/acl_bearer_request_filter_xheader_deny.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_request_filter_xheader_deny.robot
@@ -1,10 +1,12 @@
 *** Settings ***
 Variables   ../../../variables/common.py
-Library     ../${RESOURCES}/neofs.py
-Library     ../${RESOURCES}/payment_neogo.py
 
 Library     Collections
+Library     neofs.py
+Library     acl.py
+Library     payment_neogo.py
 
+Resource    ../../../variables/eacl_tables.robot
 Resource    common_steps_acl_bearer.robot
 Resource    ../${RESOURCES}/payment_operations.robot
 Resource    ../${RESOURCES}/setup_teardown.robot
@@ -25,7 +27,6 @@ BearerToken Operations
                             Check eACL Allow All Bearer Filter Requst Equal Deny
 
                             Log    Check Bearer token with complex object
-
                             Generate file    ${COMPLEX_OBJ_SIZE}
                             Check eACL Allow All Bearer Filter Requst Equal Deny
 
@@ -37,10 +38,10 @@ BearerToken Operations
 
 Check eACL Allow All Bearer Filter Requst Equal Deny
     ${CID} =                Create Container Public
-    ${S_OID_USER} =         Put object                 ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${FILE_USR_HEADER}
-    ${S_OID_USER_2} =       Put object                 ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${EMPTY}
-    ${D_OID_USER} =         Put object                 ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${FILE_USR_HEADER_DEL}
-    @{S_OBJ_H} =	    Create List	               ${S_OID_USER}
+    ${S_OID_USER} =         Put object         ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${FILE_USR_HEADER}
+    ${S_OID_USER_2} =       Put object         ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${EMPTY}
+    ${D_OID_USER} =         Put object         ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${FILE_USR_HEADER_DEL}
+    @{S_OBJ_H} =	    Create List	       ${S_OID_USER}
 
 
     ${filters}=             Create Dictionary    headerType=REQUEST    matchType=STRING_EQUAL    key=a    value=256
@@ -52,27 +53,28 @@ Check eACL Allow All Bearer Filter Requst Equal Deny
     ${rule6}=               Create Dictionary    Operation=GETRANGE        Access=DENY    Role=USER    Filters=${filters}
     ${rule7}=               Create Dictionary    Operation=GETRANGEHASH    Access=DENY    Role=USER    Filters=${filters}
     ${eACL_gen}=            Create List    ${rule1}    ${rule2}    ${rule3}    ${rule4}    ${rule5}    ${rule6}    ${rule7}
-                            Form BearerToken file               ${USER_KEY}    ${CID}    bearer_allow_all_user   ${eACL_gen}   100500
 
-                            Put object      ${USER_KEY}    ${FILE_S}     ${CID}           bearer_allow_all_user    ${FILE_OTH_HEADER}       ${EMPTY}      --xhdr a=2
-                            Get object    ${USER_KEY}    ${CID}        ${S_OID_USER}    bearer_allow_all_user    local_file_eacl          ${EMPTY}      --xhdr a=2
-                            Search object            ${USER_KEY}    ${CID}        ${EMPTY}         bearer_allow_all_user    ${FILE_USR_HEADER}       ${S_OBJ_H}    --xhdr a=2
-                            Head object              ${USER_KEY}    ${CID}        ${S_OID_USER}    bearer_allow_all_user    ${EMPTY}                 --xhdr a=2
-                            Get Range                ${USER_KEY}    ${CID}        ${S_OID_USER}    s_get_range              bearer_allow_all_user    0:256         --xhdr a=2
-                            Get Range Hash           ${USER_KEY}    ${CID}        ${S_OID_USER}    bearer_allow_all_user    0:256                    --xhdr a=2
-                            Delete object            ${USER_KEY}    ${CID}        ${D_OID_USER}    bearer_allow_all_user    --xhdr a=2
+    ${EACL_TOKEN} =         Form BearerToken File       ${USER_KEY}    ${CID}    ${eACL_gen}
 
-                            Run Keyword And Expect Error    *
-                            ...  Put object             ${USER_KEY}    ${FILE_S}    ${CID}           bearer_allow_all_user    ${FILE_USR_HEADER}       ${EMPTY}       --xhdr a=256
-                            Run Keyword And Expect Error    *
-                            ...  Get object           ${USER_KEY}    ${CID}       ${S_OID_USER}    bearer_allow_all_user    local_file_eacl          ${EMPTY}       --xhdr a=256
-                            Run Keyword And Expect Error    *
-                            ...  Search object                   ${USER_KEY}    ${CID}       ${EMPTY}         bearer_allow_all_user    ${FILE_USR_HEADER}       ${EMPTY}       --xhdr a=256
-                            Run Keyword And Expect Error    *
-                            ...  Head object                     ${USER_KEY}    ${CID}       ${S_OID_USER}    bearer_allow_all_user    ${EMPTY}                 --xhdr a=256
-                            Run Keyword And Expect Error    *
-                            ...  Get Range                       ${USER_KEY}    ${CID}       ${S_OID_USER}    s_get_range              bearer_allow_all_user    0:256          --xhdr a=256
-                            Run Keyword And Expect Error    *
-                            ...  Get Range Hash                  ${USER_KEY}    ${CID}       ${S_OID_USER}    bearer_allow_all_user    0:256                    --xhdr a=256
-                            Run Keyword And Expect Error    *
-                            ...  Delete object                   ${USER_KEY}    ${CID}       ${S_OID_USER}    bearer_allow_all_user    --xhdr a=256
+                        Put object      ${USER_KEY}    ${FILE_S}     ${CID}           ${EACL_TOKEN}    ${FILE_OTH_HEADER}   ${EMPTY}      --xhdr a=2
+                        Get object      ${USER_KEY}    ${CID}        ${S_OID_USER}    ${EACL_TOKEN}    local_file_eacl      ${EMPTY}      --xhdr a=2
+                        Search object   ${USER_KEY}    ${CID}        ${EMPTY}         ${EACL_TOKEN}    ${FILE_USR_HEADER}   ${S_OBJ_H}    --xhdr a=2
+                        Head object     ${USER_KEY}    ${CID}        ${S_OID_USER}    ${EACL_TOKEN}    ${EMPTY}         --xhdr a=2
+                        Get Range       ${USER_KEY}    ${CID}        ${S_OID_USER}    s_get_range      ${EACL_TOKEN}    0:256         --xhdr a=2
+                        Get Range Hash  ${USER_KEY}    ${CID}        ${S_OID_USER}    ${EACL_TOKEN}    0:256            --xhdr a=2
+                        Delete object   ${USER_KEY}    ${CID}        ${D_OID_USER}    ${EACL_TOKEN}    --xhdr a=2
+
+                        Run Keyword And Expect Error    *
+                        ...  Put object     ${USER_KEY}    ${FILE_S}    ${CID}       ${EACL_TOKEN}    ${FILE_USR_HEADER}       ${EMPTY}   --xhdr a=256
+                        Run Keyword And Expect Error    *
+                        ...  Get object     ${USER_KEY}    ${CID}       ${S_OID_USER}    ${EACL_TOKEN}    local_file_eacl      ${EMPTY}   --xhdr a=256
+                        Run Keyword And Expect Error    *
+                        ...  Search object   ${USER_KEY}    ${CID}       ${EMPTY}     ${EACL_TOKEN}    ${FILE_USR_HEADER}   ${EMPTY}   --xhdr a=256
+                        Run Keyword And Expect Error    *
+                        ...  Head object     ${USER_KEY}    ${CID}       ${S_OID_USER}    ${EACL_TOKEN}    ${EMPTY}     --xhdr a=256
+                        Run Keyword And Expect Error    *
+                        ...  Get Range       ${USER_KEY}    ${CID}       ${S_OID_USER}    s_get_range      ${EACL_TOKEN}    0:256      --xhdr a=256
+                        Run Keyword And Expect Error    *
+                        ...  Get Range Hash  ${USER_KEY}    ${CID}       ${S_OID_USER}    ${EACL_TOKEN}    0:256    --xhdr a=256
+                        Run Keyword And Expect Error    *
+                        ...  Delete object   ${USER_KEY}    ${CID}       ${S_OID_USER}    ${EACL_TOKEN}    --xhdr a=256

--- a/robot/testsuites/integration/acl/acl_bearer_request_filter_xheader_equal.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_request_filter_xheader_equal.robot
@@ -1,10 +1,12 @@
 *** Settings ***
 Variables   ../../../variables/common.py
-Library     ../${RESOURCES}/neofs.py
-Library     ../${RESOURCES}/payment_neogo.py
 
 Library     Collections
+Library     acl.py
+Library     neofs.py
+Library     payment_neogo.py
 
+Resource   ../../../variables/eacl_tables.robot
 Resource    common_steps_acl_bearer.robot
 Resource    ../${RESOURCES}/payment_operations.robot
 Resource    ../${RESOURCES}/setup_teardown.robot
@@ -13,7 +15,7 @@ Resource    ../${RESOURCES}/setup_teardown.robot
 *** Test cases ***
 BearerToken Operations with Filter Requst Equal
     [Documentation]         Testcase to validate NeoFS operations with BearerToken with Filter Requst Equal.
-    [Tags]                  ACL  NeoFS  NeoCLI BearerToken
+    [Tags]                  ACL  NeoFSCLI BearerToken
     [Timeout]               20 min
 
     [Setup]                 Setup
@@ -26,7 +28,6 @@ BearerToken Operations with Filter Requst Equal
                             Check eACL Deny and Allow All Bearer Filter Requst Equal
 
                             Log    Check Bearer token with complex object
-
                             Generate file    ${COMPLEX_OBJ_SIZE}
                             Check eACL Deny and Allow All Bearer Filter Requst Equal
 
@@ -38,51 +39,51 @@ BearerToken Operations with Filter Requst Equal
 
 Check eACL Deny and Allow All Bearer Filter Requst Equal
     ${CID} =                Create Container Public
-    ${S_OID_USER} =         Put object                 ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${FILE_USR_HEADER}
-    ${S_OID_USER_2} =       Put object                 ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${EMPTY}
-    ${D_OID_USER} =         Put object                 ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${FILE_USR_HEADER_DEL}
-    @{S_OBJ_H} =	    Create List	               ${S_OID_USER}
+    ${S_OID_USER} =         Put object         ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${FILE_USR_HEADER}
+    ${S_OID_USER_2} =       Put object         ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${EMPTY}
+    ${D_OID_USER} =         Put object         ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${FILE_USR_HEADER_DEL}
+    @{S_OBJ_H} =	    Create List	       ${S_OID_USER}
 
-                            Put object                 ${USER_KEY}    ${FILE_S}     ${CID}                   ${EMPTY}              ${FILE_OTH_HEADER}
-                            Get object                 ${USER_KEY}    ${CID}        ${S_OID_USER}            ${EMPTY}              local_file_eacl
-                            Search object              ${USER_KEY}    ${CID}        ${EMPTY}                 ${EMPTY}              ${FILE_USR_HEADER}         ${S_OBJ_H}
-                            Head object                ${USER_KEY}    ${CID}        ${S_OID_USER}            ${EMPTY}
-                            Get Range                  ${USER_KEY}    ${CID}        ${S_OID_USER}            s_get_range            ${EMPTY}              0:256
-                            Delete object              ${USER_KEY}    ${CID}        ${D_OID_USER}            ${EMPTY}
+                            Put object         ${USER_KEY}    ${FILE_S}     ${CID}               ${EMPTY}      ${FILE_OTH_HEADER}
+                            Get object         ${USER_KEY}    ${CID}        ${S_OID_USER}        ${EMPTY}      local_file_eacl
+                            Search object      ${USER_KEY}    ${CID}        ${EMPTY}             ${EMPTY}      ${FILE_USR_HEADER}     ${S_OBJ_H}
+                            Head object        ${USER_KEY}    ${CID}        ${S_OID_USER}        ${EMPTY}
+                            Get Range          ${USER_KEY}    ${CID}        ${S_OID_USER}        s_get_range    ${EMPTY}      0:256
+                            Delete object      ${USER_KEY}    ${CID}        ${D_OID_USER}        ${EMPTY}
 
-                            Set eACL                   ${USER_KEY}    ${CID}        ${EACL_DENY_ALL_USER}
+                            Set eACL           ${USER_KEY}    ${CID}        ${EACL_DENY_ALL_USER}
 
                             # The current ACL cache lifetime is 30 sec
                             Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}
 
-    ${filters}=             Create Dictionary    headerType=REQUEST    matchType=STRING_EQUAL    key=a    value=256
-    ${rule1}=               Create Dictionary    Operation=GET             Access=ALLOW    Role=USER    Filters=${filters}
-    ${rule2}=               Create Dictionary    Operation=HEAD            Access=ALLOW    Role=USER    Filters=${filters}
-    ${rule3}=               Create Dictionary    Operation=PUT             Access=ALLOW    Role=USER    Filters=${filters}
-    ${rule4}=               Create Dictionary    Operation=DELETE          Access=ALLOW    Role=USER    Filters=${filters}
-    ${rule5}=               Create Dictionary    Operation=SEARCH          Access=ALLOW    Role=USER    Filters=${filters}
-    ${rule6}=               Create Dictionary    Operation=GETRANGE        Access=ALLOW    Role=USER    Filters=${filters}
-    ${rule7}=               Create Dictionary    Operation=GETRANGEHASH    Access=ALLOW    Role=USER    Filters=${filters}
-    ${eACL_gen}=            Create List    ${rule1}    ${rule2}    ${rule3}    ${rule4}    ${rule5}    ${rule6}    ${rule7}
-                            Form BearerToken file               ${USER_KEY}    ${CID}    bearer_allow_all_user   ${eACL_gen}   100500
+    ${filters}=         Create Dictionary    headerType=REQUEST    matchType=STRING_EQUAL    key=a    value=256
+    ${rule1}=           Create Dictionary    Operation=GET             Access=ALLOW    Role=USER    Filters=${filters}
+    ${rule2}=           Create Dictionary    Operation=HEAD            Access=ALLOW    Role=USER    Filters=${filters}
+    ${rule3}=           Create Dictionary    Operation=PUT             Access=ALLOW    Role=USER    Filters=${filters}
+    ${rule4}=           Create Dictionary    Operation=DELETE          Access=ALLOW    Role=USER    Filters=${filters}
+    ${rule5}=           Create Dictionary    Operation=SEARCH          Access=ALLOW    Role=USER    Filters=${filters}
+    ${rule6}=           Create Dictionary    Operation=GETRANGE        Access=ALLOW    Role=USER    Filters=${filters}
+    ${rule7}=           Create Dictionary    Operation=GETRANGEHASH    Access=ALLOW    Role=USER    Filters=${filters}
+    ${eACL_gen}=        Create List    ${rule1}    ${rule2}    ${rule3}    ${rule4}    ${rule5}    ${rule6}    ${rule7}
+    ${EACL_TOKEN} =     Form BearerToken File      ${USER_KEY}    ${CID}   ${eACL_gen}
 
-                            Run Keyword And Expect Error    *
-                            ...  Put object        ${USER_KEY}    ${FILE_S}    ${CID}           ${EMPTY}       ${FILE_USR_HEADER}
-                            Run Keyword And Expect Error    *
-                            ...  Get object      ${USER_KEY}    ${CID}       ${S_OID_USER}    ${EMPTY}       local_file_eacl
-                            Run Keyword And Expect Error    *
-                            ...  Search object              ${USER_KEY}    ${CID}       ${EMPTY}         ${EMPTY}       ${FILE_USR_HEADER}    ${S_OBJ_H}
-                            Run Keyword And Expect Error    *
-                            ...  Head object                ${USER_KEY}    ${CID}       ${S_OID_USER}    ${EMPTY}
-                            Run Keyword And Expect Error    *
-                            ...  Get Range                  ${USER_KEY}    ${CID}       ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
-                            Run Keyword And Expect Error    *
-                            ...  Delete object              ${USER_KEY}    ${CID}       ${S_OID_USER}    ${EMPTY}
+                        Run Keyword And Expect Error    *
+                        ...  Put object     ${USER_KEY}    ${FILE_S}    ${CID}           ${EMPTY}       ${FILE_USR_HEADER}
+                        Run Keyword And Expect Error    *
+                        ...  Get object     ${USER_KEY}    ${CID}       ${S_OID_USER}    ${EMPTY}       local_file_eacl
+                        Run Keyword And Expect Error    *
+                        ...  Search object  ${USER_KEY}    ${CID}       ${EMPTY}         ${EMPTY}       ${FILE_USR_HEADER}    ${S_OBJ_H}
+                        Run Keyword And Expect Error    *
+                        ...  Head object    ${USER_KEY}    ${CID}       ${S_OID_USER}    ${EMPTY}
+                        Run Keyword And Expect Error    *
+                        ...  Get Range      ${USER_KEY}    ${CID}       ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+                        Run Keyword And Expect Error    *
+                        ...  Delete object  ${USER_KEY}    ${CID}       ${S_OID_USER}    ${EMPTY}
 
-                            Put object             ${USER_KEY}    ${FILE_S}    ${CID}           bearer_allow_all_user    ${FILE_USR_HEADER}       ${EMPTY}       --xhdr a=256
-                            Get object           ${USER_KEY}    ${CID}       ${S_OID_USER}    bearer_allow_all_user    local_file_eacl          ${EMPTY}       --xhdr a=256
-                            Search object                   ${USER_KEY}    ${CID}       ${EMPTY}         bearer_allow_all_user    ${FILE_USR_HEADER}       ${EMPTY}       --xhdr a=256
-                            Head object                     ${USER_KEY}    ${CID}       ${S_OID_USER}    bearer_allow_all_user    ${EMPTY}                 --xhdr a=256
-                            Get Range                       ${USER_KEY}    ${CID}       ${S_OID_USER}    s_get_range              bearer_allow_all_user    0:256          --xhdr a=256
-                            Get Range Hash                  ${USER_KEY}    ${CID}       ${S_OID_USER}    bearer_allow_all_user    0:256                    --xhdr a=256
-                            Delete object                   ${USER_KEY}    ${CID}       ${S_OID_USER}    bearer_allow_all_user    --xhdr a=256
+                        Put object      ${USER_KEY}    ${FILE_S}    ${CID}           ${EACL_TOKEN}    ${FILE_USR_HEADER}       ${EMPTY}       --xhdr a=256
+                        Get object      ${USER_KEY}    ${CID}       ${S_OID_USER}    ${EACL_TOKEN}    local_file_eacl          ${EMPTY}       --xhdr a=256
+                        Search object   ${USER_KEY}    ${CID}       ${EMPTY}         ${EACL_TOKEN}    ${FILE_USR_HEADER}       ${EMPTY}       --xhdr a=256
+                        Head object     ${USER_KEY}    ${CID}       ${S_OID_USER}    ${EACL_TOKEN}    ${EMPTY}         --xhdr a=256
+                        Get Range       ${USER_KEY}    ${CID}       ${S_OID_USER}    s_get_range      ${EACL_TOKEN}    0:256          --xhdr a=256
+                        Get Range Hash  ${USER_KEY}    ${CID}       ${S_OID_USER}    ${EACL_TOKEN}    0:256            --xhdr a=256
+                        Delete object   ${USER_KEY}    ${CID}       ${S_OID_USER}    ${EACL_TOKEN}    --xhdr a=256

--- a/robot/testsuites/integration/acl/acl_bearer_request_filter_xheader_not_equal.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_request_filter_xheader_not_equal.robot
@@ -1,10 +1,12 @@
 *** Settings ***
 Variables   ../../../variables/common.py
-Library     ../${RESOURCES}/neofs.py
-Library     ../${RESOURCES}/payment_neogo.py
 
 Library     Collections
+Library     acl.py
+Library     neofs.py
+Library     payment_neogo.py
 
+Resource    ../../../variables/eacl_tables.robot
 Resource    common_steps_acl_bearer.robot
 Resource    ../${RESOURCES}/payment_operations.robot
 Resource    ../${RESOURCES}/setup_teardown.robot
@@ -13,13 +15,12 @@ Resource    ../${RESOURCES}/setup_teardown.robot
 *** Test cases ***
 BearerToken Operations with Filter Requst NotEqual
     [Documentation]         Testcase to validate NeoFS operations with BearerToken with Filter Requst NotEqual.
-    [Tags]                  ACL  NeoFS  NeoCLI BearerToken
+    [Tags]                  ACL  NeoFSCLI BearerToken
     [Timeout]               20 min
 
     [Setup]                 Setup
 
                             Generate Keys
-                            Prepare eACL Role rules
 
                             Log    Check Bearer token with simple object
                             Generate file    ${SIMPLE_OBJ_SIZE}
@@ -36,51 +37,51 @@ BearerToken Operations with Filter Requst NotEqual
 
 Check eACL Deny and Allow All Bearer Filter Requst NotEqual
     ${CID} =                Create Container Public
-    ${S_OID_USER} =         Put object                 ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${FILE_USR_HEADER}
-    ${S_OID_USER_2} =       Put object                 ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${EMPTY}
-    ${D_OID_USER} =         Put object                 ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${FILE_USR_HEADER_DEL}
-    @{S_OBJ_H} =	    Create List	               ${S_OID_USER}
+    ${S_OID_USER} =         Put object         ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${FILE_USR_HEADER}
+    ${S_OID_USER_2} =       Put object         ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${EMPTY}
+    ${D_OID_USER} =         Put object         ${USER_KEY}     ${FILE_S}   ${CID}  ${EMPTY}  ${FILE_USR_HEADER_DEL}
+    @{S_OBJ_H} =	    Create List	       ${S_OID_USER}
 
-                            Put object                 ${USER_KEY}    ${FILE_S}     ${CID}                   ${EMPTY}              ${FILE_OTH_HEADER}
-                            Get object                 ${USER_KEY}    ${CID}        ${S_OID_USER}            ${EMPTY}              local_file_eacl
-                            Search object              ${USER_KEY}    ${CID}        ${EMPTY}                 ${EMPTY}              ${FILE_USR_HEADER}         ${S_OBJ_H}
-                            Head object                ${USER_KEY}    ${CID}        ${S_OID_USER}            ${EMPTY}
-                            Get Range                  ${USER_KEY}    ${CID}        ${S_OID_USER}            s_get_range            ${EMPTY}              0:256
-                            Delete object              ${USER_KEY}    ${CID}        ${D_OID_USER}            ${EMPTY}
+                            Put object         ${USER_KEY}    ${FILE_S}     ${CID}           ${EMPTY}      ${FILE_OTH_HEADER}
+                            Get object         ${USER_KEY}    ${CID}        ${S_OID_USER}    ${EMPTY}      local_file_eacl
+                            Search object      ${USER_KEY}    ${CID}        ${EMPTY}         ${EMPTY}      ${FILE_USR_HEADER}     ${S_OBJ_H}
+                            Head object        ${USER_KEY}    ${CID}        ${S_OID_USER}    ${EMPTY}
+                            Get Range          ${USER_KEY}    ${CID}        ${S_OID_USER}    s_get_range       ${EMPTY}      0:256
+                            Delete object      ${USER_KEY}    ${CID}        ${D_OID_USER}    ${EMPTY}
 
-                            Set eACL                   ${USER_KEY}    ${CID}        ${EACL_DENY_ALL_USER}
+                            Set eACL           ${USER_KEY}    ${CID}        ${EACL_DENY_ALL_USER}
 
                             # The current ACL cache lifetime is 30 sec
                             Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}
 
-    ${filters}=             Create Dictionary    headerType=REQUEST    matchType=STRING_NOT_EQUAL    key=a    value=256
-    ${rule1}=               Create Dictionary    Operation=GET             Access=ALLOW    Role=USER    Filters=${filters}
-    ${rule2}=               Create Dictionary    Operation=HEAD            Access=ALLOW    Role=USER    Filters=${filters}
-    ${rule3}=               Create Dictionary    Operation=PUT             Access=ALLOW    Role=USER    Filters=${filters}
-    ${rule4}=               Create Dictionary    Operation=DELETE          Access=ALLOW    Role=USER    Filters=${filters}
-    ${rule5}=               Create Dictionary    Operation=SEARCH          Access=ALLOW    Role=USER    Filters=${filters}
-    ${rule6}=               Create Dictionary    Operation=GETRANGE        Access=ALLOW    Role=USER    Filters=${filters}
-    ${rule7}=               Create Dictionary    Operation=GETRANGEHASH    Access=ALLOW    Role=USER    Filters=${filters}
-    ${eACL_gen}=            Create List    ${rule1}    ${rule2}    ${rule3}    ${rule4}    ${rule5}    ${rule6}    ${rule7}
-                            Form BearerToken file               ${USER_KEY}    ${CID}    bearer_allow_all_user   ${eACL_gen}   100500
+    ${filters}=         Create Dictionary    headerType=REQUEST    matchType=STRING_NOT_EQUAL    key=a    value=256
+    ${rule1}=           Create Dictionary    Operation=GET             Access=ALLOW    Role=USER    Filters=${filters}
+    ${rule2}=           Create Dictionary    Operation=HEAD            Access=ALLOW    Role=USER    Filters=${filters}
+    ${rule3}=           Create Dictionary    Operation=PUT             Access=ALLOW    Role=USER    Filters=${filters}
+    ${rule4}=           Create Dictionary    Operation=DELETE          Access=ALLOW    Role=USER    Filters=${filters}
+    ${rule5}=           Create Dictionary    Operation=SEARCH          Access=ALLOW    Role=USER    Filters=${filters}
+    ${rule6}=           Create Dictionary    Operation=GETRANGE        Access=ALLOW    Role=USER    Filters=${filters}
+    ${rule7}=           Create Dictionary    Operation=GETRANGEHASH    Access=ALLOW    Role=USER    Filters=${filters}
+    ${eACL_gen}=        Create List    ${rule1}    ${rule2}    ${rule3}    ${rule4}    ${rule5}    ${rule6}    ${rule7}
+    ${EACL_TOKEN} =     Form BearerToken File      ${USER_KEY}    ${CID}    ${eACL_gen}
 
-                            Run Keyword And Expect Error    *
-                            ...  Put object        ${USER_KEY}    ${FILE_S}    ${CID}           ${EMPTY}       ${FILE_USR_HEADER}
-                            Run Keyword And Expect Error    *
-                            ...  Get object      ${USER_KEY}    ${CID}       ${S_OID_USER}    ${EMPTY}       local_file_eacl
-                            #Run Keyword And Expect Error    *
-                            #...  Search object              ${USER_KEY}    ${CID}       ${EMPTY}         ${EMPTY}       ${FILE_USR_HEADER}    ${S_OBJ_H}
-                            Run Keyword And Expect Error    *
-                            ...  Head object                ${USER_KEY}    ${CID}       ${S_OID_USER}    ${EMPTY}
-                            Run Keyword And Expect Error    *
-                            ...  Get Range                  ${USER_KEY}    ${CID}       ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
-                            Run Keyword And Expect Error    *
-                            ...  Delete object              ${USER_KEY}    ${CID}       ${S_OID_USER}    ${EMPTY}
+                        Run Keyword And Expect Error    *
+                        ...  Put object      ${USER_KEY}    ${FILE_S}    ${CID}           ${EMPTY}       ${FILE_USR_HEADER}
+                        Run Keyword And Expect Error    *
+                        ...  Get object      ${USER_KEY}    ${CID}       ${S_OID_USER}    ${EMPTY}       local_file_eacl
+                        #Run Keyword And Expect Error    *
+                        #...  Search object  ${USER_KEY}    ${CID}       ${EMPTY}         ${EMPTY}       ${FILE_USR_HEADER}    ${S_OBJ_H}
+                        Run Keyword And Expect Error    *
+                        ...  Head object     ${USER_KEY}    ${CID}       ${S_OID_USER}    ${EMPTY}
+                        Run Keyword And Expect Error    *
+                        ...  Get Range       ${USER_KEY}    ${CID}       ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+                        Run Keyword And Expect Error    *
+                        ...  Delete object   ${USER_KEY}    ${CID}       ${S_OID_USER}    ${EMPTY}
 
-                            Put object             ${USER_KEY}    ${FILE_S}    ${CID}           bearer_allow_all_user    ${FILE_USR_HEADER}      ${EMPTY}       --xhdr a=2
-                            Get object           ${USER_KEY}    ${CID}       ${S_OID_USER}    bearer_allow_all_user    local_file_eacl          ${EMPTY}       --xhdr a=2
-                            Search object                   ${USER_KEY}    ${CID}       ${EMPTY}         bearer_allow_all_user    ${FILE_USR_HEADER}       ${EMPTY}       --xhdr a=2
-                            Head object                     ${USER_KEY}    ${CID}       ${S_OID_USER}    bearer_allow_all_user    ${EMPTY}                 --xhdr a=2
-                            Get Range                       ${USER_KEY}    ${CID}       ${S_OID_USER}    s_get_range              bearer_allow_all_user    0:256          --xhdr a=2
-                            Get Range Hash                  ${USER_KEY}    ${CID}       ${S_OID_USER}    bearer_allow_all_user    0:256                    --xhdr a=2
-                            Delete object                   ${USER_KEY}    ${CID}       ${S_OID_USER}    bearer_allow_all_user    --xhdr a=2
+                        Put object       ${USER_KEY}    ${FILE_S}    ${CID}           ${EACL_TOKEN}    ${FILE_USR_HEADER}   ${EMPTY}       --xhdr a=2
+                        Get object       ${USER_KEY}    ${CID}       ${S_OID_USER}    ${EACL_TOKEN}    local_file_eacl      ${EMPTY}       --xhdr a=2
+                        Search object    ${USER_KEY}    ${CID}       ${EMPTY}         ${EACL_TOKEN}    ${FILE_USR_HEADER}   ${EMPTY}       --xhdr a=2
+                        Head object      ${USER_KEY}    ${CID}       ${S_OID_USER}    ${EACL_TOKEN}    ${EMPTY}         --xhdr a=2
+                        Get Range        ${USER_KEY}    ${CID}       ${S_OID_USER}    s_get_range      ${EACL_TOKEN}    0:256          --xhdr a=2
+                        Get Range Hash   ${USER_KEY}    ${CID}       ${S_OID_USER}    ${EACL_TOKEN}    0:256            --xhdr a=2
+                        Delete object    ${USER_KEY}    ${CID}       ${S_OID_USER}    ${EACL_TOKEN}    --xhdr a=2

--- a/robot/testsuites/integration/acl/acl_extended_actions_pubkey.robot
+++ b/robot/testsuites/integration/acl/acl_extended_actions_pubkey.robot
@@ -1,9 +1,10 @@
 *** Settings ***
 Variables    ../../../variables/common.py
-Library      ../${RESOURCES}/neofs.py
-Library      ../${RESOURCES}/payment_neogo.py
 
 Library      Collections
+Library      acl.py
+Library      neofs.py
+Library      payment_neogo.py
 
 Resource     common_steps_acl_extended.robot
 Resource     ../${RESOURCES}/payment_operations.robot

--- a/robot/testsuites/integration/acl/acl_extended_filters.robot
+++ b/robot/testsuites/integration/acl/acl_extended_filters.robot
@@ -1,8 +1,9 @@
 *** Settings ***
 Variables       ../../../variables/common.py
 
-Library         ../${RESOURCES}/neofs.py
-Library         ../${RESOURCES}/payment_neogo.py
+Library         acl.py
+Library         neofs.py
+Library         payment_neogo.py
 Library         Collections
 
 Resource        common_steps_acl_extended.robot


### PR DESCRIPTION
- fixed few ACL test cases
- `Form BearerToken File` now takes three arguments instead of five and returns absolute file path to bearer token
- ACL related keywords moved to separate library
- `_cmd_run` moved to separarte library
- some code corrected according to pylint