### PR TITLE
Fixed ACL import ; made `Verify Split Chain`  work

### DIFF
--- a/robot/resources/lib/neofs.py
+++ b/robot/resources/lib/neofs.py
@@ -287,10 +287,15 @@ def verify_split_chain(private_key: str, cid: str, oid: str):
                 # Recursive chain validation up to the first object
                 final_verif_data = _verify_child_link(private_key, cid, oid, header_last_parsed, final_verif_data)
                 break
+            logger.info(f"Found Split Object with header:\n\t{parsed_header_virtual}")
+            logger.info("Continue to search Last Split Object")
 
-        except:
-            if marker_last_obj == 0:
-                raise Exception("Latest object has not been found.")
+        except RuntimeError as e:
+            logger.info(f"Failed while collectiong Split Objects: {e}")
+            continue
+
+    if marker_last_obj == 0:
+        raise Exception("Last object has not been found")
 
     # Get Linking object
     logger.info("Compare Split objects result information with Linking object.")
@@ -333,9 +338,14 @@ def verify_split_chain(private_key: str, cid: str, oid: str):
                                     f"is not equal to expected ({final_verif_data['Split ID']})")
 
                 break
-        except:
-            if marker_link_obj == 0:
-                raise Exception("Linked object has not been found.")
+            logger.info(f"Found Linking Object with header:\n\t{parsed_header_virtual}")
+            logger.info("Continue to search Linking Object")
+        except RuntimeError as e:
+            logger.info(f"Failed while collecting Split Object: {e}")
+            continue
+
+    if marker_link_obj == 0:
+        raise Exception("Linked object has not been found")
 
 
     logger.info("Compare Split objects result information with Virtual object.")
@@ -820,7 +830,7 @@ def get_object(private_key: str, cid: str, oid: str, bearer_token: str,
 
     file_path = f"{ASSETS_DIR}/{write_object}"
 
-    logger.info("Going to put the object")
+    logger.info("Going to get the object")
     if not endpoint:
       endpoint = random.sample(_get_storage_nodes(), 1)[0]
 

--- a/robot/testsuites/integration/acl/acl_extended_actions_other.robot
+++ b/robot/testsuites/integration/acl/acl_extended_actions_other.robot
@@ -1,14 +1,15 @@
 *** Settings ***
 Variables    ../../../variables/common.py
 
-Library      Collections
-Library      ../${RESOURCES}/neofs.py
-Library      ../${RESOURCES}/payment_neogo.py
+Library     Collections
+Library     neofs.py
+Library     payment_neogo.py
+Library     acl.py
 
 Resource     common_steps_acl_extended.robot
 Resource     ../${RESOURCES}/payment_operations.robot
 Resource     ../${RESOURCES}/setup_teardown.robot
-Resource       ../../../variables/eacl_tables.robot
+Resource     ../../../variables/eacl_tables.robot
 
 *** Test cases ***
 Extended ACL Operations

--- a/robot/testsuites/integration/acl/acl_extended_actions_system.robot
+++ b/robot/testsuites/integration/acl/acl_extended_actions_system.robot
@@ -1,9 +1,10 @@
 *** Settings ***
 Variables       ../../../variables/common.py
 
-Library         Collections
-Library         ../${RESOURCES}/neofs.py
-Library         ../${RESOURCES}/payment_neogo.py
+Library     Collections
+Library     neofs.py
+Library     payment_neogo.py
+Library     acl.py
 
 Resource        common_steps_acl_extended.robot
 Resource        ../${RESOURCES}/payment_operations.robot

--- a/robot/testsuites/integration/acl/acl_extended_actions_user.robot
+++ b/robot/testsuites/integration/acl/acl_extended_actions_user.robot
@@ -1,8 +1,9 @@
 *** Settings ***
 Variables    ../../../variables/common.py
-Library      Collections
-Library      ../${RESOURCES}/neofs.py
-Library      ../${RESOURCES}/payment_neogo.py
+Library     Collections
+Library     neofs.py
+Library     payment_neogo.py
+Library     acl.py
 
 Resource     common_steps_acl_extended.robot
 Resource     ../${RESOURCES}/payment_operations.robot

--- a/robot/testsuites/integration/acl/acl_extended_compound.robot
+++ b/robot/testsuites/integration/acl/acl_extended_compound.robot
@@ -1,8 +1,9 @@
 *** Settings ***
 Variables    ../../../variables/common.py
-Library      Collections
-Library      ../${RESOURCES}/neofs.py
-Library      ../${RESOURCES}/payment_neogo.py
+Library     Collections
+Library     neofs.py
+Library     payment_neogo.py
+Library     acl.py
 
 Resource     common_steps_acl_extended.robot
 Resource     ../${RESOURCES}/payment_operations.robot


### PR DESCRIPTION
- `Verify Split Chain` failed if HEAD to first storage node failed; now it writes log message and continues with another storage node
- added missing imports of `acl.py` library

[Run](https://master.ci.nspcc.ru/job/Neofs_Int_Tests/331/artifact/testcases/artifacts/log.html) result: `Object Complex` succeded, ACL tests don't fail with "keyword not found" error