### PR TITLE
timeout on "make up" increased to 120 sec

### DIFF
--- a/robot/resources/lib/python/utility_keywords.py
+++ b/robot/resources/lib/python/utility_keywords.py
@@ -67,7 +67,7 @@ def make_up(services=['']):
     else:
         cmd = f'make up/basic; make update.max_object_size val={SIMPLE_OBJ_SIZE}'
         logger.info(f"Cmd: {cmd}")
-        _cmd_run(cmd, timeout=80)
+        _cmd_run(cmd, timeout=120)
 
     os.chdir(test_path)
 


### PR DESCRIPTION
About half of [tests](https://master.ci.nspcc.ru/job/Neofs_Int_Tests/477/) fail because there isn't enough time for devenv to start. 