### PR TITLE
[#163] Setup and Teardown restart dev-env

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,8 @@ Test cases are designed to run on Python 3.8.
 
 ## Run
 
-Execute `./run.sh` script. It will run all the tests available in this repo. To run an arbitrary UserScenario or testcase(s), you need to run the command:
-`./run.sh robot/testsuites/integration/<UserScenario>` or `./run.sh robot/testsuites/integration/<UserScenario>/<testcase>.robot`
-
-Logs will be saved in the artifacts/ directory after tests with any of the statuses are completed.
+To run an arbitrary UserScenario or testcase, you need to run the command:
+`robot --outputdir artifacts/ robot/testsuites/integration/<UserScenario>` or `robot --outputdir artifacts/ robot/testsuites/integration/<UserScenario>/<testcase>.robot`
 
 The following UserScenarios and testcases are available for execution:
 

--- a/robot/resources/lib/python/cli_helpers.py
+++ b/robot/resources/lib/python/cli_helpers.py
@@ -13,14 +13,14 @@ from robot.api import logger
 ROBOT_AUTO_KEYWORDS = False
 
 
-def _cmd_run(cmd):
+def _cmd_run(cmd, timeout=30):
     """
     Runs given shell command <cmd>, in case of success returns its stdout,
     in case of failure returns error message.
     """
     try:
         compl_proc = subprocess.run(cmd, check=True, universal_newlines=True,
-                    stdout=subprocess.PIPE, stderr=subprocess.STDOUT, timeout=30,
+                    stdout=subprocess.PIPE, stderr=subprocess.STDOUT, timeout=timeout,
                     shell=True)
         output = compl_proc.stdout
         logger.info(f"Output: {output}")

--- a/robot/resources/lib/robot/setup_teardown.robot
+++ b/robot/resources/lib/robot/setup_teardown.robot
@@ -7,9 +7,12 @@ Library     utility_keywords.py
 *** Keywords ***
 
 Setup
+    [Arguments]       
+    Make Up    
     Create Directory    ${ASSETS_DIR}
 
 Teardown
     [Arguments]     ${LOGFILE}
     Remove Directory    ${ASSETS_DIR}   True
     Get Docker Logs     ${LOGFILE}
+    Make Down

--- a/robot/testsuites/integration/services/http_gate.robot
+++ b/robot/testsuites/integration/services/http_gate.robot
@@ -7,6 +7,7 @@ Library     payment_neogo.py
 Library     gates.py
 Library     wallet_keywords.py
 Library     rpc_call_keywords.py
+Library     utility_keywords.py
 
 Resource    payment_operations.robot
 Resource    setup_teardown.robot
@@ -16,6 +17,7 @@ ${PLACEMENT_RULE} =     REP 1 IN X CBF 1 SELECT 1 FROM * AS X
 ${TRANSFER_AMOUNT} =    ${6}
 ${DEPOSIT_AMOUNT} =     ${5}
 ${CONTAINER_WAIT_INTERVAL} =    1 min
+@{INCLUDE_SVC} =    http_gate
 
 *** Test cases ***
 
@@ -23,7 +25,8 @@ NeoFS HTTP Gateway
     [Documentation]     Creates container and does PUT, GET via HTTP Gate
     [Timeout]           5 min
 
-    [Setup]             Setup
+    [Setup]             Setup    
+                        Make Up    ${INCLUDE_SVC}
     
     ${WALLET}   ${ADDR}     ${WIF} =   Prepare Wallet And Deposit
 

--- a/robot/testsuites/integration/services/s3_gate_bucket.robot
+++ b/robot/testsuites/integration/services/s3_gate_bucket.robot
@@ -16,13 +16,15 @@ Resource    payment_operations.robot
 ${DEPOSIT} =     ${30}
 ${WIF} =    ${MAINNET_WALLET_WIF}
 ${DEPOSIT_TIMEOUT}=    30s
+@{INCLUDE_SVC} =    s3_gate
 
 *** Test cases ***
 Buckets in NeoFS S3 Gateway
     [Documentation]             Execute operations with bucket via S3 Gate
     [Timeout]                   10 min
 
-    [Setup]                     Setup
+    [Setup]                     Setup    
+                                Make Up    ${INCLUDE_SVC}
 
     ${WALLET}   ${ADDR}    ${WIF} =    Prepare Wallet And Deposit
     ${FILE_S3} =                Generate file of bytes    ${COMPLEX_OBJ_SIZE}

--- a/robot/testsuites/integration/services/s3_gate_object.robot
+++ b/robot/testsuites/integration/services/s3_gate_object.robot
@@ -7,12 +7,14 @@ Library     payment_neogo.py
 Library     gates.py
 Library     wallet_keywords.py
 Library     contract_keywords.py
+Library     utility_keywords.py
 
 Resource    setup_teardown.robot
 
 *** Variables ***
 ${DEPOSIT_AMOUNT} =     ${5}
 ${WIF} =                ${MAINNET_WALLET_WIF}
+@{INCLUDE_SVC} =    s3_gate
 
 *** Test cases ***
 Objects in NeoFS S3 Gateway
@@ -20,7 +22,8 @@ Objects in NeoFS S3 Gateway
     [Documentation]             Execute operations with objects via S3 Gate
     [Timeout]                   10 min
 
-    [Setup]                     Setup
+    [Setup]                     Setup    
+                                Make Up    ${INCLUDE_SVC}
 
     ${WALLET}   ${ADDR} =       Init Wallet from WIF    ${ASSETS_DIR}     ${WIF}
     ${TX_DEPOSIT} =             NeoFS Deposit                         ${WIF}    ${DEPOSIT_AMOUNT}


### PR DESCRIPTION
- `Make Up` & `Make Down` keywords added into `utility_keywords.py`;
- `Make Up` & `Make Down` added to `Setup` & `Teardown` respectively, so that dev-env is now reset within every test upon it's setup;
- README.md changed
- timeout for `_cmd_run` is set 30s as default, but can be changed if needed (I used it for running `make up, etc.` and 30s is not always enough)

#163 
Logs for a test with `s3` in the name (it affects the dev-env build-up), a test without `s3` in the name, and a test in a subdirectory:[logs.zip](https://github.com/nspcc-dev/neofs-testcases/files/7838931/logs.zip)
Signed-off-by: Elizaveta Chichindaeva <elizaveta@nspcc.ru>