### PR TITLE
#103 Test to check eACL filter keys for objects

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-robotframework==3.2.1
+robotframework==4.1.2
 requests==2.25.1
 pexpect==4.8.0
 boto3==1.16.33

--- a/robot/resources/lib/neofs.py
+++ b/robot/resources/lib/neofs.py
@@ -569,62 +569,73 @@ def decode_object_system_header_json(header):
     # Header - Constant attributes
 
     # ID
-    ID = json_header["objectID"]["value"]
-    if ID is not None:
-        result_header["ID"] = _json_cli_decode(ID)
+    oid = json_header["objectID"]["value"]
+    if oid is not None:
+        result_header["ID"] = _json_cli_decode(oid)
     else:
         raise Exception(f"no ID was parsed from header: \t{header}" )
 
     # CID
-    CID = json_header["header"]["containerID"]["value"]
-    if CID is not None:
-        result_header["CID"] = _json_cli_decode(CID)
+    cid = json_header["header"]["containerID"]["value"]
+    if cid is not None:
+        result_header["CID"] = _json_cli_decode(cid)
     else:
         raise Exception(f"no CID was parsed from header: \t{header}")
 
     # OwnerID
-    OwnerID = json_header["header"]["ownerID"]["value"]
-    if OwnerID is not None:
-        result_header["OwnerID"] = _json_cli_decode(OwnerID)
+    owner_id = json_header["header"]["ownerID"]["value"]
+    if owner_id is not None:
+        result_header["OwnerID"] = _json_cli_decode(owner_id)
     else:
         raise Exception(f"no OwnerID was parsed from header: \t{header}")
 
     # CreatedAtEpoch
-    CreatedAtEpoch = json_header["header"]["creationEpoch"]
-    if CreatedAtEpoch is not None:
-        result_header["CreatedAtEpoch"] = CreatedAtEpoch
+    created_at_epoch = json_header["header"]["creationEpoch"]
+    if created_at_epoch is not None:
+        result_header["CreatedAtEpoch"] = created_at_epoch
     else:
         raise Exception(f"no CreatedAtEpoch was parsed from header: \t{header}")
 
     # PayloadLength
-    PayloadLength = json_header["header"]["payloadLength"]
-    if PayloadLength is not None:
-        result_header["PayloadLength"] = PayloadLength
+    payload_length = json_header["header"]["payloadLength"]
+    if payload_length is not None:
+        result_header["PayloadLength"] = payload_length
     else:
         raise Exception(f"no PayloadLength was parsed from header: \t{header}")
 
 
     # HomoHash
-    HomoHash = json_header["header"]["homomorphicHash"]["sum"]
-    if HomoHash is not None:
-        result_header["HomoHash"] = _json_cli_decode(HomoHash)
+    homo_hash = json_header["header"]["homomorphicHash"]["sum"]
+    if homo_hash is not None:
+        homo_hash_64_d = base64.b64decode(homo_hash)
+        homo_hash_bytes = binascii.hexlify(homo_hash_64_d)
+        result_header["HomoHash"] = bytes.decode(homo_hash_bytes)
     else:
         raise Exception(f"no HomoHash was parsed from header: \t{header}")
 
-    # Checksum
-    Checksum = json_header["header"]["payloadHash"]["sum"]
-    if Checksum is not None:
-        Checksum_64_d = base64.b64decode(Checksum)
-        result_header["Checksum"] = binascii.hexlify(Checksum_64_d)
+    # PayloadHash
+    payload_hash = json_header["header"]["payloadHash"]["sum"]
+    if payload_hash is not None:
+        payload_hash_64_d = base64.b64decode(payload_hash)
+        payload_hash_bytes = binascii.hexlify(payload_hash_64_d)
+        result_header["PayloadHash"] = bytes.decode(payload_hash_bytes)
     else:
         raise Exception(f"no Checksum was parsed from header: \t{header}")
 
     # Type
-    Type = json_header["header"]["objectType"]
-    if Type is not None:
-        result_header["Type"] = Type
+    object_type = json_header["header"]["objectType"]
+    if object_type is not None:
+        result_header["Type"] = object_type
     else:
         raise Exception(f"no Type was parsed from header: \t{header}")
+
+    # Version
+    version = json_header["header"]["version"]
+    if version is not None:
+        version_full = f'v{version["major"]}.{version["minor"]}'
+        result_header["Version"] = version_full
+    else:
+        raise Exception(f"no version was parsed from header: \t{header}" )
 
     # Header - Optional attributes
 
@@ -722,7 +733,7 @@ def verify_file_hash(filename, expected_hash):
 
 
 @keyword('Put object')
-def put_object(private_key: str, path: str, cid: str, bearer: str, user_headers: str,
+def put_object(private_key: str, path: str, cid: str, bearer: str, user_headers: str="",
     endpoint: str="", options: str="" ):
     logger.info("Going to put the object")
 
@@ -761,7 +772,6 @@ def get_control_endpoint_with_wif(endpoint_number: str = ''):
     wif = endpoint_values['wif']
     
     return endpoint_num, endpoint_control, wif
-
 
 @keyword('Get Locode')
 def get_locode():

--- a/robot/testsuites/integration/acl/acl_extended_filters.robot
+++ b/robot/testsuites/integration/acl/acl_extended_filters.robot
@@ -141,14 +141,14 @@ Check eACL MatchType String Equal Object
     [Arguments]    ${USER_KEY}    ${OTHER_KEY}
 
     ${CID} =                Create Container Public    ${USER_KEY} 
-    ${S_OID_USER} =         Put object                      ${USER_KEY}     ${FILE_S}    ${CID}           ${EMPTY}    ${FILE_USR_HEADER}
+    ${S_OID_USER} =         Put Object    ${USER_KEY}     ${FILE_S}    ${CID}    ${EMPTY}    ${FILE_USR_HEADER}
 
-    ${HEADER} =             Head object                     ${USER_KEY}     ${CID}       ${S_OID_USER}    ${EMPTY}    json_output=True
+    ${HEADER} =             Head Object    ${USER_KEY}     ${CID}       ${S_OID_USER}    ${EMPTY}    json_output=True
     &{HEADER_DICT} =        Decode Object System Header Json      ${HEADER}
-                            Get object                      ${OTHER_KEY}    ${CID}       ${S_OID_USER}    ${EMPTY}    ${PATH}
+                            Get Object    ${OTHER_KEY}    ${CID}       ${S_OID_USER}    ${EMPTY}    ${PATH}
 
 
-                            Log	                            Set eACL for Deny GET operation with StringEqual Object ID
+                            Log    Set eACL for Deny GET operation with StringEqual Object ID
     ${ID_value} =	    Get From Dictionary	            ${HEADER_DICT}    ID
 
     ${filters} =            Create Dictionary    headerType=OBJECT    matchType=STRING_EQUAL    key=$Object:objectID    value=${ID_value}
@@ -158,22 +158,22 @@ Check eACL MatchType String Equal Object
 
                             Set eACL                        ${USER_KEY}       ${CID}    ${EACL_CUSTOM}
                             Run Keyword And Expect Error    *
-                            ...  Get object                 ${OTHER_KEY}      ${CID}    ${S_OID_USER}     ${EMPTY}        ${PATH}
+                            ...  Get object                 ${OTHER_KEY}      ${CID}    ${S_OID_USER}     ${EMPTY}    ${PATH}
 
 
                             Log	                 Set eACL for Deny GET operation with StringEqual Object Extended User Header
-    ${S_OID_USER_OTH} =     Put object           ${USER_KEY}     ${FILE_S}    ${CID}               ${EMPTY}        ${FILE_OTH_HEADER}
+    ${S_OID_USER_OTH} =     Put object           ${USER_KEY}     ${FILE_S}    ${CID}    ${EMPTY}    ${FILE_OTH_HEADER}
 
     ${filters} =            Create Dictionary    headerType=OBJECT    matchType=STRING_EQUAL    key=key1    value=1
-    ${rule1} =              Create Dictionary    Operation=GET        Access=DENY               Role=OTHERS             Filters=${filters}
+    ${rule1} =              Create Dictionary    Operation=GET        Access=DENY               Role=OTHERS    Filters=${filters}
     ${eACL_gen} =           Create List    ${rule1}
     ${EACL_CUSTOM} =        Form eACL JSON Common File      ${eACL_gen}
 
 
                             Set eACL             ${USER_KEY}     ${CID}       ${EACL_CUSTOM}
                             Run Keyword And Expect Error    *
-                            ...  Get object      ${OTHER_KEY}    ${CID}       ${S_OID_USER}        ${EMPTY}        ${PATH}
-                            Get object           ${OTHER_KEY}    ${CID}       ${S_OID_USER_OTH}    ${EMPTY}        ${PATH}
+                            ...  Get object      ${OTHER_KEY}    ${CID}    ${S_OID_USER}    ${EMPTY}    ${PATH}
+                            Get object           ${OTHER_KEY}    ${CID}    ${S_OID_USER_OTH}    ${EMPTY}    ${PATH}
 
 
 

--- a/robot/testsuites/integration/acl/common_steps_acl_extended.robot
+++ b/robot/testsuites/integration/acl/common_steps_acl_extended.robot
@@ -1,12 +1,20 @@
 *** Settings ***
 Variables   ../../../variables/common.py
+Variables   ../../../variables/eacl_object_filters.py
 
 Library     acl.py
+Library     neofs.py
+Library     Collections
+
+Resource        common_steps_acl_basic.robot
+Resource        ../${RESOURCES}/payment_operations.robot
 
 *** Variables ***
 ${FILE_USR_HEADER} =        key1=1,key2=abc
 ${FILE_USR_HEADER_DEL} =    key1=del,key2=del
 ${FILE_OTH_HEADER} =        key1=oth,key2=oth
+${OBJECT_PATH} =   testfile
+${EACL_ERR_MSG} =    *
 
 *** Keywords ***
 
@@ -80,3 +88,134 @@ Check eACL Deny and Allow All
                             Get Range Hash                      ${KEY}    ${CID}        ${S_OID_USER}       ${EMPTY}             0:256
                             Delete object                       ${KEY}    ${CID}        ${S_OID_USER}       ${EMPTY}
 
+Compose eACL Custom
+    [Arguments]    ${HEADER_DICT}    ${MATCH_TYPE}    ${FILTER}    ${ACCESS}    ${ROLE}
+
+    ${filter_value} =    Get From dictionary    ${HEADER_DICT}    ${EACL_OBJ_FILTERS}[${FILTER}]
+
+    ${filters} =        Create Dictionary    headerType=OBJECT    matchType=${MATCH_TYPE}    key=${FILTER}    value=${filter_value}
+    ${rule_get}=        Create Dictionary    Operation=GET             Access=${ACCESS}    Role=${ROLE}    Filters=${filters}
+    ${rule_head}=       Create Dictionary    Operation=HEAD            Access=${ACCESS}    Role=${ROLE}    Filters=${filters}
+    ${rule_put}=        Create Dictionary    Operation=PUT             Access=${ACCESS}    Role=${ROLE}    Filters=${filters}
+    ${rule_del}=        Create Dictionary    Operation=DELETE          Access=${ACCESS}    Role=${ROLE}    Filters=${filters}
+    ${rule_search}=     Create Dictionary    Operation=SEARCH          Access=${ACCESS}    Role=${ROLE}    Filters=${filters}
+    ${rule_range}=      Create Dictionary    Operation=GETRANGE        Access=${ACCESS}    Role=${ROLE}    Filters=${filters}
+    ${rule_rangehash}=    Create Dictionary    Operation=GETRANGEHASH    Access=${ACCESS}    Role=${ROLE}    Filters=${filters}
+
+    ${eACL_gen}=        Create List    ${rule_get}    ${rule_head}    ${rule_put}    ${rule_del}    
+    ...  ${rule_search}    ${rule_range}    ${rule_rangehash}
+    ${EACL_CUSTOM} =    Form eACL JSON Common File    ${eACL_gen}
+
+    [Return]    ${EACL_CUSTOM}
+
+Object Header Decoded
+    [Arguments]    ${USER_KEY}    ${CID}    ${S_OID_USER}
+
+    ${HEADER} =         Head Object    ${USER_KEY}    ${CID}    ${S_OID_USER}    ${EMPTY}    json_output=True
+    &{HEADER_DICT} =    Decode Object System Header Json    ${HEADER}
+
+    [Return]    &{HEADER_DICT}
+
+Check eACL Filters with MatchType String Equal
+    [Arguments]    ${FILTER}
+
+    ${_}   ${_}    ${USER_KEY} =    Prepare Wallet And Deposit  
+    ${_}   ${_}    ${OTHER_KEY} =    Prepare Wallet And Deposit
+
+    ${CID} =            Create Container Public    ${USER_KEY} 
+    ${FILE_S}    ${_} =    Generate file    ${SIMPLE_OBJ_SIZE}
+
+    ${S_OID_USER} =     Put Object    ${USER_KEY}    ${FILE_S}    ${CID}    ${EMPTY}    ${FILE_USR_HEADER}
+    ${D_OID_USER} =     Put object    ${USER_KEY}    ${FILE_S}    ${CID}    ${EMPTY}
+    @{S_OBJ_H} =	    Create List    ${S_OID_USER}
+
+                        Get Object    ${OTHER_KEY}    ${CID}    ${S_OID_USER}    ${EMPTY}    local_file_eacl
+                        Search Object    ${OTHER_KEY}    ${CID}    ${EMPTY}    ${EMPTY}    ${FILE_USR_HEADER}    ${S_OBJ_H}
+                        Head Object    ${OTHER_KEY}    ${CID}    ${S_OID_USER}    ${EMPTY}
+                        Get Range    ${OTHER_KEY}    ${CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+                        Get Range Hash    ${OTHER_KEY}    ${CID}    ${S_OID_USER}    ${EMPTY}    0:256
+                        Delete Object    ${OTHER_KEY}    ${CID}    ${D_OID_USER}    ${EMPTY}
+
+    &{HEADER_DICT} =    Object Header Decoded    ${USER_KEY}    ${CID}    ${S_OID_USER}
+    ${EACL_CUSTOM} =    Compose eACL Custom    ${HEADER_DICT}    STRING_EQUAL    ${FILTER}    DENY    OTHERS
+                        Set eACL    ${USER_KEY}    ${CID}    ${EACL_CUSTOM}
+
+    IF    'GET' in ${VERB_FILTER_DEP}[${FILTER}]  
+        Run Keyword And Expect Error   ${EACL_ERR_MSG}    
+        ...  Get object    ${OTHER_KEY}    ${CID}    ${S_OID_USER}    ${EMPTY}    ${OBJECT_PATH}
+    END
+    IF    'HEAD' in ${VERB_FILTER_DEP}[${FILTER}]
+        Run Keyword And Expect error    ${EACL_ERR_MSG}
+        ...  Head object    ${OTHER_KEY}    ${CID}    ${S_OID_USER}    ${EMPTY}
+    END
+    IF    'RANGE' in ${VERB_FILTER_DEP}[${FILTER}]
+        Run Keyword And Expect error    ${EACL_ERR_MSG}
+        ...  Get Range    ${OTHER_KEY}    ${CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256   
+    END
+    IF    'SEARCH' in ${VERB_FILTER_DEP}[${FILTER}]  
+        Run Keyword And Expect Error   ${EACL_ERR_MSG}    
+        ...  Search Object    ${OTHER_KEY}    ${CID}    ${EMPTY}    ${EMPTY}    ${FILE_USR_HEADER}    ${S_OBJ_H}
+    END
+    IF    'RANGEHASH' in ${VERB_FILTER_DEP}[${FILTER}]
+        Run Keyword And Expect error    ${EACL_ERR_MSG}
+        ...  Get Range Hash    ${OTHER_KEY}    ${CID}    ${S_OID_USER}    ${EMPTY}    0:256
+    END
+    IF    'DELETE' in ${VERB_FILTER_DEP}[${FILTER}]
+        Run Keyword And Expect error    ${EACL_ERR_MSG}
+        ...  Delete Object    ${OTHER_KEY}    ${CID}    ${S_OID_USER}    ${EMPTY}   
+    END
+    
+Check eACL Filters with MatchType String Not Equal
+    [Arguments]    ${FILTER}
+
+    ${_}   ${_}    ${USER_KEY} =    Prepare Wallet And Deposit  
+    ${_}   ${_}    ${OTHER_KEY} =    Prepare Wallet And Deposit
+
+    ${CID} =            Create Container Public    ${USER_KEY}
+    ${FILE_S}    ${_} =    Generate file    ${SIMPLE_OBJ_SIZE}
+
+    ${S_OID_OTH} =      Put Object    ${OTHER_KEY}    ${FILE_S}    ${CID}    ${EMPTY}    ${FILE_OTH_HEADER}
+    ${S_OID_USER} =     Put Object    ${USER_KEY}    ${FILE_S}    ${CID}    ${EMPTY}    ${FILE_USR_HEADER}
+    ${D_OID_USER} =     Put object    ${USER_KEY}    ${FILE_S}    ${CID}    ${EMPTY}
+    @{S_OBJ_H} =	    Create List    ${S_OID_USER}
+
+                        Get Object    ${USER_KEY}    ${CID}    ${S_OID_USER}    ${EMPTY}    local_file_eacl
+                        Head Object    ${USER_KEY}    ${CID}    ${S_OID_USER}    ${EMPTY}
+                        Search Object    ${USER_KEY}    ${CID}    ${EMPTY}    ${EMPTY}    ${FILE_USR_HEADER}    ${S_OBJ_H}
+                        Get Range    ${USER_KEY}    ${CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+                        Get Range Hash    ${USER_KEY}    ${CID}    ${S_OID_USER}    ${EMPTY}    0:256
+
+    &{HEADER_DICT} =    Object Header Decoded    ${USER_KEY}    ${CID}    ${S_OID_USER}
+    ${EACL_CUSTOM} =    Compose eACL Custom    ${HEADER_DICT}    STRING_NOT_EQUAL    ${FILTER}    DENY    OTHERS
+                        Set eACL    ${USER_KEY}    ${CID}    ${EACL_CUSTOM}
+
+    IF    'GET' in ${VERB_FILTER_DEP}[${FILTER}]  
+        Run Keyword And Expect Error   ${EACL_ERR_MSG}    
+        ...  Get object    ${OTHER_KEY}    ${CID}    ${S_OID_OTH}    ${EMPTY}    ${OBJECT_PATH}
+        Get object    ${OTHER_KEY}    ${CID}    ${S_OID_USER}     ${EMPTY}    ${OBJECT_PATH}
+    END
+    IF    'HEAD' in ${VERB_FILTER_DEP}[${FILTER}]
+        Run Keyword And Expect error    ${EACL_ERR_MSG}
+        ...  Head object    ${OTHER_KEY}    ${CID}    ${S_OID_OTH}    ${EMPTY}
+        Head object    ${OTHER_KEY}    ${CID}    ${S_OID_USER}    ${EMPTY}
+    END
+    IF    'SEARCH' in ${VERB_FILTER_DEP}[${FILTER}]
+        Run Keyword And Expect error    ${EACL_ERR_MSG}
+        ...  Search object    ${OTHER_KEY}    ${CID}    ${EMPTY}    ${EMPTY}    ${FILE_OTH_HEADER}    ${S_OBJ_H}
+        Search object    ${OTHER_KEY}    ${CID}    ${EMPTY}    ${EMPTY}    ${FILE_USR_HEADER}    ${S_OBJ_H}
+    END
+    IF    'RANGE' in ${VERB_FILTER_DEP}[${FILTER}]
+        Run Keyword And Expect error    ${EACL_ERR_MSG}
+        ...  Get Range    ${OTHER_KEY}    ${CID}    ${S_OID_OTH}    s_get_range    ${EMPTY}    0:256
+        Get Range    ${OTHER_KEY}    ${CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256  
+    END
+    IF    'RANGEHASH' in ${VERB_FILTER_DEP}[${FILTER}]
+        Run Keyword And Expect error    ${EACL_ERR_MSG}
+        ...  Get Range Hash    ${OTHER_KEY}    ${CID}    ${S_OID_OTH}    ${EMPTY}    0:256
+        Get Range Hash    ${OTHER_KEY}    ${CID}    ${S_OID_USER}    ${EMPTY}    0:256
+    END
+    IF    'DELETE' in ${VERB_FILTER_DEP}[${FILTER}]
+        Run Keyword And Expect error    ${EACL_ERR_MSG}
+        ...  Delete Object    ${OTHER_KEY}    ${CID}    ${S_OID_OTH}    ${EMPTY}
+        Delete Object    ${OTHER_KEY}    ${CID}    ${S_OID_USER}    ${EMPTY}   
+    END

--- a/robot/testsuites/integration/acl/object_attributes/container_id_filter.robot
+++ b/robot/testsuites/integration/acl/object_attributes/container_id_filter.robot
@@ -1,0 +1,17 @@
+*** Settings ***
+
+Resource        ../common_steps_acl_extended.robot
+Resource        ../../${RESOURCES}/setup_teardown.robot
+
+*** Test cases ***
+Container ID Object Filter for Extended ACL
+    [Documentation]         Testcase to validate if $Object:containerID eACL filter is correctly handled.
+    [Tags]                  ACL  eACL  NeoFS  NeoCLI
+    [Timeout]               20 min
+
+    [Setup]                 Setup
+    
+    Log    Check eACL containerID Filter with MatchType String Equal
+    Check eACL Filters with MatchType String Equal    $Object:containerID
+
+    [Teardown]          Teardown    container_id_filter

--- a/robot/testsuites/integration/acl/object_attributes/creation_epoch_filter.robot
+++ b/robot/testsuites/integration/acl/object_attributes/creation_epoch_filter.robot
@@ -1,0 +1,62 @@
+*** Settings ***
+Variables       ../../../../variables/common.py
+Variables       ../../../../variables/eacl_object_filters.py
+
+Library         acl.py
+Library         neofs.py
+Library         Collections
+Library         contract_keywords.py
+
+Resource        ../common_steps_acl_extended.robot
+Resource        ../common_steps_acl_basic.robot
+Resource        ../../${RESOURCES}/payment_operations.robot
+Resource        ../../${RESOURCES}/setup_teardown.robot
+
+*** Variables ***
+${OBJECT_PATH} =   testfile
+${EACL_ERR_MSG} =    *
+
+*** Test cases ***
+Creation Epoch Object Filter for Extended ACL
+    [Documentation]         Testcase to validate if $Object:creationEpoch eACL filter is correctly handled.
+    [Tags]                  ACL  eACL  NeoFS  NeoCLI
+    [Timeout]               20 min
+
+    [Setup]                 Setup
+
+    Log    Check eACL creationEpoch Filter with MatchType String Equal
+    Check eACL Filters with MatchType String Equal    $Object:creationEpoch
+    Log    Check eACL creationEpoch Filter with MatchType String Not Equal
+    Check $Object:creationEpoch Filter with MatchType String Not Equal    $Object:creationEpoch
+
+*** Keywords ***
+
+Check $Object:creationEpoch Filter with MatchType String Not Equal
+    [Arguments]    ${FILTER}
+
+    ${_}   ${_}    ${USER_KEY} =    Prepare Wallet And Deposit  
+    ${_}   ${_}    ${OTHER_KEY} =    Prepare Wallet And Deposit
+
+    ${CID} =            Create Container Public    ${USER_KEY}
+    ${FILE_S}    ${_} =    Generate file    ${SIMPLE_OBJ_SIZE}
+
+    ${S_OID} =          Put Object    ${USER_KEY}    ${FILE_S}    ${CID}    ${EMPTY}
+    Tick Epoch
+    ${S_OID_NEW} =      Put Object    ${USER_KEY}    ${FILE_S}    ${CID}    ${EMPTY}
+
+                        Get Object    ${USER_KEY}    ${CID}    ${S_OID_NEW}    ${EMPTY}    local_file_eacl
+                        Head Object    ${USER_KEY}    ${CID}    ${S_OID_NEW}    ${EMPTY}
+
+    &{HEADER_DICT} =    Object Header Decoded    ${USER_KEY}    ${CID}    ${S_OID_NEW}
+    ${EACL_CUSTOM} =    Compose eACL Custom    ${HEADER_DICT}    STRING_NOT_EQUAL    ${FILTER}    DENY    OTHERS
+                        Set eACL    ${USER_KEY}    ${CID}    ${EACL_CUSTOM}
+
+
+    Run Keyword And Expect Error   ${EACL_ERR_MSG}    
+    ...  Get object    ${OTHER_KEY}    ${CID}    ${S_OID}    ${EMPTY}    ${OBJECT_PATH}
+    Get object    ${OTHER_KEY}    ${CID}    ${S_OID_NEW}     ${EMPTY}    ${OBJECT_PATH}
+    Run Keyword And Expect error    ${EACL_ERR_MSG}
+    ...  Head object    ${OTHER_KEY}    ${CID}    ${S_OID}    ${EMPTY}
+    Head object    ${OTHER_KEY}    ${CID}    ${S_OID_NEW}    ${EMPTY}
+
+    [Teardown]          Teardown    creation_epoch_filter

--- a/robot/testsuites/integration/acl/object_attributes/homomorphic_hash_filter.robot
+++ b/robot/testsuites/integration/acl/object_attributes/homomorphic_hash_filter.robot
@@ -1,0 +1,17 @@
+*** Settings ***
+
+Resource        ../common_steps_acl_extended.robot
+Resource        ../../${RESOURCES}/setup_teardown.robot
+
+*** Test cases ***
+Homomorphic Hash Object Filter for Extended ACL
+    [Documentation]         Testcase to validate if $Object:homomorphicHash eACL filter is correctly handled.
+    [Tags]                  ACL  eACL  NeoFS  NeoCLI
+    [Timeout]               20 min
+
+    [Setup]                 Setup
+
+    Log    Check eACL homomorphicHash Filter with MatchType String Equal
+    Check eACL Filters with MatchType String Equal    $Object:homomorphicHash
+    
+    [Teardown]          Teardown    homomorphic_hash_filter

--- a/robot/testsuites/integration/acl/object_attributes/object_id_filter.robot
+++ b/robot/testsuites/integration/acl/object_attributes/object_id_filter.robot
@@ -1,0 +1,134 @@
+*** Settings ***
+Variables       ../../../../variables/common.py
+Variables       ../../../../variables/eacl_object_filters.py
+
+Library         acl.py
+Library         neofs.py
+Library         Collections
+
+Resource        ../common_steps_acl_extended.robot
+Resource        ../common_steps_acl_basic.robot
+Resource        ../../${RESOURCES}/payment_operations.robot
+Resource        ../../${RESOURCES}/setup_teardown.robot
+
+*** Variables ***
+${OBJECT_PATH} =   testfile
+${EACL_ERR_MSG} =    *
+
+*** Test cases ***
+Object ID Object Filter for Extended ACL
+    [Documentation]         Testcase to validate if $Object:objectID eACL filter is correctly handled.
+    [Tags]                  ACL  eACL  NeoFS  NeoCLI
+    [Timeout]               20 min
+
+    [Setup]                 Setup
+    
+    Log    Check eACL objectID Filter with MatchType String Equal
+    Check eACL Filters with MatchType String Equal    $Object:objectID
+    Log    Check eACL objectID Filter with MatchType String Not Equal
+    Check eACL Filters with MatchType String Not Equal   $Object:objectID
+
+    #################################################################################
+    # If the first eACL rule contradicts the second, the second one won't be applied
+    #################################################################################
+    Log    Check if the second rule that contradicts the first is not applied
+    Check eACL Filters with MatchType String Equal with two contradicting filters    $Object:objectID
+
+    ###########################################################################################################################
+    # If both STRING_EQUAL and STRING_NOT_EQUAL matchTypes are applied for the same filter value, no object can be operated on
+    ###########################################################################################################################
+    Log    Check two matchTypes applied
+    Check eACL Filters, two matchTypes    $Object:objectID
+
+
+*** Keywords ***
+ 
+Check eACL Filters with MatchType String Equal with two contradicting filters
+    [Arguments]    ${FILTER}
+
+    ${_}   ${_}     ${USER_KEY} =    Prepare Wallet And Deposit  
+    ${_}   ${_}     ${OTHER_KEY} =    Prepare Wallet And Deposit
+
+    ${CID} =            Create Container Public    ${USER_KEY} 
+    ${FILE_S_USER}    ${_} =    Generate file    ${SIMPLE_OBJ_SIZE}
+
+    ${S_OID_USER} =     Put Object    ${USER_KEY}     ${FILE_S_USER}    ${CID}    ${EMPTY}
+    &{HEADER_DICT_USER} =    Object Header Decoded    ${USER_KEY}    ${CID}    ${S_OID_USER}
+   
+                        Get Object    ${OTHER_KEY}    ${CID}       ${S_OID_USER}    ${EMPTY}    ${OBJECT_PATH}
+
+    ${filter_value} =    Get From Dictionary    ${HEADER_DICT_USER}    ${EACL_OBJ_FILTERS}[${FILTER}]
+    ${filters} =        Create Dictionary    
+                            ...    headerType=OBJECT    
+                            ...    matchType=STRING_EQUAL    
+                            ...    key=${FILTER}    
+                            ...    value=${filter_value}
+    ${rule} =           Create Dictionary    
+                            ...    Operation=GET    
+                            ...    Access=ALLOW    
+                            ...    Role=OTHERS    
+                            ...    Filters=${filters}
+    ${contradicting_filters} =     Create Dictionary    
+                            ...    headerType=OBJECT    
+                            ...    matchType=STRING_EQUAL    
+                            ...    key=$Object:payloadLength    
+                            ...    value=${SIMPLE_OBJ_SIZE}
+    ${contradicting_rule} =    Create Dictionary    
+                            ...    Operation=GET    
+                            ...    Access=DENY    
+                            ...    Role=OTHERS    
+                            ...    Filters=${contradicting_filters}
+    ${eACL_gen} =       Create List    ${rule}    ${contradicting_rule}
+    ${EACL_CUSTOM} =    Form eACL JSON Common File      ${eACL_gen}
+
+                        Set eACL    ${USER_KEY}    ${CID}    ${EACL_CUSTOM}
+                        Get object    ${OTHER_KEY}    ${CID}    ${S_OID_USER}    ${EMPTY}    ${OBJECT_PATH}
+
+Check eACL Filters, two matchTypes
+    [Arguments]    ${FILTER}
+
+    ${_}   ${_}    ${USER_KEY} =    Prepare Wallet And Deposit  
+    ${_}   ${_}    ${OTHER_KEY} =    Prepare Wallet And Deposit
+
+    ${CID} =            Create Container Public    ${USER_KEY}
+    ${FILE_S}    ${_} =    Generate file    ${SIMPLE_OBJ_SIZE}
+
+    ${S_OID_USER} =     Put Object    ${USER_KEY}    ${FILE_S}    ${CID}    ${EMPTY}
+    ${S_OID_OTHER} =    Put Object    ${OTHER_KEY}    ${FILE_S}    ${CID}    ${EMPTY}
+    &{HEADER_DICT_USER} =    Object Header Decoded    ${USER_KEY}    ${CID}    ${S_OID_USER}
+
+                        Get Object    ${OTHER_KEY}    ${CID}    ${S_OID_USER}     ${EMPTY}    ${OBJECT_PATH}
+                        Get Object    ${OTHER_KEY}    ${CID}    ${S_OID_OTHER}    ${EMPTY}    ${OBJECT_PATH}
+
+    ${filter_value} =    Get From Dictionary    ${HEADER_DICT_USER}    ${EACL_OBJ_FILTERS}[${FILTER}]
+    ${noneq_filters} =    Create Dictionary    
+                            ...    headerType=OBJECT    
+                            ...    matchType=STRING_NOT_EQUAL    
+                            ...    key=${FILTER}    
+                            ...    value=${filter_value}
+    ${rule_noneq_filter} =    Create Dictionary    
+                            ...    Operation=GET    
+                            ...    Access=DENY    
+                            ...    Role=OTHERS    
+                            ...    Filters=${noneq_filters}
+    ${eq_filters} =     Create Dictionary    
+                            ...    headerType=OBJECT    
+                            ...    matchType=STRING_EQUAL    
+                            ...    key=${FILTER}    
+                            ...    value=${filter_value}
+    ${rule_eq_filter} =    Create Dictionary    
+                            ...    Operation=GET    
+                            ...    Access=DENY    
+                            ...    Role=OTHERS    
+                            ...    Filters=${eq_filters}
+    ${eACL_gen} =       Create List    ${rule_noneq_filter}    ${rule_eq_filter}
+    ${EACL_CUSTOM} =    Form eACL JSON Common File      ${eACL_gen}
+
+                        Set eACL    ${USER_KEY}    ${CID}    ${EACL_CUSTOM}
+                        Run Keyword And Expect Error    *
+                        ...  Get object      ${OTHER_KEY}    ${CID}    ${S_OID_OTHER}    ${EMPTY}    ${OBJECT_PATH}
+                        Run Keyword And Expect Error    *
+                        ...  Get Object    ${OTHER_KEY}    ${CID}    ${S_OID_USER}    ${EMPTY}    ${OBJECT_PATH}
+
+
+    [Teardown]          Teardown    object_id

--- a/robot/testsuites/integration/acl/object_attributes/object_type_filter.robot
+++ b/robot/testsuites/integration/acl/object_attributes/object_type_filter.robot
@@ -1,0 +1,17 @@
+*** Settings ***
+
+Resource        ../common_steps_acl_extended.robot
+Resource        ../../${RESOURCES}/setup_teardown.robot
+
+*** Test cases ***
+Object Type Object Filter for Extended ACL
+    [Documentation]         Testcase to validate if $Object:objectType eACL filter is correctly handled.
+    [Tags]                  ACL  eACL  NeoFS  NeoCLI
+    [Timeout]               20 min
+
+    [Setup]                 Setup
+
+    Log    Check eACL objectType Filter with MatchType String Equal
+    Check eACL Filters with MatchType String Equal    $Object:objectType
+
+    [Teardown]          Teardown    object_type_filter

--- a/robot/testsuites/integration/acl/object_attributes/owner_id_filter.robot
+++ b/robot/testsuites/integration/acl/object_attributes/owner_id_filter.robot
@@ -1,0 +1,19 @@
+*** Settings ***
+
+Resource        ../common_steps_acl_extended.robot
+Resource        ../../${RESOURCES}/setup_teardown.robot
+
+*** Test cases ***
+Owner ID Object Filter for Extended ACL
+    [Documentation]         Testcase to validate if $Object:ownerID eACL filter is correctly handled.
+    [Tags]                  ACL  eACL  NeoFS  NeoCLI
+    [Timeout]               20 min
+
+    [Setup]                 Setup
+    
+    Log    Check eACL ownerID Filter with MatchType String Equal
+    Check eACL Filters with MatchType String Equal    $Object:ownerID
+    Log    Check eACL ownerID Filter with MatchType String Not Equal    
+    Check eACL Filters with MatchType String Not Equal    $Object:ownerID
+
+    [Teardown]          Teardown    owner_id_filter

--- a/robot/testsuites/integration/acl/object_attributes/payload_hash_filter.robot
+++ b/robot/testsuites/integration/acl/object_attributes/payload_hash_filter.robot
@@ -1,0 +1,17 @@
+*** Settings ***
+
+Resource        ../common_steps_acl_extended.robot
+Resource        ../../${RESOURCES}/setup_teardown.robot
+
+*** Test cases ***
+Payload Hash Object Filter for Extended ACL 
+    [Documentation]         Testcase to validate if $Object:payloadHash eACL filter is correctly handled.
+    [Tags]                  ACL  eACL  NeoFS  NeoCLI
+    [Timeout]               20 min
+
+    [Setup]                 Setup
+
+    Log    Check eACL payloadHash Filter with MatchType String Equal
+    Check eACL Filters with MatchType String Equal    $Object:payloadHash
+
+    [Teardown]          Teardown    payload_hash_filter

--- a/robot/testsuites/integration/acl/object_attributes/payload_length_filter.robot
+++ b/robot/testsuites/integration/acl/object_attributes/payload_length_filter.robot
@@ -1,0 +1,62 @@
+*** Settings ***
+Variables       ../../../../variables/common.py
+Variables       ../../../../variables/eacl_object_filters.py
+
+Library         acl.py
+Library         neofs.py
+Library         Collections
+
+Resource        ../common_steps_acl_extended.robot
+Resource        ../common_steps_acl_basic.robot
+Resource        ../../${RESOURCES}/payment_operations.robot
+Resource        ../../${RESOURCES}/setup_teardown.robot
+
+*** Variables ***
+${OBJECT_PATH} =   testfile
+${EACL_ERR_MSG} =    *
+
+*** Test cases ***
+Payload Length Object Filter for Extended ACL
+    [Documentation]         Testcase to validate if $Object:payloadLength eACL filter is correctly handled.
+    [Tags]                  ACL  eACL  NeoFS  NeoCLI
+    [Timeout]               20 min
+
+    [Setup]                 Setup
+
+    Log    Check eACL payloadLength Filter with MatchType String Equal
+    Check eACL Filters with MatchType String Equal    $Object:payloadLength
+    Log    Check eACL payloadLength Filter with MatchType String Not Equal
+    Check $Object:payloadLength Filter with MatchType String Not Equal    $Object:payloadLength
+
+*** Keywords ***
+
+Check $Object:payloadLength Filter with MatchType String Not Equal
+    [Arguments]    ${FILTER}
+
+    ${_}   ${_}    ${USER_KEY} =    Prepare Wallet And Deposit  
+    ${_}   ${_}    ${OTHER_KEY} =    Prepare Wallet And Deposit
+
+    ${CID} =            Create Container Public    ${USER_KEY}
+    ${FILE_S}    ${_} =    Generate file    ${SIMPLE_OBJ_SIZE}
+    ${FILE_0}    ${_} =    Generate file    ${0}
+
+    ${S_OID_0} =        Put Object    ${USER_KEY}    ${FILE_0}    ${CID}    ${EMPTY}
+    ${S_OID} =          Put Object    ${USER_KEY}    ${FILE_S}    ${CID}    ${EMPTY}
+
+                        Get Object    ${USER_KEY}    ${CID}    ${S_OID}    ${EMPTY}    local_file_eacl
+                        Head Object    ${USER_KEY}    ${CID}    ${S_OID}    ${EMPTY}
+
+    &{HEADER_DICT} =    Object Header Decoded    ${USER_KEY}    ${CID}    ${S_OID}
+    ${EACL_CUSTOM} =    Compose eACL Custom    ${HEADER_DICT}    STRING_NOT_EQUAL    ${FILTER}    DENY    OTHERS
+                        Set eACL    ${USER_KEY}    ${CID}    ${EACL_CUSTOM}
+
+ 
+    Run Keyword And Expect Error   ${EACL_ERR_MSG}    
+    ...  Get object    ${OTHER_KEY}    ${CID}    ${S_OID_0}    ${EMPTY}    ${OBJECT_PATH}
+    Get object    ${OTHER_KEY}    ${CID}    ${S_OID}     ${EMPTY}    ${OBJECT_PATH}
+    Run Keyword And Expect error    ${EACL_ERR_MSG}
+    ...  Head object    ${OTHER_KEY}    ${CID}    ${S_OID_0}    ${EMPTY}
+    Head object    ${OTHER_KEY}    ${CID}    ${S_OID}    ${EMPTY}
+
+
+    [Teardown]          Teardown    payload_length_filter

--- a/robot/testsuites/integration/acl/object_attributes/version_filter.robot
+++ b/robot/testsuites/integration/acl/object_attributes/version_filter.robot
@@ -1,0 +1,17 @@
+*** Settings ***
+
+Resource        ../common_steps_acl_extended.robot
+Resource        ../../${RESOURCES}/setup_teardown.robot
+
+*** Test cases ***
+Version Object Filter for Extended ACL
+    [Documentation]         Testcase to validate if $Object:version eACL filter is correctly handled.
+    [Tags]                  ACL  eACL  NeoFS  NeoCLI
+    [Timeout]               20 min
+
+    [Setup]                 Setup
+
+    Log    Check eACL version Filter with MatchType String Equal 
+    Check eACL Filters with MatchType String Equal    $Object:version  
+
+    [Teardown]          Teardown    version_filter

--- a/robot/variables/eacl_object_filters.py
+++ b/robot/variables/eacl_object_filters.py
@@ -1,0 +1,21 @@
+EACL_OBJ_FILTERS = {'$Object:objectID': 'ID', 
+                    '$Object:containerID': 'CID', 
+                    '$Object:ownerID': 'OwnerID', 
+                    '$Object:creationEpoch': 'CreatedAtEpoch', 
+                    '$Object:payloadLength': 'PayloadLength', 
+                    '$Object:payloadHash': 'PayloadHash', 
+                    '$Object:objectType': 'Type', 
+                    '$Object:homomorphicHash': 'HomoHash', 
+                    '$Object:version': 'Version'}
+
+VERB_FILTER_DEP = {
+                    '$Object:objectID': ['GET', 'HEAD', 'DELETE', 'RANGE', 'RANGEHASH'], 
+                    '$Object:containerID': ['GET', 'PUT', 'HEAD', 'DELETE', 'SEARCH', 'RANGE', 'RANGEHASH'], 
+                    '$Object:ownerID': ['GET', 'HEAD'], 
+                    '$Object:creationEpoch': ['GET', 'PUT', 'HEAD'], 
+                    '$Object:payloadLength': ['GET', 'PUT', 'HEAD'], 
+                    '$Object:payloadHash': ['GET', 'PUT', 'HEAD'], 
+                    '$Object:objectType': ['GET', 'PUT', 'HEAD'], 
+                    '$Object:homomorphicHash': ['GET', 'PUT', 'HEAD'], 
+                    '$Object:version': ['GET', 'PUT', 'HEAD']
+                }


### PR DESCRIPTION
- Add `acl_extended_filters_object.robot` that checks if
1. all nine filters work properly 
2. the second rule for eACL is not applied if it contradicts the first one set
- Version is now parsed within `Decode Object System Header Json`
- PayloadHash and HomoHash are not byte strings any more
- Extra space between arguments in `acl_extended_filters.robot` removed
- Make `user_headers` parameter default `str = ""` in `'Put object'`

#103 