### PR TITLE
fixed "Form eACL json common file" keyword

### DIFF
--- a/robot/resources/lib/acl.py
+++ b/robot/resources/lib/acl.py
@@ -155,15 +155,16 @@ def sign_bearer_token(wif: str, eacl_rules_file: str):
     _cmd_run(cmd)
 
 
-@keyword('Form eACL json common file')
-def form_eacl_json_common_file(file_path: str, eacl_records: list) -> str:
+@keyword('Form eACL JSON Common File')
+def form_eacl_json_common_file(eacl_records: list) -> str:
     # Input role can be Role (USER, SYSTEM, OTHERS) or public key.
     eacl = {"records":[]}
+    file_path = f"{os.getcwd()}/{ASSETS_DIR}/{str(uuid.uuid4())}"
 
     for record in eacl_records:
         op_data = dict()
 
-        if record['Role'] == "USER" or record['Role'] == "SYSTEM" or record['Role'] == "OTHERS":
+        if Role(record['Role']):
             op_data = {
                         "operation": record['Operation'],
                         "action":    record['Access'],

--- a/robot/testsuites/integration/acl/acl_extended_actions_system.robot
+++ b/robot/testsuites/integration/acl/acl_extended_actions_system.robot
@@ -11,9 +11,6 @@ Resource        ../${RESOURCES}/payment_operations.robot
 Resource        ../${RESOURCES}/setup_teardown.robot
 Resource        ../../../variables/eacl_tables.robot
 
-*** Variables ***
-${SYSTEM_KEY} =     ${NEOFS_IR_WIF}
-
 
 *** Test cases ***
 Extended ACL Operations
@@ -23,7 +20,7 @@ Extended ACL Operations
 
     [Setup]                 Setup
 
-    ${WALLET}   ${ADDR}     ${USER_KEY} =   Prepare Wallet And Deposit    
+    ${WALLET}   ${ADDR}     ${USER_KEY} =   Prepare Wallet And Deposit
 
                             Log    Check extended ACL with simple object
                             Generate files    ${SIMPLE_OBJ_SIZE}
@@ -39,107 +36,106 @@ Extended ACL Operations
 *** Keywords ***
 
 Check eACL Deny and Allow All System
-    [Arguments]    ${USER_KEY}    ${FILE_S}
+    [Arguments]     ${USER_KEY}      ${FILE_S}
 
-    ${CID} =                Create Container Public    ${USER_KEY} 
+    ${CID} =                Create Container Public     ${USER_KEY}
 
-    ${S_OID_USER} =         Put object      ${USER_KEY}    ${FILE_S}    ${CID}    ${EMPTY}    ${FILE_USR_HEADER}
-    ${D_OID_USER_S} =       Put object      ${USER_KEY}    ${FILE_S}    ${CID}    ${EMPTY}    ${FILE_USR_HEADER_DEL}
-    ${D_OID_USER_SN} =      Put object      ${USER_KEY}    ${FILE_S}    ${CID}    ${EMPTY}    ${FILE_USR_HEADER_DEL}
+    ${S_OID_USER} =     Put object      ${USER_KEY}    ${FILE_S}    ${CID}    ${EMPTY}    ${FILE_USR_HEADER}
+    ${D_OID_USER_S} =   Put object      ${USER_KEY}    ${FILE_S}    ${CID}    ${EMPTY}    ${FILE_USR_HEADER_DEL}
+    ${D_OID_USER_SN} =  Put object      ${USER_KEY}    ${FILE_S}    ${CID}    ${EMPTY}    ${FILE_USR_HEADER_DEL}
 
-    @{S_OBJ_H} =	        Create List	             ${S_OID_USER}
+    @{S_OBJ_H} =	Create List	    ${S_OID_USER}
 
-    Put object      ${SYSTEM_KEY}       ${FILE_S}    ${CID}    ${EMPTY}    ${FILE_OTH_HEADER}
-    Put object      ${NEOFS_SN_WIF}    ${FILE_S}    ${CID}    ${EMPTY}    ${FILE_OTH_HEADER}
+                        Put object      ${NEOFS_IR_WIF}    ${FILE_S}    ${CID}    ${EMPTY}    ${FILE_OTH_HEADER}
+                        Put object      ${NEOFS_SN_WIF}    ${FILE_S}    ${CID}    ${EMPTY}    ${FILE_OTH_HEADER}
 
-    Get object    ${SYSTEM_KEY}       ${CID}    ${S_OID_USER}    ${EMPTY}    local_file_eacl
-    Get object    ${NEOFS_SN_WIF}    ${CID}    ${S_OID_USER}    ${EMPTY}    local_file_eacl
+                        Get object    ${NEOFS_IR_WIF}    ${CID}    ${S_OID_USER}    ${EMPTY}    local_file_eacl
+                        Get object    ${NEOFS_SN_WIF}    ${CID}    ${S_OID_USER}    ${EMPTY}    local_file_eacl
 
-    Search object            ${SYSTEM_KEY}       ${CID}    ${EMPTY}    ${EMPTY}    ${FILE_USR_HEADER}    ${S_OBJ_H}
-    Search object            ${NEOFS_SN_WIF}    ${CID}    ${EMPTY}    ${EMPTY}    ${FILE_USR_HEADER}    ${S_OBJ_H}
+                        Search object        ${NEOFS_IR_WIF}    ${CID}    ${EMPTY}    ${EMPTY}    ${FILE_USR_HEADER}    ${S_OBJ_H}
+                        Search object        ${NEOFS_SN_WIF}    ${CID}    ${EMPTY}    ${EMPTY}    ${FILE_USR_HEADER}    ${S_OBJ_H}
 
-    Head object              ${SYSTEM_KEY}       ${CID}    ${S_OID_USER}    ${EMPTY}
-    Head object              ${NEOFS_SN_WIF}    ${CID}    ${S_OID_USER}    ${EMPTY}
+                        Head object          ${NEOFS_IR_WIF}    ${CID}    ${S_OID_USER}    ${EMPTY}
+                        Head object          ${NEOFS_SN_WIF}    ${CID}    ${S_OID_USER}    ${EMPTY}
 
-    Get Range                ${SYSTEM_KEY}       ${CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
-    Get Range                ${NEOFS_SN_WIF}    ${CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+                        Get Range            ${NEOFS_IR_WIF}    ${CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+                        Get Range            ${NEOFS_SN_WIF}    ${CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
 
-    Get Range Hash           ${SYSTEM_KEY}       ${CID}    ${S_OID_USER}    ${EMPTY}    0:256
-    Get Range Hash           ${NEOFS_SN_WIF}    ${CID}    ${S_OID_USER}    ${EMPTY}    0:256
+                        Get Range Hash       ${NEOFS_IR_WIF}    ${CID}    ${S_OID_USER}    ${EMPTY}    0:256
+                        Get Range Hash       ${NEOFS_SN_WIF}    ${CID}    ${S_OID_USER}    ${EMPTY}    0:256
 
-    Delete object            ${SYSTEM_KEY}       ${CID}    ${D_OID_USER_S}     ${EMPTY}
-    Delete object            ${NEOFS_SN_WIF}    ${CID}    ${D_OID_USER_SN}    ${EMPTY}
+                        Delete object        ${NEOFS_IR_WIF}    ${CID}    ${D_OID_USER_S}     ${EMPTY}
+                        Delete object        ${NEOFS_SN_WIF}    ${CID}    ${D_OID_USER_SN}    ${EMPTY}
 
-    Set eACL                 ${USER_KEY}     ${CID}        ${EACL_DENY_ALL_SYSTEM}
+                        Set eACL             ${USER_KEY}     ${CID}       ${EACL_DENY_ALL_SYSTEM}
 
-    # The current ACL cache lifetime is 30 sec
-    Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}
+                        # The current ACL cache lifetime is 30 sec
+                        Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}
 
-    Run Keyword And Expect Error    *
-    ...  Put object        ${SYSTEM_KEY}       ${FILE_S}    ${CID}    ${EMPTY}    ${FILE_OTH_HEADER}
-    Run Keyword And Expect Error    *
-    ...  Put object        ${NEOFS_SN_WIF}    ${FILE_S}    ${CID}    ${EMPTY}    ${FILE_OTH_HEADER}
+                        Run Keyword And Expect Error    *
+                        ...  Put object        ${NEOFS_IR_WIF}    ${FILE_S}    ${CID}    ${EMPTY}    ${FILE_OTH_HEADER}
+                        Run Keyword And Expect Error    *
+                        ...  Put object        ${NEOFS_SN_WIF}    ${FILE_S}    ${CID}    ${EMPTY}    ${FILE_OTH_HEADER}
 
-    Run Keyword And Expect Error    *
-    ...  Get object      ${SYSTEM_KEY}       ${CID}    ${S_OID_USER}    ${EMPTY}    local_file_eacl
-    Run Keyword And Expect Error    *
-    ...  Get object      ${NEOFS_SN_WIF}    ${CID}    ${S_OID_USER}    ${EMPTY}    local_file_eacl
+                        Run Keyword And Expect Error    *
+                        ...  Get object      ${NEOFS_IR_WIF}      ${CID}    ${S_OID_USER}    ${EMPTY}    local_file_eacl
+                        Run Keyword And Expect Error    *
+                        ...  Get object      ${NEOFS_SN_WIF}    ${CID}    ${S_OID_USER}    ${EMPTY}    local_file_eacl
 
-    Run Keyword And Expect Error    *
-    ...  Search object              ${SYSTEM_KEY}       ${CID}    ${EMPTY}    ${EMPTY}    ${FILE_USR_HEADER}    ${S_OBJ_H}
-    Run Keyword And Expect Error    *
-    ...  Search object              ${NEOFS_SN_WIF}    ${CID}    ${EMPTY}    ${EMPTY}    ${FILE_USR_HEADER}    ${S_OBJ_H}
-
-
-    Run Keyword And Expect Error        *
-    ...  Head object                         ${SYSTEM_KEY}       ${CID}    ${S_OID_USER}    ${EMPTY}
-    Run Keyword And Expect Error        *
-    ...  Head object                         ${SYSTEM_KEY_SN}    ${CID}    ${S_OID_USER}    ${EMPTY}
-
-    Run Keyword And Expect Error        *
-    ...  Get Range                           ${SYSTEM_KEY}       ${CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
-    Run Keyword And Expect Error        *
-    ...  Get Range                           ${SYSTEM_KEY_SN}    ${CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+                        Run Keyword And Expect Error    *
+                        ...  Search object              ${NEOFS_IR_WIF}    ${CID}    ${EMPTY}    ${EMPTY}    ${FILE_USR_HEADER}    ${S_OBJ_H}
+                        Run Keyword And Expect Error    *
+                        ...  Search object              ${NEOFS_SN_WIF}    ${CID}    ${EMPTY}    ${EMPTY}    ${FILE_USR_HEADER}    ${S_OBJ_H}
 
 
-    Run Keyword And Expect Error        *
-    ...  Get Range Hash                      ${SYSTEM_KEY}       ${CID}    ${S_OID_USER}    ${EMPTY}    0:256
-    Run Keyword And Expect Error        *
-    ...  Get Range Hash                      ${SYSTEM_KEY_SN}    ${CID}    ${S_OID_USER}    ${EMPTY}    0:256
+                        Run Keyword And Expect Error        *
+                        ...  Head object                ${NEOFS_IR_WIF}    ${CID}    ${S_OID_USER}    ${EMPTY}
+                        Run Keyword And Expect Error        *
+                        ...  Head object                ${NEOFS_SN_WIF}    ${CID}    ${S_OID_USER}    ${EMPTY}
+
+                        Run Keyword And Expect Error        *
+                        ...  Get Range                  ${NEOFS_IR_WIF}    ${CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+                        Run Keyword And Expect Error        *
+                        ...  Get Range                  ${NEOFS_SN_WIF}    ${CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
 
 
-    Run Keyword And Expect Error        *
-    ...  Delete object                       ${SYSTEM_KEY}    ${CID}        ${S_OID_USER}            ${EMPTY}
-    Run Keyword And Expect Error        *
-    ...  Delete object                       ${SYSTEM_KEY_SN}    ${CID}        ${S_OID_USER}            ${EMPTY}
+                        Run Keyword And Expect Error        *
+                        ...  Get Range Hash             ${NEOFS_IR_WIF}    ${CID}    ${S_OID_USER}    ${EMPTY}    0:256
+                        Run Keyword And Expect Error        *
+                        ...  Get Range Hash             ${NEOFS_SN_WIF}    ${CID}    ${S_OID_USER}    ${EMPTY}    0:256
 
 
-    Set eACL                            ${USER_KEY}     ${CID}        ${EACL_ALLOW_ALL_SYSTEM}
-
-    # The current ACL cache lifetime is 30 sec
-    Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}
-
-    ${D_OID_USER_S} =       Put object             ${USER_KEY}     ${FILE_S}            ${CID}            ${EMPTY}            ${FILE_USR_HEADER_DEL}
-    ${D_OID_USER_SN} =      Put object             ${USER_KEY}     ${FILE_S}            ${CID}            ${EMPTY}            ${FILE_USR_HEADER_DEL}
+                        Run Keyword And Expect Error        *
+                        ...  Delete object              ${NEOFS_IR_WIF}    ${CID}        ${S_OID_USER}    ${EMPTY}
+                        Run Keyword And Expect Error        *
+                        ...  Delete object              ${NEOFS_SN_WIF}    ${CID}        ${S_OID_USER}    ${EMPTY}
 
 
-    Put object             ${SYSTEM_KEY}       ${FILE_S}     ${CID}            ${EMPTY}                   ${FILE_OTH_HEADER}
-    Put object             ${SYSTEM_KEY_SN}    ${FILE_S}     ${CID}            ${EMPTY}                   ${FILE_OTH_HEADER}
+                        Set eACL                        ${USER_KEY}     ${CID}        ${EACL_ALLOW_ALL_SYSTEM}
 
-    Get object               ${SYSTEM_KEY}       ${CID}        ${S_OID_USER}            ${EMPTY}            local_file_eacl
-    Get object               ${SYSTEM_KEY_SN}    ${CID}        ${S_OID_USER}            ${EMPTY}            local_file_eacl
+                        # The current ACL cache lifetime is 30 sec
+                        Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}
 
-    Search object            ${SYSTEM_KEY}       ${CID}    ${EMPTY}        ${EMPTY}     ${FILE_USR_HEADER}       ${S_OBJ_H}
-    Search object            ${SYSTEM_KEY_SN}    ${CID}    ${EMPTY}        ${EMPTY}     ${FILE_USR_HEADER}       ${S_OBJ_H}
+    ${D_OID_USER_S} =   Put object     ${USER_KEY}     ${FILE_S}    ${CID}    ${EMPTY}    ${FILE_USR_HEADER_DEL}
+    ${D_OID_USER_SN} =  Put object     ${USER_KEY}     ${FILE_S}    ${CID}    ${EMPTY}    ${FILE_USR_HEADER_DEL}
 
-    Head object              ${SYSTEM_KEY}       ${CID}        ${S_OID_USER}            ${EMPTY}
-    Head object              ${SYSTEM_KEY_SN}    ${CID}        ${S_OID_USER}            ${EMPTY}
+                        Put object     ${NEOFS_IR_WIF}    ${FILE_S}     ${CID}    ${EMPTY}       ${FILE_OTH_HEADER}
+                        Put object     ${NEOFS_SN_WIF}    ${FILE_S}     ${CID}    ${EMPTY}       ${FILE_OTH_HEADER}
 
-    Get Range                ${SYSTEM_KEY}       ${CID}        ${S_OID_USER}    s_get_range      ${EMPTY}    0:256
-    Get Range                ${SYSTEM_KEY_SN}    ${CID}        ${S_OID_USER}    s_get_range      ${EMPTY}    0:256
+                        Get object       ${NEOFS_IR_WIF}    ${CID}        ${S_OID_USER}      ${EMPTY}    local_file_eacl
+                        Get object       ${NEOFS_SN_WIF}    ${CID}        ${S_OID_USER}      ${EMPTY}    local_file_eacl
 
-    Get Range Hash           ${SYSTEM_KEY}       ${CID}        ${S_OID_USER}            ${EMPTY}            0:256
-    Get Range Hash           ${SYSTEM_KEY_SN}    ${CID}        ${S_OID_USER}            ${EMPTY}            0:256
+                        Search object        ${NEOFS_IR_WIF}    ${CID}    ${EMPTY}        ${EMPTY}     ${FILE_USR_HEADER}       ${S_OBJ_H}
+                        Search object        ${NEOFS_SN_WIF}    ${CID}    ${EMPTY}        ${EMPTY}     ${FILE_USR_HEADER}       ${S_OBJ_H}
 
-    Delete object            ${SYSTEM_KEY}       ${CID}        ${D_OID_USER_S}            ${EMPTY}
-    Delete object            ${SYSTEM_KEY_SN}    ${CID}        ${D_OID_USER_SN}           ${EMPTY}
+                        Head object          ${NEOFS_IR_WIF}    ${CID}    ${S_OID_USER}    ${EMPTY}
+                        Head object          ${NEOFS_SN_WIF}    ${CID}    ${S_OID_USER}    ${EMPTY}
+
+                        Get Range            ${NEOFS_IR_WIF}    ${CID}    ${S_OID_USER}    s_get_range      ${EMPTY}    0:256
+                        Get Range            ${NEOFS_SN_WIF}    ${CID}    ${S_OID_USER}    s_get_range      ${EMPTY}    0:256
+
+                        Get Range Hash       ${NEOFS_IR_WIF}    ${CID}    ${S_OID_USER}    ${EMPTY}    0:256
+                        Get Range Hash       ${NEOFS_SN_WIF}    ${CID}    ${S_OID_USER}    ${EMPTY}    0:256
+
+                        Delete object        ${NEOFS_IR_WIF}    ${CID}    ${D_OID_USER_S}        ${EMPTY}
+                        Delete object        ${NEOFS_SN_WIF}    ${CID}    ${D_OID_USER_SN}       ${EMPTY}

--- a/robot/testsuites/integration/acl/acl_extended_filters.robot
+++ b/robot/testsuites/integration/acl/acl_extended_filters.robot
@@ -11,6 +11,9 @@ Resource        ../${RESOURCES}/payment_operations.robot
 Resource        ../${RESOURCES}/setup_teardown.robot
 Resource        ../../../variables/eacl_tables.robot
 
+*** Variables ***
+${PATH} =   testfile
+
 *** Test cases ***
 Extended ACL Operations
     [Documentation]         Testcase to validate NeoFS operations with extended ACL.
@@ -50,24 +53,24 @@ Check eACL MatchType String Equal Request Deny
 
     ${HEADER} =             Head object                     ${USER_KEY}     ${CID}       ${S_OID_USER}    ${EMPTY}    json_output=True
     &{HEADER_DICT} =        Decode Object System Header Json      ${HEADER}
-                            Get object           ${OTHER_KEY}    ${CID}       ${S_OID_USER}    ${EMPTY}    local_file_eacl
+                            Get object           ${OTHER_KEY}    ${CID}       ${S_OID_USER}    ${EMPTY}    ${PATH}
 
 
-    ${ID_value} =	        Get From Dictionary	            ${HEADER_DICT}    ID
+    ${ID_value} =	    Get From Dictionary	    ${HEADER_DICT}    ID
 
-                            Set eACL                        ${USER_KEY}    ${CID}    ${EACL_XHEADER_DENY_ALL}
+                            Set eACL                ${USER_KEY}    ${CID}    ${EACL_XHEADER_DENY_ALL}
 
                             # The current ACL cache lifetime is 30 sec
                             Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}
 
                             Run Keyword And Expect Error    *
-                            ...  Get object      ${OTHER_KEY}    ${CID}    ${S_OID_USER}    ${EMPTY}    local_file_eacl    ${EMPTY}    --xhdr a=2
-                            Get object           ${OTHER_KEY}    ${CID}    ${S_OID_USER}    ${EMPTY}    local_file_eacl    ${EMPTY}    --xhdr a=256
+                            ...  Get object      ${OTHER_KEY}    ${CID}    ${S_OID_USER}    ${EMPTY}    ${PATH}    ${EMPTY}    --xhdr a=2
+                            Get object           ${OTHER_KEY}    ${CID}    ${S_OID_USER}    ${EMPTY}    ${PATH}    ${EMPTY}    --xhdr a=256
 
                             Run Keyword And Expect Error    *
                             ...  Put object        ${OTHER_KEY}    ${FILE_S}     ${CID}           ${EMPTY}       ${FILE_OTH_HEADER}    ${EMPTY}      --xhdr a=2
                             Run Keyword And Expect Error    *
-                            ...  Get object      ${OTHER_KEY}    ${CID}        ${S_OID_USER}    ${EMPTY}       local_file_eacl       ${EMPTY}      --xhdr a=2
+                            ...  Get object      ${OTHER_KEY}    ${CID}        ${S_OID_USER}    ${EMPTY}       ${PATH}       ${EMPTY}      --xhdr a=2
                             Run Keyword And Expect Error    *
                             ...   Search object             ${OTHER_KEY}    ${CID}        ${EMPTY}         ${EMPTY}       ${FILE_USR_HEADER}    ${EMPTY}      --xhdr a=2
                             Run Keyword And Expect Error    *
@@ -80,7 +83,7 @@ Check eACL MatchType String Equal Request Deny
                             ...  Delete object              ${OTHER_KEY}    ${CID}        ${S_OID_USER}    ${EMPTY}       --xhdr a=2
 
                             Put object                      ${OTHER_KEY}    ${FILE_S}     ${CID}           ${EMPTY}       ${FILE_OTH_HEADER}    ${EMPTY}        --xhdr a=256
-                            Get object                      ${OTHER_KEY}    ${CID}        ${S_OID_USER}    ${EMPTY}       local_file_eacl       ${EMPTY}        --xhdr a=*
+                            Get object                      ${OTHER_KEY}    ${CID}        ${S_OID_USER}    ${EMPTY}       ${PATH}       ${EMPTY}        --xhdr a=*
                             Search object                   ${OTHER_KEY}    ${CID}        ${EMPTY}         ${EMPTY}       ${FILE_USR_HEADER}    ${EMPTY}        --xhdr a=
                             Head object                     ${OTHER_KEY}    ${CID}        ${S_OID_USER}    ${EMPTY}       ${EMPTY}              --xhdr a=.*
                             Get Range                       ${OTHER_KEY}    ${CID}        ${S_OID_USER}    s_get_range    ${EMPTY}              0:256           --xhdr a="2 2"
@@ -94,14 +97,14 @@ Check eACL MatchType String Equal Request Allow
     ${CID} =                Create Container Public    ${USER_KEY} 
     ${S_OID_USER} =         Put object             ${USER_KEY}     ${FILE_S}    ${CID}           ${EMPTY}    ${FILE_USR_HEADER}
 
-    ${HEADER} =             Head object                     ${USER_KEY}     ${CID}       ${S_OID_USER}    ${EMPTY}    json_output=True
+    ${HEADER} =             Head object            ${USER_KEY}     ${CID}       ${S_OID_USER}    ${EMPTY}    json_output=True
     &{HEADER_DICT} =        Decode Object System Header Json      ${HEADER}
-                            Get object           ${OTHER_KEY}    ${CID}       ${S_OID_USER}    ${EMPTY}    local_file_eacl
+                            Get object           ${OTHER_KEY}    ${CID}       ${S_OID_USER}    ${EMPTY}    ${PATH}
 
 
-    ${ID_value} =	        Get From Dictionary	            ${HEADER_DICT}    ID
+    ${ID_value} =	    Get From Dictionary	    ${HEADER_DICT}    ID
 
-                            Set eACL                        ${USER_KEY}    ${CID}    ${EACL_XHEADER_ALLOW_ALL}
+                            Set eACL                ${USER_KEY}    ${CID}    ${EACL_XHEADER_ALLOW_ALL}
 
                             # The current ACL cache lifetime is 30 sec
                             Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}
@@ -109,11 +112,11 @@ Check eACL MatchType String Equal Request Allow
                             Get eACL                        ${USER_KEY}    ${CID}
 
                             Run Keyword And Expect Error    *
-                            ...  Get object                 ${OTHER_KEY}    ${CID}    ${S_OID_USER}    ${EMPTY}    local_file_eacl    ${EMPTY}
+                            ...  Get object                 ${OTHER_KEY}    ${CID}    ${S_OID_USER}    ${EMPTY}    ${PATH}    ${EMPTY}
                             Run Keyword And Expect Error    *
                             ...  Put object                 ${OTHER_KEY}    ${FILE_S}     ${CID}           ${EMPTY}       ${FILE_OTH_HEADER}    ${EMPTY}
                             Run Keyword And Expect Error    *
-                            ...  Get object                 ${OTHER_KEY}    ${CID}        ${S_OID_USER}    ${EMPTY}       local_file_eacl       ${EMPTY}
+                            ...  Get object                 ${OTHER_KEY}    ${CID}        ${S_OID_USER}    ${EMPTY}       ${PATH}       ${EMPTY}
                             Run Keyword And Expect Error    *
                             ...   Search object             ${OTHER_KEY}    ${CID}        ${EMPTY}         ${EMPTY}       ${FILE_USR_HEADER}    ${EMPTY}
                             Run Keyword And Expect Error    *
@@ -126,7 +129,7 @@ Check eACL MatchType String Equal Request Allow
                             ...  Delete object              ${OTHER_KEY}    ${CID}        ${S_OID_USER}    ${EMPTY}
 
                             Put object                      ${OTHER_KEY}    ${FILE_S}     ${CID}           ${EMPTY}       ${FILE_OTH_HEADER}    ${EMPTY}        --xhdr a=2
-                            Get object                      ${OTHER_KEY}    ${CID}        ${S_OID_USER}    ${EMPTY}       local_file_eacl       ${EMPTY}        --xhdr a=2
+                            Get object                      ${OTHER_KEY}    ${CID}        ${S_OID_USER}    ${EMPTY}       ${PATH}       ${EMPTY}        --xhdr a=2
                             Search object                   ${OTHER_KEY}    ${CID}        ${EMPTY}         ${EMPTY}       ${FILE_USR_HEADER}    ${EMPTY}        --xhdr a=2
                             Head object                     ${OTHER_KEY}    ${CID}        ${S_OID_USER}    ${EMPTY}       ${EMPTY}              --xhdr a=2
                             Get Range                       ${OTHER_KEY}    ${CID}        ${S_OID_USER}    s_get_range    ${EMPTY}              0:256           --xhdr a=2
@@ -142,35 +145,35 @@ Check eACL MatchType String Equal Object
 
     ${HEADER} =             Head object                     ${USER_KEY}     ${CID}       ${S_OID_USER}    ${EMPTY}    json_output=True
     &{HEADER_DICT} =        Decode Object System Header Json      ${HEADER}
-                            Get object                      ${OTHER_KEY}    ${CID}       ${S_OID_USER}    ${EMPTY}    local_file_eacl
+                            Get object                      ${OTHER_KEY}    ${CID}       ${S_OID_USER}    ${EMPTY}    ${PATH}
 
 
                             Log	                            Set eACL for Deny GET operation with StringEqual Object ID
-    ${ID_value} =	        Get From Dictionary	            ${HEADER_DICT}    ID
+    ${ID_value} =	    Get From Dictionary	            ${HEADER_DICT}    ID
 
     ${filters} =            Create Dictionary    headerType=OBJECT    matchType=STRING_EQUAL    key=$Object:objectID    value=${ID_value}
     ${rule1} =              Create Dictionary    Operation=GET        Access=DENY               Role=OTHERS             Filters=${filters}
     ${eACL_gen} =           Create List          ${rule1}
-    ${EACL_CUSTOM} =        Form eACL json common file    ${ASSETS_DIR}/eacl_custom    ${eACL_gen}
+    ${EACL_CUSTOM} =        Form eACL JSON Common File      ${eACL_gen}
 
                             Set eACL                        ${USER_KEY}       ${CID}    ${EACL_CUSTOM}
                             Run Keyword And Expect Error    *
-                            ...  Get object                 ${OTHER_KEY}      ${CID}    ${S_OID_USER}     ${EMPTY}        local_file_eacl
+                            ...  Get object                 ${OTHER_KEY}      ${CID}    ${S_OID_USER}     ${EMPTY}        ${PATH}
 
 
-                            Log	                            Set eACL for Deny GET operation with StringEqual Object Extended User Header
-    ${S_OID_USER_OTH} =     Put object             ${USER_KEY}     ${FILE_S}    ${CID}               ${EMPTY}        ${FILE_OTH_HEADER}
+                            Log	                 Set eACL for Deny GET operation with StringEqual Object Extended User Header
+    ${S_OID_USER_OTH} =     Put object           ${USER_KEY}     ${FILE_S}    ${CID}               ${EMPTY}        ${FILE_OTH_HEADER}
 
     ${filters} =            Create Dictionary    headerType=OBJECT    matchType=STRING_EQUAL    key=key1    value=1
     ${rule1} =              Create Dictionary    Operation=GET        Access=DENY               Role=OTHERS             Filters=${filters}
     ${eACL_gen} =           Create List    ${rule1}
-    ${EACL_CUSTOM} =        Form eACL json common file    ${ASSETS_DIR}/eacl_custom    ${eACL_gen}
+    ${EACL_CUSTOM} =        Form eACL JSON Common File      ${eACL_gen}
 
 
-                            Set eACL                        ${USER_KEY}     ${CID}       ${EACL_CUSTOM}
+                            Set eACL             ${USER_KEY}     ${CID}       ${EACL_CUSTOM}
                             Run Keyword And Expect Error    *
-                            ...  Get object      ${OTHER_KEY}    ${CID}       ${S_OID_USER}        ${EMPTY}        local_file_eacl
-                            Get object           ${OTHER_KEY}    ${CID}       ${S_OID_USER_OTH}    ${EMPTY}        local_file_eacl
+                            ...  Get object      ${OTHER_KEY}    ${CID}       ${S_OID_USER}        ${EMPTY}        ${PATH}
+                            Get object           ${OTHER_KEY}    ${CID}       ${S_OID_USER_OTH}    ${EMPTY}        ${PATH}
 
 
 
@@ -179,40 +182,40 @@ Check eACL MatchType String Not Equal Object
 
     ${CID} =                Create Container Public    ${USER_KEY} 
 
-    ${S_OID_USER} =         Put object             ${USER_KEY}     ${FILE_S}      ${CID}    ${EMPTY}    ${FILE_USR_HEADER}
-    ${S_OID_OTHER} =        Put object             ${OTHER_KEY}    ${FILE_S_2}    ${CID}    ${EMPTY}    ${FILE_OTH_HEADER}
+    ${S_OID_USER} =         Put object         ${USER_KEY}     ${FILE_S}      ${CID}    ${EMPTY}    ${FILE_USR_HEADER}
+    ${S_OID_OTHER} =        Put object         ${OTHER_KEY}    ${FILE_S_2}    ${CID}    ${EMPTY}    ${FILE_OTH_HEADER}
 
-    ${HEADER} =             Head object                     ${USER_KEY}    ${CID}    ${S_OID_USER}     ${EMPTY}    json_output=True
-                            Head object                     ${USER_KEY}    ${CID}    ${S_OID_OTHER}    ${EMPTY}    json_output=True
+    ${HEADER} =             Head object        ${USER_KEY}    ${CID}    ${S_OID_USER}     ${EMPTY}    json_output=True
+                            Head object        ${USER_KEY}    ${CID}    ${S_OID_OTHER}    ${EMPTY}    json_output=True
 
     &{HEADER_DICT} =        Decode Object System Header Json      ${HEADER}
 
-                            Get object           ${OTHER_KEY}    ${CID}    ${S_OID_USER}     ${EMPTY}    local_file_eacl
-                            Get object           ${OTHER_KEY}    ${CID}    ${S_OID_OTHER}    ${EMPTY}    local_file_eacl
+                            Get object          ${OTHER_KEY}    ${CID}    ${S_OID_USER}     ${EMPTY}    ${PATH}
+                            Get object          ${OTHER_KEY}    ${CID}    ${S_OID_OTHER}    ${EMPTY}    ${PATH}
 
-                            Log	                            Set eACL for Deny GET operation with StringNotEqual Object ID
-    ${ID_value} =	    Get From Dictionary	            ${HEADER_DICT}    ID
+                            Log	                    Set eACL for Deny GET operation with StringNotEqual Object ID
+    ${ID_value} =	    Get From Dictionary	    ${HEADER_DICT}    ID
 
     ${filters} =            Create Dictionary    headerType=OBJECT    matchType=STRING_NOT_EQUAL    key=$Object:objectID    value=${ID_value}
     ${rule1} =              Create Dictionary    Operation=GET        Access=DENY                   Role=OTHERS             Filters=${filters}
     ${eACL_gen} =           Create List    ${rule1}
-    ${EACL_CUSTOM} =        Form eACL json common file    ${ASSETS_DIR}/eacl_custom    ${eACL_gen}
+    ${EACL_CUSTOM} =        Form eACL JSON Common File      ${eACL_gen}
 
                             Set eACL                        ${USER_KEY}       ${CID}    ${EACL_CUSTOM}
                             Run Keyword And Expect Error    *
-                            ...  Get object      ${OTHER_KEY}      ${CID}    ${S_OID_OTHER}    ${EMPTY}            local_file_eacl
-                            Get object           ${OTHER_KEY}      ${CID}    ${S_OID_USER}     ${EMPTY}            local_file_eacl
+                            ...  Get object      ${OTHER_KEY}      ${CID}    ${S_OID_OTHER}    ${EMPTY}            ${PATH}
+                            Get object           ${OTHER_KEY}      ${CID}    ${S_OID_USER}     ${EMPTY}            ${PATH}
 
 
-                            Log	                            Set eACL for Deny GET operation with StringEqual Object Extended User Header
-    ${S_OID_USER_OTH} =     Put object             ${USER_KEY}    ${FILE_S}    ${CID}               ${EMPTY}            ${FILE_OTH_HEADER}
+                            Log	               Set eACL for Deny GET operation with StringEqual Object Extended User Header
+    ${S_OID_USER_OTH} =     Put object         ${USER_KEY}    ${FILE_S}    ${CID}               ${EMPTY}            ${FILE_OTH_HEADER}
 
     ${filters} =            Create Dictionary    headerType=OBJECT    matchType=STRING_NOT_EQUAL    key=key1       value=1
     ${rule1} =              Create Dictionary    Operation=GET        Access=DENY                   Role=OTHERS    Filters=${filters}
     ${eACL_gen} =           Create List    ${rule1}
-    ${EACL_CUSTOM} =        Form eACL json common file    ${ASSETS_DIR}/eacl_custom    ${eACL_gen}
+    ${EACL_CUSTOM} =        Form eACL JSON Common File      ${eACL_gen}
 
                             Set eACL                        ${USER_KEY}    ${CID}       ${EACL_CUSTOM}
                             Run Keyword And Expect Error    *
-                            ...  Get object      ${OTHER_KEY}    ${CID}      ${S_OID_USER_OTH}    ${EMPTY}            local_file_eacl
-                            Get object           ${OTHER_KEY}    ${CID}      ${S_OID_USER}        ${EMPTY}            local_file_eacl
+                            ...  Get object      ${OTHER_KEY}    ${CID}      ${S_OID_USER_OTH}    ${EMPTY}            ${PATH}
+                            Get object           ${OTHER_KEY}    ${CID}      ${S_OID_USER}        ${EMPTY}            ${PATH}

--- a/robot/testsuites/integration/acl/common_steps_acl_bearer.robot
+++ b/robot/testsuites/integration/acl/common_steps_acl_bearer.robot
@@ -47,7 +47,7 @@ Prepare eACL Role rules
         ${rule7} =              Create Dictionary    Operation=GETRANGEHASH    Access=DENY    Role=${role}
 
         ${eACL_gen} =           Create List    ${rule1}    ${rule2}    ${rule3}    ${rule4}    ${rule5}    ${rule6}    ${rule7}
-                                Form eACL json common file    gen_eacl_deny_all_${role}    ${eACL_gen}
-                                Set Global Variable    ${EACL_DENY_ALL_${role}}       gen_eacl_deny_all_${role}
+        ${EACL_FILE} =          Form eACL JSON Common File    ${eACL_gen}
+                                Set Global Variable    ${EACL_DENY_ALL_${role}}    ${EACL_FILE}
     END
     [Return]    gen_eacl_deny_all_${role}


### PR DESCRIPTION
- removed filename parameter from `Form eACL JSON Common File` keywords, as it wasn't changed inside function and returned as-is
- removed `${SYSTEM_KEY}` and `${SYSTEM_KEY_SN}` variables from testsuites: early, it was global variables, now they are obsolete