### PR TITLE
changed pythonpath for virtualenv; shortened test libraries imports

### DIFF
--- a/robot/testsuites/integration/acl/acl_extended_actions_user.robot
+++ b/robot/testsuites/integration/acl/acl_extended_actions_user.robot
@@ -7,8 +7,8 @@ Library     payment_neogo.py
 Library     acl.py
 
 Resource     common_steps_acl_extended.robot
-Resource     ../${RESOURCES}/payment_operations.robot
-Resource     ../${RESOURCES}/setup_teardown.robot
+Resource     payment_operations.robot
+Resource     setup_teardown.robot
 Resource     ../../../variables/eacl_tables.robot
 
 *** Test cases ***
@@ -19,7 +19,7 @@ Extended ACL Operations
 
     [Setup]                 Setup
 
-    ${WALLET}   ${ADDR}     ${USER_KEY} =   Prepare Wallet And Deposit  
+    ${WALLET}   ${ADDR}     ${USER_KEY} =   Prepare Wallet And Deposit
 
                             Log    Check extended ACL with simple object
                             Generate files    ${SIMPLE_OBJ_SIZE}

--- a/robot/testsuites/integration/acl/common_steps_acl_extended.robot
+++ b/robot/testsuites/integration/acl/common_steps_acl_extended.robot
@@ -1,6 +1,8 @@
 *** Settings ***
 Variables   ../../../variables/common.py
 
+Library     acl.py
+
 *** Variables ***
 ${FILE_USR_HEADER} =        key1=1,key2=abc
 ${FILE_USR_HEADER_DEL} =    key1=del,key2=del
@@ -20,7 +22,7 @@ Create Container Public
 
 Generate files
     [Arguments]             ${SIZE}
-    
+
     ${FILE_S_GEN_1} =       Generate file of bytes    ${SIZE}
     ${FILE_S_GEN_2} =       Generate file of bytes    ${SIZE}
                             Set Global Variable       ${FILE_S}      ${FILE_S_GEN_1}

--- a/robot/testsuites/integration/cli/netmap/networkinfo_rpc_method.robot
+++ b/robot/testsuites/integration/cli/netmap/networkinfo_rpc_method.robot
@@ -1,12 +1,12 @@
 *** Settings ***
-Variables   ../../../variables/common.py
+Variables   ../../../../variables/common.py
 
 Library    Collections
 Library    Process
 Library    String
-Library    ${KEYWORDS}/contract_keywords.py
+Library    contract_keywords.py
 
-Resource    ../${RESOURCES}/setup_teardown.robot
+Resource    setup_teardown.robot
 
 *** Variables ***
 ${SN_01_ADDR} =    s01.neofs.devenv:8080

--- a/robot/testsuites/integration/container/container_delete.robot
+++ b/robot/testsuites/integration/container/container_delete.robot
@@ -2,12 +2,12 @@
 Variables   ../../../variables/common.py
 Variables   ../../../variables/acl.py
 
-Library     ../${RESOURCES}/neofs.py
-Library     ../${RESOURCES}/payment_neogo.py
-Library     ${KEYWORDS}/wallet_keywords.py
+Library     neofs.py
+Library     payment_neogo.py
+Library     wallet_keywords.py
 
-Resource    ../${RESOURCES}/setup_teardown.robot
-Resource    ../${RESOURCES}/payment_operations.robot
+Resource    setup_teardown.robot
+Resource    payment_operations.robot
 
 *** Variables ***
 ${CONTAINER_WAIT_INTERVAL} =    1 min

--- a/robot/testsuites/integration/network/netmap_simple.robot
+++ b/robot/testsuites/integration/network/netmap_simple.robot
@@ -1,10 +1,10 @@
 *** Settings ***
 Variables   ../../../variables/common.py
 
-Library     ../${RESOURCES}/neofs.py
-Library     ../${RESOURCES}/payment_neogo.py
-Library     ${KEYWORDS}/wallet_keywords.py
-Library     ${KEYWORDS}/rpc_call_keywords.py
+Library     neofs.py
+Library     payment_neogo.py
+Library     wallet_keywords.py
+Library     rpc_call_keywords.py
 
 Resource    ../${RESOURCES}/payment_operations.robot
 Resource    ../${RESOURCES}/setup_teardown.robot

--- a/robot/testsuites/integration/object/common_steps_object.robot
+++ b/robot/testsuites/integration/object/common_steps_object.robot
@@ -1,8 +1,8 @@
 *** Settings ***
 Variables   ../../../variables/common.py
 
-Library     ${KEYWORDS}/wallet_keywords.py
-Library     ${KEYWORDS}/rpc_call_keywords.py
+Library     wallet_keywords.py
+Library     rpc_call_keywords.py
 
 *** Variables ***
 ${FILE_USR_HEADER} =    key1=1,key2=abc

--- a/robot/testsuites/integration/object/object_complex.robot
+++ b/robot/testsuites/integration/object/object_complex.robot
@@ -1,13 +1,13 @@
 *** Settings ***
 Variables   ../../../variables/common.py
 
-Library     ../${RESOURCES}/neofs.py
-Library     ../${RESOURCES}/payment_neogo.py
-Library    ${KEYWORDS}/contract_keywords.py
+Library     neofs.py
+Library     payment_neogo.py
+Library     contract_keywords.py
 
 Resource    common_steps_object.robot
-Resource    ../${RESOURCES}/setup_teardown.robot
-Resource    ../${RESOURCES}/payment_operations.robot
+Resource    setup_teardown.robot
+Resource    payment_operations.robot
 
 *** Variables ***
 ${CLEANUP_TIMEOUT} =    10s

--- a/robot/testsuites/integration/object/object_expiration.robot
+++ b/robot/testsuites/integration/object/object_expiration.robot
@@ -1,13 +1,13 @@
 *** Settings ***
 Variables   ../../../variables/common.py
 
-Library     ../${RESOURCES}/neofs.py
-Library     ../${RESOURCES}/payment_neogo.py
-Library     ${KEYWORDS}/contract_keywords.py
+Library     neofs.py
+Library     payment_neogo.py
+Library     contract_keywords.py
 
 Resource    common_steps_object.robot
-Resource    ../${RESOURCES}/setup_teardown.robot
-Resource    ../${RESOURCES}/payment_operations.robot
+Resource    setup_teardown.robot
+Resource    payment_operations.robot
 
 *** Variables ***
 ${CLEANUP_TIMEOUT} =    10s

--- a/robot/testsuites/integration/object/object_simple.robot
+++ b/robot/testsuites/integration/object/object_simple.robot
@@ -1,13 +1,13 @@
 *** Settings ***
 Variables   ../../../variables/common.py
 
-Library     ../${RESOURCES}/neofs.py
-Library     ../${RESOURCES}/payment_neogo.py
-Library     ${KEYWORDS}/contract_keywords.py
+Library     neofs.py
+Library     payment_neogo.py
+Library     contract_keywords.py
 
 Resource    common_steps_object.robot
-Resource    ../${RESOURCES}/payment_operations.robot
-Resource    ../${RESOURCES}/setup_teardown.robot
+Resource    payment_operations.robot
+Resource    setup_teardown.robot
 
 *** Variables ***
 ${CLEANUP_TIMEOUT} =    10s

--- a/robot/testsuites/integration/payment/withdraw.robot
+++ b/robot/testsuites/integration/payment/withdraw.robot
@@ -1,12 +1,12 @@
 *** Settings ***
 Variables   ../../../variables/common.py
 
-Library     ../${RESOURCES}/neofs.py
-Library     ../${RESOURCES}/payment_neogo.py
-Library     ${KEYWORDS}/wallet_keywords.py
-Library     ${KEYWORDS}/rpc_call_keywords.py
+Library     neofs.py
+Library     payment_neogo.py
+Library     wallet_keywords.py
+Library     rpc_call_keywords.py
 
-Resource    ../${RESOURCES}/setup_teardown.robot
+Resource    setup_teardown.robot
 
 *** Variables ***
 ${DEPOSIT_AMOUNT} =     ${10}

--- a/robot/testsuites/integration/services/http_gate.robot
+++ b/robot/testsuites/integration/services/http_gate.robot
@@ -1,13 +1,13 @@
 *** Settings ***
 Variables   ../../../variables/common.py
 
-Library     ../${RESOURCES}/neofs.py
-Library     ../${RESOURCES}/payment_neogo.py
-Library     ../${RESOURCES}/gates.py
-Library     ${KEYWORDS}/wallet_keywords.py
-Library     ${KEYWORDS}/rpc_call_keywords.py
+Library     neofs.py
+Library     payment_neogo.py
+Library     gates.py
+Library     wallet_keywords.py
+Library     rpc_call_keywords.py
 
-Resource    ../${RESOURCES}/setup_teardown.robot
+Resource    setup_teardown.robot
 
 *** Variables ***
 ${PLACEMENT_RULE} =     REP 1 IN X CBF 1 SELECT 1 FROM * AS X

--- a/robot/variables/common.py
+++ b/robot/variables/common.py
@@ -4,7 +4,6 @@ ROOT='../..'
 
 RESOURCES="%s/resources/lib" % ROOT
 CERT="%s/../../ca" % ROOT
-KEYWORDS="%s/../../../neofs-keywords/robot/" % ROOT
 
 # Common NeoFS variables can be declared from neofs-dev-env env variables.
 # High priority is accepted for those envs.

--- a/venv/localtest/environment.sh
+++ b/venv/localtest/environment.sh
@@ -4,4 +4,4 @@ pushd ../neofs-dev-env
 export `make env`
 popd
 
-export PYTHONPATH=${PYTHONPATH}:${VIRTUAL_ENV}/neofs-keywords/lib:${VIRTUAL_ENV}/neofs-keywords/robot:~/neofs-testcases/robot/resources/lib
+export PYTHONPATH=${PYTHONPATH}:${VIRTUAL_ENV}/neofs-keywords/lib:${VIRTUAL_ENV}/neofs-keywords/robot:${VIRTUAL_ENV}/../robot/resources/lib


### PR DESCRIPTION
There was a reported problem with libraries import when using virtual env. In this PR, pythonpath adjusted to avoid this issue. Also, removed prefixes with exact paths to test libraries, because they are included into the pythonpath. 