### PR TITLE
[#424] neofs-cli: WIF replaced with wallets

### DIFF
--- a/robot/resources/lib/python/acl.py
+++ b/robot/resources/lib/python/acl.py
@@ -9,7 +9,7 @@ import uuid
 import base64
 import base58
 from cli_helpers import _cmd_run
-from common import ASSETS_DIR, NEOFS_ENDPOINT
+from common import ASSETS_DIR, NEOFS_ENDPOINT, WALLET_PASS
 from robot.api.deco import keyword
 from robot.api import logger
 
@@ -36,10 +36,10 @@ class Role(AutoName):
 
 
 @keyword('Get eACL')
-def get_eacl(wif: str, cid: str):
+def get_eacl(wallet: str, cid: str):
     cmd = (
-        f'{NEOFS_CLI_EXEC} --rpc-endpoint {NEOFS_ENDPOINT} --wallet {wif} '
-        f'container get-eacl --cid {cid}'
+        f'{NEOFS_CLI_EXEC} --rpc-endpoint {NEOFS_ENDPOINT} --wallet {wallet} '
+        f'container get-eacl --cid {cid} --config {WALLET_PASS}'
     )
     try:
         output = _cmd_run(cmd)
@@ -53,10 +53,10 @@ def get_eacl(wif: str, cid: str):
 
 
 @keyword('Set eACL')
-def set_eacl(wif: str, cid: str, eacl_table_path: str):
+def set_eacl(wallet: str, cid: str, eacl_table_path: str):
     cmd = (
-        f'{NEOFS_CLI_EXEC} --rpc-endpoint {NEOFS_ENDPOINT} --wallet {wif} '
-        f'container set-eacl --cid {cid} --table {eacl_table_path} --await'
+        f'{NEOFS_CLI_EXEC} --rpc-endpoint {NEOFS_ENDPOINT} --wallet {wallet} '
+        f'container set-eacl --cid {cid} --table {eacl_table_path} --config {WALLET_PASS} --await'
     )
     _cmd_run(cmd)
 
@@ -159,9 +159,9 @@ def form_bearertoken_file(wif: str, cid: str, eacl_records: list) -> str:
     return file_path
 
 
-def sign_bearer_token(wif: str, eacl_rules_file: str):
+def sign_bearer_token(wallet: str, eacl_rules_file: str):
     cmd = (
         f'{NEOFS_CLI_EXEC} util sign bearer-token --from {eacl_rules_file} '
-        f'--to {eacl_rules_file} --wallet {wif} --json'
+        f'--to {eacl_rules_file} --wallet {wallet} --config {WALLET_PASS} --json'
     )
     _cmd_run(cmd)

--- a/robot/resources/lib/python/neofs_verbs.py
+++ b/robot/resources/lib/python/neofs_verbs.py
@@ -11,7 +11,7 @@ import random
 import uuid
 from functools import reduce
 
-from common import NEOFS_ENDPOINT, ASSETS_DIR, NEOFS_NETMAP
+from common import NEOFS_ENDPOINT, ASSETS_DIR, NEOFS_NETMAP, WALLET_PASS
 from cli_helpers import _cmd_run
 import json_transformers
 
@@ -25,7 +25,7 @@ NEOFS_CLI_EXEC = os.getenv('NEOFS_CLI_EXEC', 'neofs-cli')
 
 
 @keyword('Get object')
-def get_object(wif: str, cid: str, oid: str, bearer_token: str="",
+def get_object(wallet: str, cid: str, oid: str, bearer_token: str="",
     write_object: str="", endpoint: str="", options: str="" ):
     '''
     GET from NeoFS.
@@ -50,8 +50,8 @@ def get_object(wif: str, cid: str, oid: str, bearer_token: str="",
         endpoint = random.sample(NEOFS_NETMAP, 1)[0]
 
     cmd = (
-        f'{NEOFS_CLI_EXEC} --rpc-endpoint {endpoint} --wallet {wif} '
-        f'object get --cid {cid} --oid {oid} --file {file_path} '
+        f'{NEOFS_CLI_EXEC} --rpc-endpoint {endpoint} --wallet {wallet} '
+        f'object get --cid {cid} --oid {oid} --file {file_path} --config {WALLET_PASS} '
         f'{"--bearer " + bearer_token if bearer_token else ""} '
         f'{options}'
     )
@@ -60,7 +60,7 @@ def get_object(wif: str, cid: str, oid: str, bearer_token: str="",
 
 
 @keyword('Get Range Hash')
-def get_range_hash(wif: str, cid: str, oid: str, bearer_token: str,
+def get_range_hash(wallet: str, cid: str, oid: str, bearer_token: str,
         range_cut: str, options: str=""):
     '''
     GETRANGEHASH of given Object.
@@ -77,8 +77,8 @@ def get_range_hash(wif: str, cid: str, oid: str, bearer_token: str,
         None
     '''
     cmd = (
-        f'{NEOFS_CLI_EXEC} --rpc-endpoint {NEOFS_ENDPOINT} --wallet {wif} '
-        f'object hash --cid {cid} --oid {oid} --range {range_cut} '
+        f'{NEOFS_CLI_EXEC} --rpc-endpoint {NEOFS_ENDPOINT} --wallet {wallet} '
+        f'object hash --cid {cid} --oid {oid} --range {range_cut} --config {WALLET_PASS} '
         f'{"--bearer " + bearer_token if bearer_token else ""} '
         f'{options}'
     )
@@ -86,7 +86,7 @@ def get_range_hash(wif: str, cid: str, oid: str, bearer_token: str,
 
 
 @keyword('Put object')
-def put_object(wif: str, path: str, cid: str, bearer: str="", user_headers: dict={},
+def put_object(wallet: str, path: str, cid: str, bearer: str="", user_headers: dict={},
     endpoint: str="", options: str="" ):
     '''
     PUT of given file.
@@ -105,8 +105,8 @@ def put_object(wif: str, path: str, cid: str, bearer: str="", user_headers: dict
     if not endpoint:
         endpoint = random.sample(NEOFS_NETMAP, 1)[0]
     cmd = (
-        f'{NEOFS_CLI_EXEC} --rpc-endpoint {endpoint} --wallet {wif} '
-        f'object put --file {path} --cid {cid} {options} '
+        f'{NEOFS_CLI_EXEC} --rpc-endpoint {endpoint} --wallet {wallet} '
+        f'object put --file {path} --cid {cid} {options} --config {WALLET_PASS} '
         f'{"--bearer " + bearer if bearer else ""} '
         f'{"--attributes " + _dict_to_attrs(user_headers) if user_headers else ""}'
     )
@@ -118,7 +118,7 @@ def put_object(wif: str, path: str, cid: str, bearer: str="", user_headers: dict
 
 
 @keyword('Delete object')
-def delete_object(wif: str, cid: str, oid: str, bearer: str="", options: str=""):
+def delete_object(wallet: str, cid: str, oid: str, bearer: str="", options: str=""):
     '''
     DELETE an Object.
 
@@ -132,8 +132,8 @@ def delete_object(wif: str, cid: str, oid: str, bearer: str="", options: str="")
         (str): Tombstone ID
     '''
     cmd = (
-        f'{NEOFS_CLI_EXEC} --rpc-endpoint {NEOFS_ENDPOINT} --wallet {wif} '
-        f'object delete --cid {cid} --oid {oid} {options} '
+        f'{NEOFS_CLI_EXEC} --rpc-endpoint {NEOFS_ENDPOINT} --wallet {wallet} '
+        f'object delete --cid {cid} --oid {oid} {options} --config {WALLET_PASS} '
         f'{"--bearer " + bearer if bearer else ""}'
     )
     output = _cmd_run(cmd)
@@ -143,7 +143,7 @@ def delete_object(wif: str, cid: str, oid: str, bearer: str="", options: str="")
 
 
 @keyword('Get Range')
-def get_range(wif: str, cid: str, oid: str, range_file: str, bearer: str,
+def get_range(wallet: str, cid: str, oid: str, range_file: str, bearer: str,
         range_cut: str, options:str=""):
     '''
     GETRANGE an Object.
@@ -160,8 +160,8 @@ def get_range(wif: str, cid: str, oid: str, range_file: str, bearer: str,
         None
     '''
     cmd = (
-        f'{NEOFS_CLI_EXEC} --rpc-endpoint {NEOFS_ENDPOINT} --wallet {wif} '
-        f'object range --cid {cid} --oid {oid} --range {range_cut} '
+        f'{NEOFS_CLI_EXEC} --rpc-endpoint {NEOFS_ENDPOINT} --wallet {wallet} '
+        f'object range --cid {cid} --oid {oid} --range {range_cut} --config {WALLET_PASS} '
         f'--file {ASSETS_DIR}/{range_file} {options} '
         f'{"--bearer " + bearer if bearer else ""} '
     )
@@ -169,7 +169,7 @@ def get_range(wif: str, cid: str, oid: str, range_file: str, bearer: str,
 
 
 @keyword('Search object')
-def search_object(wif: str, cid: str, keys: str="", bearer: str="", filters: dict={},
+def search_object(wallet: str, cid: str, keys: str="", bearer: str="", filters: dict={},
         expected_objects_list=[], options:str=""):
     '''
     GETRANGE an Object.
@@ -193,8 +193,8 @@ def search_object(wif: str, cid: str, keys: str="", bearer: str="", filters: dic
         filters_result += ','.join(map(lambda i: f"'{i} EQ {filters[i]}'", filters))
 
     cmd = (
-        f'{NEOFS_CLI_EXEC} --rpc-endpoint {NEOFS_ENDPOINT} --wallet {wif} '
-        f'object search {keys} --cid {cid} {filters_result} {options} '
+        f'{NEOFS_CLI_EXEC} --rpc-endpoint {NEOFS_ENDPOINT} --wallet {wallet} '
+        f'object search {keys} --cid {cid} {filters_result} {options} --config {WALLET_PASS} '
         f'{"--bearer " + bearer if bearer else ""}'
     )
     output = _cmd_run(cmd)
@@ -213,7 +213,7 @@ def search_object(wif: str, cid: str, keys: str="", bearer: str="", filters: dic
 
 
 @keyword('Head object')
-def head_object(wif: str, cid: str, oid: str, bearer_token: str="",
+def head_object(wallet: str, cid: str, oid: str, bearer_token: str="",
     options:str="", endpoint: str="", json_output: bool = True,
     is_raw: bool = False, is_direct: bool = False):
     '''
@@ -240,7 +240,7 @@ def head_object(wif: str, cid: str, oid: str, bearer_token: str="",
     '''
     cmd = (
         f'{NEOFS_CLI_EXEC} --rpc-endpoint {endpoint if endpoint else NEOFS_ENDPOINT} '
-        f'--wallet {wif} '
+        f'--wallet {wallet} --config {WALLET_PASS} '
         f'object head --cid {cid} --oid {oid} {options} '
         f'{"--bearer " + bearer_token if bearer_token else ""} '
         f'{"--json" if json_output else ""} '

--- a/robot/resources/lib/python/utility_keywords.py
+++ b/robot/resources/lib/python/utility_keywords.py
@@ -45,14 +45,6 @@ def get_container_logs(testcase_name: str) -> None:
             os.remove(file_name)
     tar.close()
 
-@keyword('WIF to Binary')
-def wif_to_binary(wif: str) -> str:
-    priv_key = wallet.Account.private_key_from_wif(wif)
-    path = f"{os.getcwd()}/{ASSETS_DIR}/{str(uuid.uuid4())}"
-    with open(path, "wb") as out:
-        out.write(priv_key)
-    return path
-
 @keyword('Make Up')
 def make_up(services: list=[], config_dict: dict={}):
     test_path = os.getcwd()

--- a/robot/resources/lib/robot/common_steps_acl_extended.robot
+++ b/robot/resources/lib/robot/common_steps_acl_extended.robot
@@ -20,13 +20,12 @@ ${EACL_ERR_MSG} =    *
 *** Keywords ***
 
 Create Container Public
-    [Arguments]             ${USER_KEY}
+    [Arguments]             ${WALLET}
                             Log	                Create Public Container
-    ${PUBLIC_CID_GEN} =     Create container    ${USER_KEY}    ${PUBLIC_ACL}    ${COMMON_PLACEMENT_RULE}
+    ${PUBLIC_CID_GEN} =     Create container    ${WALLET}    ${PUBLIC_ACL}    ${COMMON_PLACEMENT_RULE}
                             Wait Until Keyword Succeeds    ${MORPH_BLOCK_TIME}    ${CONTAINER_WAIT_INTERVAL}
-                            ...     Container Existing    ${USER_KEY}    ${PUBLIC_CID_GEN}
+                            ...     Container Existing    ${WALLET}    ${PUBLIC_CID_GEN}
     [Return]                ${PUBLIC_CID_GEN}
-
 
 Generate files
     [Arguments]             ${SIZE}
@@ -35,59 +34,59 @@ Generate files
     ${FILE_S_GEN_2} =       Generate file of bytes    ${SIZE}
                             Set Global Variable       ${FILE_S}      ${FILE_S_GEN_1}
                             Set Global Variable       ${FILE_S_2}    ${FILE_S_GEN_2}
-
-
+    
 
 Check eACL Deny and Allow All
-    [Arguments]     ${KEY}    ${DENY_EACL}    ${ALLOW_EACL}    ${USER_KEY}
+    [Arguments]     ${WALLET}    ${DENY_EACL}    ${ALLOW_EACL}    ${USER_WALLET}
 
-    ${CID} =                Create Container Public     ${USER_KEY}
-    ${S_OID_USER} =         Put object                  ${USER_KEY}     ${FILE_S}        ${CID}   user_headers=${USER_HEADER}
-    ${D_OID_USER} =         Put object                  ${USER_KEY}     ${FILE_S}        ${CID}   user_headers=${USER_HEADER_DEL}
-    @{S_OBJ_H} =            Create List                 ${S_OID_USER}
+    ${CID} =                Create Container Public    ${USER_WALLET}
+    ${FILE_S}    ${_} =    Generate file    ${SIMPLE_OBJ_SIZE}
+    ${S_OID_USER} =         Put object                 ${USER_WALLET}     ${FILE_S}    ${CID}      user_headers=${USER_HEADER}
+    ${D_OID_USER} =         Put object                 ${USER_WALLET}     ${FILE_S}    ${CID}      user_headers=${USER_HEADER_DEL}
+    @{S_OBJ_H} =	        Create List	               ${S_OID_USER}
 
-                            Put object                 ${KEY}    ${FILE_S}        ${CID}     user_headers=${ANOTHER_HEADER}
+                            Put object                 ${WALLET}    ${FILE_S}    ${CID}            user_headers=${ANOTHER_HEADER}
 
-                            Get object                 ${KEY}    ${CID}        ${S_OID_USER}            ${EMPTY}            local_file_eacl
-                            Search object              ${KEY}    ${CID}        ${EMPTY}                 ${EMPTY}            ${USER_HEADER}    ${S_OBJ_H}
-                            Head object                ${KEY}    ${CID}        ${S_OID_USER}
+                            Get object                 ${WALLET}    ${CID}        ${S_OID_USER}    ${EMPTY}    local_file_eacl
+                            Search object              ${WALLET}    ${CID}        ${EMPTY}         ${EMPTY}    ${USER_HEADER}    ${S_OBJ_H}
+                            Head object                ${WALLET}    ${CID}        ${S_OID_USER}
 
-                            Get Range                  ${KEY}    ${CID}        ${S_OID_USER}            s_get_range       ${EMPTY}            0:256
-                            Get Range Hash             ${KEY}    ${CID}        ${S_OID_USER}            ${EMPTY}          0:256
-                            Delete object              ${KEY}    ${CID}        ${D_OID_USER}
+                            Get Range                  ${WALLET}    ${CID}        ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+                            Get Range Hash             ${WALLET}    ${CID}        ${S_OID_USER}    ${EMPTY}    0:256
+                            Delete object              ${WALLET}    ${CID}        ${D_OID_USER}
 
-                            Set eACL                   ${USER_KEY}     ${CID}        ${DENY_EACL}
-
-                            # The current ACL cache lifetime is 30 sec
-                            Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}
-
-                            Run Keyword And Expect Error        *
-                            ...  Put object                          ${KEY}    ${FILE_S}    ${CID}    user_headers=${USER_HEADER}
-                            Run Keyword And Expect Error        *
-                            ...  Get object                          ${KEY}    ${CID}       ${S_OID_USER}    ${EMPTY}            local_file_eacl
-                            Run Keyword And Expect Error        *
-                            ...  Search object                       ${KEY}    ${CID}       ${EMPTY}         ${EMPTY}            ${USER_HEADER}       ${S_OBJ_H}
-                            Run Keyword And Expect Error        *
-                            ...  Head object                         ${KEY}    ${CID}       ${S_OID_USER}
-                            Run Keyword And Expect Error        *
-                            ...  Get Range                           ${KEY}    ${CID}       ${S_OID_USER}    s_get_range         ${EMPTY}            0:256
-                            Run Keyword And Expect Error        *
-                            ...  Get Range Hash                      ${KEY}    ${CID}       ${S_OID_USER}    ${EMPTY}            0:256
-                            Run Keyword And Expect Error        *
-                            ...  Delete object                       ${KEY}    ${CID}       ${S_OID_USER}
-
-                            Set eACL                            ${USER_KEY}    ${CID}       ${ALLOW_EACL}
+                            Set eACL                   ${USER_WALLET}     ${CID}        ${DENY_EACL}
 
                             # The current ACL cache lifetime is 30 sec
                             Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}
 
-                            Put object              ${KEY}    ${FILE_S}     ${CID}              user_headers=${ANOTHER_HEADER}
-                            Get object              ${KEY}    ${CID}        ${S_OID_USER}       ${EMPTY}            local_file_eacl
-                            Search object           ${KEY}    ${CID}        ${EMPTY}            ${EMPTY}            ${USER_HEADER}     ${S_OBJ_H}
-                            Head object             ${KEY}    ${CID}        ${S_OID_USER}
-                            Get Range               ${KEY}    ${CID}        ${S_OID_USER}       s_get_range          ${EMPTY}            0:256
-                            Get Range Hash          ${KEY}    ${CID}        ${S_OID_USER}       ${EMPTY}             0:256
-                            Delete object           ${KEY}    ${CID}        ${S_OID_USER}
+                            Run Keyword And Expect Error        *
+                            ...  Put object                          ${WALLET}    ${FILE_S}    ${CID}           user_headers=${USER_HEADER}
+                            Run Keyword And Expect Error        *
+                            ...  Get object                          ${WALLET}    ${CID}       ${S_OID_USER}    ${EMPTY}    local_file_eacl
+                            Run Keyword And Expect Error        *
+                            ...  Search object                       ${WALLET}    ${CID}       ${EMPTY}         ${EMPTY}    ${USER_HEADER}    ${S_OBJ_H}
+                            Run Keyword And Expect Error        *
+                            ...  Head object                         ${WALLET}    ${CID}       ${S_OID_USER}
+                            Run Keyword And Expect Error        *
+                            ...  Get Range                           ${WALLET}    ${CID}       ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+                            Run Keyword And Expect Error        *
+                            ...  Get Range Hash                      ${WALLET}    ${CID}       ${S_OID_USER}    ${EMPTY}    0:256
+                            Run Keyword And Expect Error        *
+                            ...  Delete object                       ${WALLET}    ${CID}       ${S_OID_USER}
+
+                            Set eACL                            ${USER_WALLET}    ${CID}       ${ALLOW_EACL}
+
+                            # The current ACL cache lifetime is 30 sec
+                            Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}
+
+                            Put object        ${WALLET}    ${FILE_S}     ${CID}            user_headers=${ANOTHER_HEADER}
+                            Get object        ${WALLET}    ${CID}        ${S_OID_USER}     ${EMPTY}    local_file_eacl
+                            Search object     ${WALLET}    ${CID}        ${EMPTY}          ${EMPTY}    ${USER_HEADER}    ${S_OBJ_H}
+                            Head object       ${WALLET}    ${CID}        ${S_OID_USER}
+                            Get Range         ${WALLET}    ${CID}        ${S_OID_USER}     s_get_range    ${EMPTY}    0:256
+                            Get Range Hash    ${WALLET}    ${CID}        ${S_OID_USER}     ${EMPTY}    0:256
+                            Delete object     ${WALLET}    ${CID}        ${S_OID_USER}
 
 Compose eACL Custom
     [Arguments]    ${CID}    ${HEADER_DICT}    ${MATCH_TYPE}    ${FILTER}    ${ACCESS}    ${ROLE}
@@ -110,9 +109,9 @@ Compose eACL Custom
     [Return]    ${EACL_CUSTOM}
 
 Object Header Decoded
-    [Arguments]    ${USER_KEY}    ${CID}    ${OID}
+    [Arguments]    ${WALLET}    ${CID}    ${OID}
 
-    &{HEADER} =         Head Object    ${USER_KEY}    ${CID}    ${OID}
+    &{HEADER} =         Head Object    ${WALLET}    ${CID}    ${OID}
     # FIXME
     # 'objectID' key repositioning in dictionary for the calling keyword might
     # work uniformly with any key from 'header'
@@ -123,104 +122,109 @@ Object Header Decoded
 Check eACL Filters with MatchType String Equal
     [Arguments]    ${FILTER}
 
-    ${_}   ${_}    ${USER_KEY} =    Prepare Wallet And Deposit
-    ${_}   ${_}    ${OTHER_KEY} =    Prepare Wallet And Deposit
+    ${WALLET}   ${_}    ${_} =    Prepare Wallet And Deposit  
+    ${WALLET_OTH}   ${_}    ${_} =    Prepare Wallet And Deposit
 
-    ${CID} =            Create Container Public    ${USER_KEY}
+    ${CID} =            Create Container Public    ${WALLET} 
     ${FILE_S}    ${_} =    Generate file    ${SIMPLE_OBJ_SIZE}
 
-    ${S_OID_USER} =     Put Object    ${USER_KEY}    ${FILE_S}    ${CID}    user_headers=${USER_HEADER}
-    ${D_OID_USER} =     Put Object    ${USER_KEY}    ${FILE_S}    ${CID}
-    @{S_OBJ_H} =        Create List    ${S_OID_USER}
+    ${S_OID_USER} =     Put Object    ${WALLET}    ${FILE_S}    ${CID}  user_headers=${USER_HEADER}
+    ${D_OID_USER} =     Put object    ${WALLET}    ${FILE_S}    ${CID}
+    @{S_OBJ_H} =	    Create List    ${S_OID_USER}
 
-                        Get Object    ${OTHER_KEY}    ${CID}    ${S_OID_USER}    ${EMPTY}    local_file_eacl
-                        Search Object    ${OTHER_KEY}    ${CID}    ${EMPTY}    ${EMPTY}    ${USER_HEADER}    ${S_OBJ_H}
-                        Head Object    ${OTHER_KEY}    ${CID}    ${S_OID_USER}
-                        Get Range    ${OTHER_KEY}    ${CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
-                        Get Range Hash    ${OTHER_KEY}    ${CID}    ${S_OID_USER}    ${EMPTY}    0:256
-                        Delete Object    ${OTHER_KEY}    ${CID}    ${D_OID_USER}
+                        Get Object    ${WALLET_OTH}    ${CID}    ${S_OID_USER}    ${EMPTY}    local_file_eacl
+                        Search Object    ${WALLET_OTH}    ${CID}    ${EMPTY}    ${EMPTY}    ${USER_HEADER}    ${S_OBJ_H}
+                        Head Object    ${WALLET_OTH}    ${CID}    ${S_OID_USER}
+                        Get Range    ${WALLET_OTH}    ${CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+                        Get Range Hash    ${WALLET_OTH}    ${CID}    ${S_OID_USER}    ${EMPTY}    0:256
+                        Delete Object    ${WALLET_OTH}    ${CID}    ${D_OID_USER}
 
-    &{HEADER_DICT} =    Object Header Decoded    ${USER_KEY}    ${CID}    ${S_OID_USER}
-    ${EACL_CUSTOM} =    Compose eACL Custom    ${CID}    ${HEADER_DICT}    =    ${FILTER}    deny    others
-                        Set eACL    ${USER_KEY}    ${CID}    ${EACL_CUSTOM}
-                        Sleep                   ${MORPH_BLOCK_TIME}
+    &{HEADER_DICT} =    Object Header Decoded    ${WALLET}    ${CID}    ${S_OID_USER}
+    ${EACL_CUSTOM} =    Compose eACL Custom    ${CID}    ${HEADER_DICT}    =    ${FILTER}    DENY    OTHERS
+                        Set eACL    ${WALLET}    ${CID}    ${EACL_CUSTOM}
 
-    IF    'GET' in ${VERB_FILTER_DEP}[${FILTER}]
-        Run Keyword And Expect Error   ${EACL_ERR_MSG}
-        ...  Get object    ${OTHER_KEY}    ${CID}    ${S_OID_USER}    ${EMPTY}    ${OBJECT_PATH}
+                        # The current ACL cache lifetime is 30 sec
+                        Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}
+
+    IF    'GET' in ${VERB_FILTER_DEP}[${FILTER}]  
+        Run Keyword And Expect Error   ${EACL_ERR_MSG}    
+        ...  Get object    ${WALLET_OTH}    ${CID}    ${S_OID_USER}    ${EMPTY}    ${OBJECT_PATH}
     END
     IF    'HEAD' in ${VERB_FILTER_DEP}[${FILTER}]
         Run Keyword And Expect error    ${EACL_ERR_MSG}
-        ...  Head object    ${OTHER_KEY}    ${CID}    ${S_OID_USER}
+        ...  Head object    ${WALLET_OTH}    ${CID}    ${S_OID_USER}
     END
     IF    'RANGE' in ${VERB_FILTER_DEP}[${FILTER}]
         Run Keyword And Expect error    ${EACL_ERR_MSG}
-        ...  Get Range    ${OTHER_KEY}    ${CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+        ...  Get Range    ${WALLET_OTH}    ${CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
     END
     IF    'SEARCH' in ${VERB_FILTER_DEP}[${FILTER}]
         Run Keyword And Expect Error   ${EACL_ERR_MSG}
-        ...  Search Object    ${OTHER_KEY}    ${CID}    ${EMPTY}    ${EMPTY}    ${USER_HEADER}    ${S_OBJ_H}
+        ...  Search Object    ${WALLET_OTH}    ${CID}    ${EMPTY}    ${EMPTY}    ${USER_HEADER}    ${S_OBJ_H}
     END
     IF    'RANGEHASH' in ${VERB_FILTER_DEP}[${FILTER}]
         Run Keyword And Expect error    ${EACL_ERR_MSG}
-        ...  Get Range Hash    ${OTHER_KEY}    ${CID}    ${S_OID_USER}    ${EMPTY}    0:256
+        ...  Get Range Hash    ${WALLET_OTH}    ${CID}    ${S_OID_USER}    ${EMPTY}    0:256
     END
     IF    'DELETE' in ${VERB_FILTER_DEP}[${FILTER}]
         Run Keyword And Expect error    ${EACL_ERR_MSG}
-        ...  Delete Object    ${OTHER_KEY}    ${CID}    ${S_OID_USER}
+        ...  Delete Object    ${WALLET_OTH}    ${CID}    ${S_OID_USER}
     END
 
 Check eACL Filters with MatchType String Not Equal
     [Arguments]    ${FILTER}
 
-    ${_}   ${_}    ${USER_KEY} =    Prepare Wallet And Deposit
-    ${_}   ${_}    ${OTHER_KEY} =    Prepare Wallet And Deposit
+    ${WALLET}   ${_}    ${_} =    Prepare Wallet And Deposit
+    ${WALLET_OTH}   ${_}    ${_} =    Prepare Wallet And Deposit
 
-    ${CID} =            Create Container Public    ${USER_KEY}
+    ${CID} =            Create Container Public    ${WALLET}
     ${FILE_S}    ${_} =    Generate file    ${SIMPLE_OBJ_SIZE}
 
-    ${S_OID_OTH} =      Put Object    ${OTHER_KEY}    ${FILE_S}    ${CID}    user_headers=${ANOTHER_HEADER}
-    ${S_OID_USER} =     Put Object    ${USER_KEY}    ${FILE_S}    ${CID}    user_headers=${USER_HEADER}
-    ${D_OID_USER} =     Put object    ${USER_KEY}    ${FILE_S}    ${CID}
-    @{S_OBJ_H} =        Create List    ${S_OID_USER}
+    ${S_OID_OTH} =      Put Object    ${WALLET_OTH}    ${FILE_S}    ${CID}    user_headers=${ANOTHER_HEADER}
+    ${S_OID_USER} =     Put Object    ${WALLET}    ${FILE_S}    ${CID}    user_headers=${USER_HEADER}
+    ${D_OID_USER} =     Put object    ${WALLET}    ${FILE_S}    ${CID}
+    @{S_OBJ_H} =	    Create List    ${S_OID_USER}
 
-                        Get Object    ${USER_KEY}    ${CID}    ${S_OID_USER}    ${EMPTY}    local_file_eacl
-                        Head Object    ${USER_KEY}    ${CID}    ${S_OID_USER}
-                        Search Object    ${USER_KEY}    ${CID}    ${EMPTY}    ${EMPTY}    ${USER_HEADER}    ${S_OBJ_H}
-                        Get Range    ${USER_KEY}    ${CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
-                        Get Range Hash    ${USER_KEY}    ${CID}    ${S_OID_USER}    ${EMPTY}    0:256
+                        Get Object    ${WALLET}    ${CID}    ${S_OID_USER}    ${EMPTY}    local_file_eacl
+                        Head Object    ${WALLET}    ${CID}    ${S_OID_USER}
+                        Search Object    ${WALLET}    ${CID}    ${EMPTY}    ${EMPTY}    ${FILE_USR_HEADER}    ${S_OBJ_H}
+                        Get Range    ${WALLET}    ${CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+                        Get Range Hash    ${WALLET}    ${CID}    ${S_OID_USER}    ${EMPTY}    0:256
 
-    &{HEADER_DICT} =    Object Header Decoded    ${USER_KEY}    ${CID}    ${S_OID_USER}
+    &{HEADER_DICT} =    Object Header Decoded    ${WALLET}    ${CID}    ${S_OID_USER}
     ${EACL_CUSTOM} =    Compose eACL Custom    ${CID}    ${HEADER_DICT}    !=    ${FILTER}    deny    others
-                        Set eACL    ${USER_KEY}    ${CID}    ${EACL_CUSTOM}
+                        Set eACL    ${WALLET}    ${CID}    ${EACL_CUSTOM}
+
+                        # The current ACL cache lifetime is 30 sec
+                        Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}
 
     IF    'GET' in ${VERB_FILTER_DEP}[${FILTER}]
         Run Keyword And Expect Error   ${EACL_ERR_MSG}
-        ...  Get object    ${OTHER_KEY}    ${CID}    ${S_OID_OTH}    ${EMPTY}    ${OBJECT_PATH}
-        Get object    ${OTHER_KEY}    ${CID}    ${S_OID_USER}     ${EMPTY}    ${OBJECT_PATH}
+        ...  Get object    ${WALLET_OTH}    ${CID}    ${S_OID_OTH}    ${EMPTY}    ${OBJECT_PATH}
+        Get object    ${WALLET_OTH}    ${CID}    ${S_OID_USER}     ${EMPTY}    ${OBJECT_PATH}
     END
     IF    'HEAD' in ${VERB_FILTER_DEP}[${FILTER}]
         Run Keyword And Expect error    ${EACL_ERR_MSG}
-        ...  Head object    ${OTHER_KEY}    ${CID}    ${S_OID_OTH}
-        Head object    ${OTHER_KEY}    ${CID}    ${S_OID_USER}
+        ...  Head object    ${WALLET_OTH}    ${CID}    ${S_OID_OTH}
+        Head object    ${WALLET_OTH}    ${CID}    ${S_OID_USER}
     END
     IF    'SEARCH' in ${VERB_FILTER_DEP}[${FILTER}]
         Run Keyword And Expect error    ${EACL_ERR_MSG}
-        ...  Search object    ${OTHER_KEY}    ${CID}    ${EMPTY}    ${EMPTY}    ${ANOTHER_HEADER}    ${S_OBJ_H}
-        Search object    ${OTHER_KEY}    ${CID}    ${EMPTY}    ${EMPTY}    ${USER_HEADER}    ${S_OBJ_H}
+        ...  Search object    ${WALLET_OTH}    ${CID}    ${EMPTY}    ${EMPTY}    ${ANOTHER_HEADER}    ${S_OBJ_H}
+        Search object    ${WALLET_OTH}    ${CID}    ${EMPTY}    ${EMPTY}    ${USER_HEADER}    ${S_OBJ_H}
     END
     IF    'RANGE' in ${VERB_FILTER_DEP}[${FILTER}]
         Run Keyword And Expect error    ${EACL_ERR_MSG}
-        ...  Get Range    ${OTHER_KEY}    ${CID}    ${S_OID_OTH}    s_get_range    ${EMPTY}    0:256
-        Get Range    ${OTHER_KEY}    ${CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+        ...  Get Range    ${WALLET_OTH}    ${CID}    ${S_OID_OTH}    s_get_range    ${EMPTY}    0:256
+        Get Range    ${WALLET_OTH}    ${CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
     END
     IF    'RANGEHASH' in ${VERB_FILTER_DEP}[${FILTER}]
         Run Keyword And Expect error    ${EACL_ERR_MSG}
-        ...  Get Range Hash    ${OTHER_KEY}    ${CID}    ${S_OID_OTH}    ${EMPTY}    0:256
-        Get Range Hash    ${OTHER_KEY}    ${CID}    ${S_OID_USER}    ${EMPTY}    0:256
+        ...  Get Range Hash    ${WALLET_OTH}    ${CID}    ${S_OID_OTH}    ${EMPTY}    0:256
+        Get Range Hash    ${WALLET_OTH}    ${CID}    ${S_OID_USER}    ${EMPTY}    0:256
     END
     IF    'DELETE' in ${VERB_FILTER_DEP}[${FILTER}]
         Run Keyword And Expect error    ${EACL_ERR_MSG}
-        ...  Delete Object    ${OTHER_KEY}    ${CID}    ${S_OID_OTH}
-        Delete Object    ${OTHER_KEY}    ${CID}    ${S_OID_USER}
+        ...  Delete Object    ${WALLET_OTH}    ${CID}    ${S_OID_OTH}
+        Delete Object    ${WALLET_OTH}    ${CID}    ${S_OID_USER}
     END

--- a/robot/resources/lib/robot/common_steps_object.robot
+++ b/robot/resources/lib/robot/common_steps_object.robot
@@ -11,12 +11,12 @@ ${CONTAINER_WAIT_INTERVAL} =    1 min
 *** Keywords ***
 
 Prepare container
-    [Arguments]     ${WIF}
+    [Arguments]     ${WIF}    ${WALLET}
     ${NEOFS_BALANCE} =  Get NeoFS Balance       ${WIF}
 
-    ${CID} =            Create container          ${WIF}   ${EMPTY}     ${PLACEMENT_RULE}
+    ${CID} =            Create container          ${WALLET}   ${EMPTY}     ${PLACEMENT_RULE}
                         Wait Until Keyword Succeeds        ${MORPH_BLOCK_TIME}       ${CONTAINER_WAIT_INTERVAL}
-                        ...     Container Existing         ${WIF}   ${CID}
+                        ...     Container Existing         ${WALLET}   ${CID}
 
     ${NEW_NEOFS_BALANCE} =  Get NeoFS Balance     ${WIF}
     Should Be True      ${NEW_NEOFS_BALANCE} < ${NEOFS_BALANCE}

--- a/robot/resources/lib/robot/complex_object_operations.robot
+++ b/robot/resources/lib/robot/complex_object_operations.robot
@@ -11,10 +11,10 @@ Get Object Parts By Link Object
     [Documentation]     The keyword accepts the ID of a Large Object, retrieves its split
             ...         header and returns all Part Object IDs from Link Object.
 
-    [Arguments]         ${WIF}  ${CID}  ${LARGE_OID}
+    [Arguments]         ${WALLET}  ${CID}  ${LARGE_OID}
 
 
-    ${LINK_OID} =       Get Link Object     ${WIF}  ${CID}  ${LARGE_OID}
-    &{LINK_HEADER} =    Head Object         ${WIF}  ${CID}  ${LINK_OID}    is_raw=True
+    ${LINK_OID} =       Get Link Object     ${WALLET}  ${CID}  ${LARGE_OID}
+    &{LINK_HEADER} =    Head Object         ${WALLET}  ${CID}  ${LINK_OID}    is_raw=True
 
     [Return]    ${LINK_HEADER.header.split.children}

--- a/robot/resources/lib/robot/payment_operations.robot
+++ b/robot/resources/lib/robot/payment_operations.robot
@@ -5,32 +5,8 @@ Library     wallet_keywords.py
 Library     rpc_call_keywords.py
 Library     payment_neogo.py
 
-*** Variables ***
-${TRANSFER_AMOUNT} =    ${30}
-${DEPOSIT_AMOUNT} =     ${25}
-
 
 *** Keywords ***
-
-Payment Operations
-    [Arguments]   ${ADDR}     ${WIF}
-
-    ${TX} =       Transfer Mainnet Gas                ${MAINNET_WALLET_WIF}    ${ADDR}     ${TRANSFER_AMOUNT}
-                  Wait Until Keyword Succeeds         ${MAINNET_TIMEOUT}       ${MAINNET_BLOCK_TIME}
-                  ...  Transaction accepted in block  ${TX}
-
-    ${MAINNET_BALANCE} =    Get Mainnet Balance     ${ADDR}
-    Should Be Equal As Numbers                      ${MAINNET_BALANCE}  ${TRANSFER_AMOUNT}
-
-    ${TX_DEPOSIT} =         NeoFS Deposit           ${WIF}      ${DEPOSIT_AMOUNT}
-                            Wait Until Keyword Succeeds         ${MAINNET_TIMEOUT}  ${MAINNET_BLOCK_TIME}
-                            ...  Transaction accepted in block  ${TX_DEPOSIT}
-    # Now we have TX in main chain, but deposit might not propagate into the side chain yet.
-    # For certainty, sleeping during one morph block.
-    Sleep                   ${MORPH_BLOCK_TIME}
-
-    ${NEOFS_BALANCE} =      Get NeoFS Balance       ${WIF}
-    Should Be Equal As Numbers      ${NEOFS_BALANCE}    ${DEPOSIT_AMOUNT}
 
 Prepare Wallet And Deposit
     [Arguments]    ${DEPOSIT}=${30}
@@ -49,3 +25,18 @@ Prepare Wallet And Deposit
     Sleep               ${MORPH_BLOCK_TIME}
 
     [Return]    ${WALLET}    ${ADDR}    ${WIF}
+
+Prepare Wallet with WIF And Deposit
+    [Arguments]    ${WIF}    ${DEPOSIT}=${30}    
+
+    ${WALLET}    ${ADDR} =    Init Wallet from WIF    ${ASSETS_DIR}    ${WIF}
+    ${TX} =             Transfer Mainnet Gas                ${MAINNET_WALLET_WIF}    ${ADDR}    ${DEPOSIT+1}
+                        Wait Until Keyword Succeeds         ${MAINNET_TIMEOUT}    ${MAINNET_BLOCK_TIME}
+                        ...    Transaction accepted in block    ${TX}
+
+    ${TX_DEPOSIT} =     NeoFS Deposit           ${WIF}          ${DEPOSIT}
+                        Wait Until Keyword Succeeds             ${MAINNET_TIMEOUT}    ${MAINNET_BLOCK_TIME}
+                        ...    Transaction accepted in block    ${TX_DEPOSIT}
+    Sleep               ${MORPH_BLOCK_TIME}
+
+    [Return]    ${WALLET}    ${ADDR}

--- a/robot/resources/lib/robot/storage.robot
+++ b/robot/resources/lib/robot/storage.robot
@@ -4,12 +4,13 @@ Variables   common.py
 
 Library     Process
 
+
 *** Keywords ***
 
 Drop object
-    [Arguments]   ${NODE}    ${WIF_STORAGE}    ${CID}    ${OID}
+    [Arguments]   ${NODE}    ${WALLET_STORAGE}    ${CID}    ${OID}
 
-    ${DROP_SIMPLE} =    Run Process    ${NEOFS_CLI_EXEC} control drop-objects --endpoint ${NODE} --wallet ${WIF_STORAGE} -o ${CID}/${OID}
-                                        ...     shell=True
+    ${DROP_SIMPLE} =    Run Process    ${NEOFS_CLI_EXEC} control drop-objects --endpoint ${NODE} --wallet ${WALLET_STORAGE} --config ${WALLET_PASS} -o ${CID}/${OID}
+                        ...    shell=True
                         Log Many    stdout: ${DROP_SIMPLE.stdout}    stderr: ${DROP_SIMPLE.stderr}
                         Should Be Equal As Integers    ${DROP_SIMPLE.rc}    0   Got non-zero return code from CLI

--- a/robot/testsuites/integration/acl/acl_basic_private_container.robot
+++ b/robot/testsuites/integration/acl/acl_basic_private_container.robot
@@ -18,16 +18,16 @@ Basic ACL Operations for Private Container
 
     [Setup]                 Setup
 
-    ${_}   ${_}     ${USER_KEY} =   Prepare Wallet And Deposit
-    ${_}   ${_}     ${OTHER_KEY} =   Prepare Wallet And Deposit
+    ${WALLET}   ${_}     ${_} =   Prepare Wallet And Deposit
+    ${WALLET_OTH}   ${_}     ${_} =   Prepare Wallet And Deposit
 
-    ${PRIV_CID} =           Create Private Container    ${USER_KEY}
-    ${FILE_S}    ${_} =     Generate file    ${SIMPLE_OBJ_SIZE}
-                            Check Private Container    ${USER_KEY}    ${FILE_S}    ${PRIV_CID}    ${OTHER_KEY}
+    ${PRIV_CID} =           Create Private Container    ${WALLET}
+    ${FILE_S}    ${_} =    Generate file    ${SIMPLE_OBJ_SIZE}
+                            Check Private Container    ${WALLET}    ${FILE_S}    ${PRIV_CID}    ${WALLET_OTH}
 
-    ${PRIV_CID} =           Create Private Container    ${USER_KEY}
-    ${FILE_S}    ${_} =     Generate file    ${COMPLEX_OBJ_SIZE}
-                            Check Private Container    ${USER_KEY}    ${FILE_S}    ${PRIV_CID}    ${OTHER_KEY}
+    ${PRIV_CID} =           Create Private Container    ${WALLET}
+    ${FILE_S}    ${_} =    Generate file    ${COMPLEX_OBJ_SIZE}
+                            Check Private Container    ${WALLET}    ${FILE_S}    ${PRIV_CID}    ${WALLET_OTH}
 
     [Teardown]              Teardown    acl_basic_private_container
 
@@ -35,62 +35,63 @@ Basic ACL Operations for Private Container
 *** Keywords ***
 
 Check Private Container
-    [Arguments]    ${USER_KEY}    ${FILE_S}    ${PRIV_CID}    ${OTHER_KEY}
+    [Arguments]    ${USER_WALLET}    ${FILE_S}    ${PRIV_CID}    ${WALLET_OTH}
+
+    ${WALLET_SN}    ${ADDR_SN} =     Prepare Wallet with WIF And Deposit    ${NEOFS_SN_WIF}
+    ${WALLET_IR}    ${ADDR_IR} =     Prepare Wallet with WIF And Deposit    ${NEOFS_IR_WIF}
 
     # Put
-    ${S_OID_USER} =     Put Object         ${USER_KEY}    ${FILE_S}    ${PRIV_CID}
-                        Run Keyword And Expect Error      *
-                        ...  Put object    ${OTHER_KEY}    ${FILE_S}    ${PRIV_CID}
-    ${S_OID_SYS_IR} =    Put Object        ${NEOFS_IR_WIF}    ${FILE_S}    ${PRIV_CID}
-    ${S_OID_SYS_SN} =    Put Object        ${NEOFS_SN_WIF}    ${FILE_S}    ${PRIV_CID}
-
-                        Sleep   5s
+    ${S_OID_USER} =     Put Object         ${USER_WALLET}    ${FILE_S}    ${PRIV_CID}
+                        Run Keyword And Expect Error        *
+                        ...  Put object    ${WALLET_OTH}    ${FILE_S}    ${PRIV_CID}
+    ${S_OID_SYS_IR} =    Put Object        ${WALLET_IR}    ${FILE_S}    ${PRIV_CID}
+    ${S_OID_SYS_SN} =    Put Object        ${WALLET_SN}    ${FILE_S}    ${PRIV_CID}
 
     # Get
-                        Get Object         ${USER_KEY}    ${PRIV_CID}    ${S_OID_USER}    ${EMPTY}      s_file_read
-                        Run Keyword And Expect Error      *
-                        ...  Get object    ${OTHER_KEY}        ${PRIV_CID}    ${S_OID_USER}    ${EMPTY}      s_file_read
-                        Get Object         ${NEOFS_IR_WIF}    ${PRIV_CID}    ${S_OID_USER}    ${EMPTY}      s_file_read
-                        Get Object         ${NEOFS_SN_WIF}    ${PRIV_CID}    ${S_OID_USER}    ${EMPTY}      s_file_read
+                        Get Object         ${USER_WALLET}    ${PRIV_CID}    ${S_OID_USER}    ${EMPTY}      s_file_read
+                        Run Keyword And Expect Error        *
+                        ...  Get object    ${WALLET_OTH}        ${PRIV_CID}    ${S_OID_USER}    ${EMPTY}      s_file_read
+                        Get Object         ${WALLET_IR}    ${PRIV_CID}    ${S_OID_USER}    ${EMPTY}      s_file_read
+                        Get Object         ${WALLET_SN}    ${PRIV_CID}    ${S_OID_USER}    ${EMPTY}      s_file_read
 
     # Get Range
-                        Get Range         ${USER_KEY}    ${PRIV_CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+                        Get Range         ${USER_WALLET}    ${PRIV_CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
                         Run Keyword And Expect Error        *
-                        ...  Get Range    ${OTHER_KEY}    ${PRIV_CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+                        ...  Get Range    ${WALLET_OTH}    ${PRIV_CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
                         Run Keyword And Expect Error        *
-                        ...  Get Range    ${NEOFS_IR_WIF}    ${PRIV_CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+                        ...  Get Range    ${WALLET_IR}    ${PRIV_CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
                         Run Keyword And Expect Error        *
-                        ...  Get Range    ${NEOFS_SN_WIF}    ${PRIV_CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+                        ...  Get Range    ${WALLET_SN}    ${PRIV_CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
 
     # Get Range Hash
-                        Get Range hash         ${USER_KEY}    ${PRIV_CID}    ${S_OID_USER}    ${EMPTY}    0:256
+                        Get Range hash         ${USER_WALLET}    ${PRIV_CID}    ${S_OID_USER}    ${EMPTY}    0:256
                         Run Keyword And Expect Error        *
-                        ...  Get Range Hash    ${OTHER_KEY}    ${PRIV_CID}    ${S_OID_USER}    ${EMPTY}    0:256
-                        Get Range hash         ${NEOFS_IR_WIF}    ${PRIV_CID}    ${S_OID_USER}    ${EMPTY}    0:256
-                        Get Range hash         ${NEOFS_SN_WIF}    ${PRIV_CID}    ${S_OID_USER}    ${EMPTY}    0:256
+                        ...  Get Range Hash    ${WALLET_OTH}    ${PRIV_CID}    ${S_OID_USER}    ${EMPTY}    0:256
+                        Get Range hash         ${WALLET_IR}    ${PRIV_CID}    ${S_OID_USER}    ${EMPTY}    0:256
+                        Get Range hash         ${WALLET_SN}    ${PRIV_CID}    ${S_OID_USER}    ${EMPTY}    0:256
 
     # Search
     @{S_OBJ_PRIV} =     Create List    ${S_OID_USER}    ${S_OID_SYS_SN}    ${S_OID_SYS_IR}
-                        Search Object         ${USER_KEY}    ${PRIV_CID}    keys=--root    expected_objects_list=${S_OBJ_PRIV}
+                        Search Object         ${USER_WALLET}    ${PRIV_CID}    keys=--root    expected_objects_list=${S_OBJ_PRIV}
                         Run Keyword And Expect Error        *
-                        ...  Search object    ${OTHER_KEY}    ${PRIV_CID}    keys=--root    expected_objects_list=${S_OBJ_PRIV}
-                        Search Object         ${NEOFS_IR_WIF}    ${PRIV_CID}    keys=--root    expected_objects_list=${S_OBJ_PRIV}
-                        Search Object         ${NEOFS_SN_WIF}    ${PRIV_CID}    keys=--root    expected_objects_list=${S_OBJ_PRIV}
+                        ...  Search object    ${WALLET_OTH}    ${PRIV_CID}    keys=--root    expected_objects_list=${S_OBJ_PRIV}
+                        Search Object         ${WALLET_IR}    ${PRIV_CID}    keys=--root    expected_objects_list=${S_OBJ_PRIV}
+                        Search Object         ${WALLET_SN}    ${PRIV_CID}    keys=--root    expected_objects_list=${S_OBJ_PRIV}
 
 
     # Head
-                        Head Object         ${USER_KEY}    ${PRIV_CID}    ${S_OID_USER}
+                        Head Object         ${USER_WALLET}    ${PRIV_CID}    ${S_OID_USER}
                         Run Keyword And Expect Error        *
-                        ...  Head object    ${OTHER_KEY}    ${PRIV_CID}    ${S_OID_USER}
-                        Head Object         ${NEOFS_IR_WIF}    ${PRIV_CID}    ${S_OID_USER}
-                        Head Object         ${NEOFS_SN_WIF}    ${PRIV_CID}    ${S_OID_USER}
+                        ...  Head object    ${WALLET_OTH}    ${PRIV_CID}    ${S_OID_USER}
+                        Head Object         ${WALLET_IR}    ${PRIV_CID}    ${S_OID_USER}
+                        Head Object         ${WALLET_SN}    ${PRIV_CID}    ${S_OID_USER}
 
 
     # Delete
                         Run Keyword And Expect Error        *
-                        ...  Delete object    ${OTHER_KEY}    ${PRIV_CID}    ${S_OID_USER}
+                        ...  Delete object    ${WALLET_OTH}    ${PRIV_CID}    ${S_OID_USER}
                         Run Keyword And Expect Error        *
-                        ...  Delete object    ${NEOFS_IR_WIF}    ${PRIV_CID}    ${S_OID_USER}
+                        ...  Delete object    ${WALLET_IR}    ${PRIV_CID}    ${S_OID_USER}
                         Run Keyword And Expect Error        *
-                        ...  Delete object    ${NEOFS_SN_WIF}    ${PRIV_CID}    ${S_OID_USER}
-                        Delete Object         ${USER_KEY}    ${PRIV_CID}    ${S_OID_USER}
+                        ...  Delete object    ${WALLET_SN}    ${PRIV_CID}    ${S_OID_USER}
+                        Delete Object         ${USER_WALLET}    ${PRIV_CID}    ${S_OID_USER}

--- a/robot/testsuites/integration/acl/acl_basic_private_container_storagegroup.robot
+++ b/robot/testsuites/integration/acl/acl_basic_private_container_storagegroup.robot
@@ -20,16 +20,16 @@ Basic ACL Operations for Private Container
 
     [Setup]                 Setup
 
-    ${_}   ${_}     ${USER_KEY} =   Prepare Wallet And Deposit
-    ${_}   ${_}     ${OTHER_KEY} =   Prepare Wallet And Deposit
+    ${WALLET}   ${_}     ${_} =   Prepare Wallet And Deposit
+    ${WALLET_OTH}   ${_}     ${_} =   Prepare Wallet And Deposit
 
-    ${PRIV_CID} =           Create Private Container    ${USER_KEY}
+    ${PRIV_CID} =           Create Private Container    ${WALLET}
     ${FILE_S}    ${_} =     Generate file    ${SIMPLE_OBJ_SIZE}
-                            Check Private Container    Simple    ${USER_KEY}    ${FILE_S}    ${PRIV_CID}    ${OTHER_KEY}
+                            Check Private Container    Simple    ${WALLET}    ${FILE_S}    ${PRIV_CID}    ${WALLET_OTH}
 
-    ${PRIV_CID} =           Create Private Container    ${USER_KEY}
+    ${PRIV_CID} =           Create Private Container    ${WALLET}
     ${FILE_S}    ${_} =     Generate file    ${COMPLEX_OBJ_SIZE}
-                            Check Private Container    Complex    ${USER_KEY}    ${FILE_S}    ${PRIV_CID}    ${OTHER_KEY}
+                            Check Private Container    Complex    ${WALLET}    ${FILE_S}    ${PRIV_CID}    ${WALLET_OTH}
 
     [Teardown]              Teardown    acl_basic_private_container_storagegroup
 
@@ -37,52 +37,55 @@ Basic ACL Operations for Private Container
 *** Keywords ***
 
 Check Private Container
-    [Arguments]     ${RUN_TYPE}    ${USER_KEY}    ${FILE_S}    ${PRIV_CID}    ${OTHER_KEY}
+    [Arguments]     ${RUN_TYPE}    ${USER_WALLET}    ${FILE_S}    ${PRIV_CID}    ${OTHER_WALLET}
+
+    ${WALLET_SN}    ${ADDR_SN} =     Prepare Wallet with WIF And Deposit    ${NEOFS_SN_WIF}
+    ${WALLET_IR}    ${ADDR_IR} =     Prepare Wallet with WIF And Deposit    ${NEOFS_IR_WIF}
 
     # Put target object to use in storage groups
-    ${S_OID_USER} =     Put object    ${USER_KEY}    ${FILE_S}    ${PRIV_CID}
+    ${S_OID_USER} =     Put object    ${USER_WALLET}    ${FILE_S}    ${PRIV_CID}
 
 
     # Storage group Operations (Put, List, Get, Delete) with different Keys
     # User group key
-    ${SG_OID_INV} =     Put Storagegroup    ${USER_KEY}    ${PRIV_CID}   ${EMPTY}    ${S_OID_USER}
-    ${SG_OID} =         Put Storagegroup    ${USER_KEY}    ${PRIV_CID}   ${EMPTY}    ${S_OID_USER}
-                        List Storagegroup    ${USER_KEY}    ${PRIV_CID}   ${EMPTY}    ${SG_OID}  ${SG_OID_INV}
+    ${SG_OID_INV} =     Put Storagegroup    ${USER_WALLET}    ${PRIV_CID}   ${EMPTY}    ${S_OID_USER}
+    ${SG_OID} =         Put Storagegroup    ${USER_WALLET}    ${PRIV_CID}   ${EMPTY}    ${S_OID_USER}
+                        List Storagegroup    ${USER_WALLET}    ${PRIV_CID}   ${EMPTY}    ${SG_OID}  ${SG_OID_INV}
     @{EXPECTED_OIDS} =  Run Keyword If    "${RUN_TYPE}" == "Complex"
-                        ...     Get Object Parts By Link Object    ${USER_KEY}    ${PRIV_CID}   ${S_OID_USER}
+                        ...     Get Object Parts By Link Object    ${USER_WALLET}    ${PRIV_CID}   ${S_OID_USER}
                         ...     ELSE IF   "${RUN_TYPE}" == "Simple"    Create List   ${S_OID_USER}
-                        Get Storagegroup    ${USER_KEY}    ${PRIV_CID}    ${SG_OID}   ${EMPTY}    ${EMPTY}    @{EXPECTED_OIDS}
-                        Delete Storagegroup    ${USER_KEY}    ${PRIV_CID}    ${SG_OID}    ${EMPTY}
+                        Get Storagegroup    ${USER_WALLET}    ${PRIV_CID}    ${SG_OID}   ${EMPTY}    ${EMPTY}    @{EXPECTED_OIDS}
+                        Delete Storagegroup    ${USER_WALLET}    ${PRIV_CID}    ${SG_OID}    ${EMPTY}
 
 
     # "Others" group key
                         Run Keyword And Expect Error        *
-                        ...  Put Storagegroup    ${OTHER_KEY}    ${PRIV_CID}   ${EMPTY}    ${S_OID_USER}
+                        ...  Put Storagegroup    ${OTHER_WALLET}    ${PRIV_CID}   ${EMPTY}    ${S_OID_USER}
                         Run Keyword And Expect Error        *
-                        ...  List Storagegroup    ${OTHER_KEY}    ${PRIV_CID}   ${EMPTY}    ${SG_OID_INV}
+                        ...  List Storagegroup    ${OTHER_WALLET}    ${PRIV_CID}   ${EMPTY}    ${SG_OID_INV}
                         Run Keyword And Expect Error        *
-                        ...  Get Storagegroup    ${OTHER_KEY}    ${PRIV_CID}    ${SG_OID_INV}   ${EMPTY}    ${EMPTY}    ${S_OID_USER}
+                        ...  Get Storagegroup    ${OTHER_WALLET}    ${PRIV_CID}    ${SG_OID_INV}   ${EMPTY}    ${EMPTY}    ${S_OID_USER}
                         Run Keyword And Expect Error        *
-                        ...  Delete Storagegroup    ${OTHER_KEY}    ${PRIV_CID}    ${SG_OID_INV}    ${EMPTY}
+                        ...  Delete Storagegroup    ${OTHER_WALLET}    ${PRIV_CID}    ${SG_OID_INV}    ${EMPTY}
 
 
     # System group key (Storage Node)
-    ${SG_OID_SN} =      Put Storagegroup    ${NEOFS_SN_WIF}    ${PRIV_CID}   ${EMPTY}    ${S_OID_USER}
-                        List Storagegroup    ${NEOFS_SN_WIF}    ${PRIV_CID}   ${EMPTY}    ${SG_OID_SN}  ${SG_OID_INV}
+    ${SG_OID_SN} =      Put Storagegroup    ${WALLET_SN}    ${PRIV_CID}   ${EMPTY}    ${S_OID_USER}
+                        List Storagegroup    ${WALLET_SN}    ${PRIV_CID}   ${EMPTY}    ${SG_OID_SN}  ${SG_OID_INV}
     @{EXPECTED_OIDS} =  Run Keyword If    "${RUN_TYPE}" == "Complex"
-                        ...     Get Object Parts By Link Object    ${NEOFS_SN_WIF}    ${PRIV_CID}   ${S_OID_USER}
+                        ...     Get Object Parts By Link Object    ${WALLET_SN}    ${PRIV_CID}   ${S_OID_USER}
                         ...     ELSE IF    "${RUN_TYPE}" == "Simple"    Create List    ${S_OID_USER}
-                        Get Storagegroup    ${NEOFS_SN_WIF}    ${PRIV_CID}    ${SG_OID_SN}   ${EMPTY}    ${EMPTY}    @{EXPECTED_OIDS}
+                        Get Storagegroup    ${WALLET_SN}    ${PRIV_CID}    ${SG_OID_SN}   ${EMPTY}    ${EMPTY}    @{EXPECTED_OIDS}
                         Run Keyword And Expect Error        *
-                        ...  Delete Storagegroup    ${NEOFS_SN_WIF}    ${PRIV_CID}    ${SG_OID_SN}    ${EMPTY}
+                        ...  Delete Storagegroup    ${WALLET_SN}    ${PRIV_CID}    ${SG_OID_SN}    ${EMPTY}
 
 
     # System group key (Inner Ring Node)
-    ${SG_OID_IR} =      Put Storagegroup    ${NEOFS_IR_WIF}    ${PRIV_CID}   ${EMPTY}    ${S_OID_USER}
-                        List Storagegroup    ${NEOFS_IR_WIF}    ${PRIV_CID}   ${EMPTY}    ${SG_OID_SN}    ${SG_OID_IR}    ${SG_OID_INV}
+    ${SG_OID_IR} =      Put Storagegroup    ${WALLET_IR}    ${PRIV_CID}   ${EMPTY}    ${S_OID_USER}
+                        List Storagegroup    ${WALLET_IR}    ${PRIV_CID}   ${EMPTY}    ${SG_OID_SN}    ${SG_OID_IR}    ${SG_OID_INV}
     @{EXPECTED_OIDS} =  Run Keyword If    "${RUN_TYPE}" == "Complex"
-                        ...     Get Object Parts By Link Object    ${USER_KEY}    ${PRIV_CID}   ${S_OID_USER}
+                        ...     Get Object Parts By Link Object    ${USER_WALLET}    ${PRIV_CID}   ${S_OID_USER}
                         ...     ELSE IF   "${RUN_TYPE}" == "Simple"    Create List   ${S_OID_USER}
-                        Get Storagegroup    ${NEOFS_IR_WIF}    ${PRIV_CID}    ${SG_OID_IR}   ${EMPTY}    ${EMPTY}    @{EXPECTED_OIDS}
+                        Get Storagegroup    ${WALLET_IR}    ${PRIV_CID}    ${SG_OID_IR}   ${EMPTY}    ${EMPTY}    @{EXPECTED_OIDS}
                         Run Keyword And Expect Error        *
-                        ...  Delete Storagegroup    ${NEOFS_IR_WIF}    ${PRIV_CID}    ${SG_OID_IR}    ${EMPTY}
+                        ...  Delete Storagegroup    ${WALLET_IR}    ${PRIV_CID}    ${SG_OID_IR}    ${EMPTY}

--- a/robot/testsuites/integration/acl/acl_basic_public_container.robot
+++ b/robot/testsuites/integration/acl/acl_basic_public_container.robot
@@ -18,16 +18,16 @@ Basic ACL Operations for Public Container
 
     [Setup]                 Setup
 
-    ${_}   ${_}     ${USER_KEY} =   Prepare Wallet And Deposit
-    ${_}   ${_}     ${OTHER_KEY} =   Prepare Wallet And Deposit
+    ${WALLET}   ${_}     ${_} =   Prepare Wallet And Deposit
+    ${WALLET_OTH}   ${_}     ${_} =   Prepare Wallet And Deposit
 
-    ${PUBLIC_CID} =         Create Public Container    ${USER_KEY}
+    ${PUBLIC_CID} =         Create Public Container    ${WALLET}
     ${FILE_S}    ${_} =     Generate file    ${SIMPLE_OBJ_SIZE}
-                            Check Public Container    ${USER_KEY}    ${FILE_S}    ${PUBLIC_CID}    ${OTHER_KEY}
+                            Check Public Container    ${WALLET}    ${FILE_S}    ${PUBLIC_CID}    ${WALLET_OTH}
 
-    ${PUBLIC_CID} =         Create Public Container    ${USER_KEY}
+    ${PUBLIC_CID} =         Create Public Container    ${WALLET}
     ${FILE_S}    ${_} =     Generate file    ${COMPLEX_OBJ_SIZE}
-                            Check Public Container    ${USER_KEY}    ${FILE_S}    ${PUBLIC_CID}    ${OTHER_KEY}
+                            Check Public Container    ${WALLET}    ${FILE_S}    ${PUBLIC_CID}    ${WALLET_OTH}
 
     [Teardown]              Teardown    acl_basic_public_container
 
@@ -35,63 +35,66 @@ Basic ACL Operations for Public Container
 *** Keywords ***
 
 Check Public Container
-    [Arguments]    ${USER_KEY}    ${FILE_S}    ${PUBLIC_CID}    ${OTHER_KEY}
+    [Arguments]    ${USER_WALLET}    ${FILE_S}    ${PUBLIC_CID}    ${WALLET_OTH}
+
+    ${WALLET_SN}    ${ADDR_SN} =     Prepare Wallet with WIF And Deposit    ${NEOFS_SN_WIF}
+    ${WALLET_IR}    ${ADDR_IR} =     Prepare Wallet with WIF And Deposit    ${NEOFS_IR_WIF}
 
     # Put
-    ${S_OID_USER} =         Put Object    ${USER_KEY}    ${FILE_S}    ${PUBLIC_CID}
-    ${S_OID_OTHER} =        Put Object    ${OTHER_KEY}    ${FILE_S}    ${PUBLIC_CID}
-    ${S_OID_SYS_IR} =       Put Object    ${NEOFS_IR_WIF}    ${FILE_S}    ${PUBLIC_CID}
-    ${S_OID_SYS_SN} =       Put Object    ${NEOFS_SN_WIF}    ${FILE_S}    ${PUBLIC_CID}
+    ${S_OID_USER} =         Put Object    ${USER_WALLET}    ${FILE_S}    ${PUBLIC_CID}
+    ${S_OID_OTHER} =        Put Object    ${WALLET_OTH}    ${FILE_S}    ${PUBLIC_CID}
+    ${S_OID_SYS_IR} =       Put Object    ${WALLET_IR}    ${FILE_S}    ${PUBLIC_CID}
+    ${S_OID_SYS_SN} =       Put Object    ${WALLET_SN}    ${FILE_S}    ${PUBLIC_CID}
 
     # Get
-                            Get Object    ${USER_KEY}    ${PUBLIC_CID}    ${S_OID_USER}    ${EMPTY}    s_file_read
-                            Get Object    ${OTHER_KEY}    ${PUBLIC_CID}    ${S_OID_USER}    ${EMPTY}    s_file_read
-                            Get Object    ${NEOFS_IR_WIF}    ${PUBLIC_CID}    ${S_OID_USER}    ${EMPTY}    s_file_read
-                            Get Object    ${NEOFS_SN_WIF}    ${PUBLIC_CID}    ${S_OID_USER}    ${EMPTY}    s_file_read
+                            Get Object    ${USER_WALLET}    ${PUBLIC_CID}    ${S_OID_USER}    ${EMPTY}    s_file_read
+                            Get Object    ${WALLET_OTH}    ${PUBLIC_CID}    ${S_OID_USER}    ${EMPTY}    s_file_read
+                            Get Object    ${WALLET_IR}    ${PUBLIC_CID}    ${S_OID_USER}    ${EMPTY}    s_file_read
+                            Get Object    ${WALLET_SN}    ${PUBLIC_CID}    ${S_OID_USER}    ${EMPTY}    s_file_read
 
     # Get Range
-                            Get Range           ${USER_KEY}    ${PUBLIC_CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
-                            Get Range           ${OTHER_KEY}    ${PUBLIC_CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+                            Get Range           ${USER_WALLET}    ${PUBLIC_CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+                            Get Range           ${WALLET_OTH}    ${PUBLIC_CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
                             Run Keyword And Expect Error        *
-                            ...    Get Range    ${NEOFS_IR_WIF}    ${PUBLIC_CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+                            ...    Get Range    ${WALLET_IR}    ${PUBLIC_CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
                             Run Keyword And Expect Error        *
-                            ...    Get Range    ${NEOFS_SN_WIF}    ${PUBLIC_CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+                            ...    Get Range    ${WALLET_SN}    ${PUBLIC_CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
 
 
     # Get Range Hash
-                            Get Range Hash    ${USER_KEY}    ${PUBLIC_CID}    ${S_OID_USER}    ${EMPTY}    0:256
-                            Get Range Hash    ${OTHER_KEY}    ${PUBLIC_CID}    ${S_OID_USER}    ${EMPTY}    0:256
-                            Get Range Hash    ${NEOFS_IR_WIF}    ${PUBLIC_CID}    ${S_OID_USER}    ${EMPTY}    0:256
-                            Get Range Hash    ${NEOFS_SN_WIF}    ${PUBLIC_CID}    ${S_OID_USER}    ${EMPTY}    0:256
+                            Get Range Hash    ${USER_WALLET}    ${PUBLIC_CID}    ${S_OID_USER}    ${EMPTY}    0:256
+                            Get Range Hash    ${WALLET_OTH}    ${PUBLIC_CID}    ${S_OID_USER}    ${EMPTY}    0:256
+                            Get Range Hash    ${WALLET_IR}    ${PUBLIC_CID}    ${S_OID_USER}    ${EMPTY}    0:256
+                            Get Range Hash    ${WALLET_SN}    ${PUBLIC_CID}    ${S_OID_USER}    ${EMPTY}    0:256
 
     # Search
     @{S_OBJ_PRIV} =         Create List	      ${S_OID_USER}    ${S_OID_OTHER}    ${S_OID_SYS_SN}    ${S_OID_SYS_IR}
-                            Search object     ${USER_KEY}    ${PUBLIC_CID}     keys=--root    expected_objects_list=${S_OBJ_PRIV}
-                            Search object     ${OTHER_KEY}    ${PUBLIC_CID}     keys=--root    expected_objects_list=${S_OBJ_PRIV}
-                            Search object     ${NEOFS_IR_WIF}    ${PUBLIC_CID}     keys=--root    expected_objects_list=${S_OBJ_PRIV}
-                            Search object     ${NEOFS_SN_WIF}    ${PUBLIC_CID}     keys=--root    expected_objects_list=${S_OBJ_PRIV}
+                            Search object     ${USER_WALLET}    ${PUBLIC_CID}     keys=--root    expected_objects_list=${S_OBJ_PRIV}
+                            Search object     ${WALLET_OTH}    ${PUBLIC_CID}     keys=--root    expected_objects_list=${S_OBJ_PRIV}
+                            Search object     ${WALLET_IR}    ${PUBLIC_CID}     keys=--root    expected_objects_list=${S_OBJ_PRIV}
+                            Search object     ${WALLET_SN}    ${PUBLIC_CID}     keys=--root    expected_objects_list=${S_OBJ_PRIV}
 
     # Head
-                            Head Object    ${USER_KEY}    ${PUBLIC_CID}    ${S_OID_USER}
-                            Head Object    ${OTHER_KEY}    ${PUBLIC_CID}    ${S_OID_USER}
-                            Head Object    ${NEOFS_IR_WIF}    ${PUBLIC_CID}    ${S_OID_USER}
-                            Head Object    ${NEOFS_SN_WIF}    ${PUBLIC_CID}    ${S_OID_USER}
+                            Head Object    ${USER_WALLET}    ${PUBLIC_CID}    ${S_OID_USER}
+                            Head Object    ${WALLET_OTH}    ${PUBLIC_CID}    ${S_OID_USER}
+                            Head Object    ${WALLET_IR}    ${PUBLIC_CID}    ${S_OID_USER}
+                            Head Object    ${WALLET_SN}    ${PUBLIC_CID}    ${S_OID_USER}
 
-                            Head Object    ${USER_KEY}    ${PUBLIC_CID}    ${S_OID_OTHER}
-                            Head Object    ${OTHER_KEY}    ${PUBLIC_CID}    ${S_OID_OTHER}
-                            Head Object    ${NEOFS_IR_WIF}    ${PUBLIC_CID}    ${S_OID_OTHER}
-                            Head Object    ${NEOFS_SN_WIF}    ${PUBLIC_CID}    ${S_OID_OTHER}
+                            Head Object    ${USER_WALLET}    ${PUBLIC_CID}    ${S_OID_OTHER}
+                            Head Object    ${WALLET_OTH}    ${PUBLIC_CID}    ${S_OID_OTHER}
+                            Head Object    ${WALLET_IR}    ${PUBLIC_CID}    ${S_OID_OTHER}
+                            Head Object    ${WALLET_SN}    ${PUBLIC_CID}    ${S_OID_OTHER}
 
-                            Head Object    ${USER_KEY}    ${PUBLIC_CID}    ${S_OID_SYS_SN}
-                            Head Object    ${OTHER_KEY}    ${PUBLIC_CID}    ${S_OID_SYS_SN}
-                            Head Object    ${NEOFS_IR_WIF}    ${PUBLIC_CID}    ${S_OID_SYS_SN}
-                            Head Object    ${NEOFS_SN_WIF}    ${PUBLIC_CID}    ${S_OID_SYS_SN}
+                            Head Object    ${USER_WALLET}    ${PUBLIC_CID}    ${S_OID_SYS_SN}
+                            Head Object    ${WALLET_OTH}    ${PUBLIC_CID}    ${S_OID_SYS_SN}
+                            Head Object    ${WALLET_IR}    ${PUBLIC_CID}    ${S_OID_SYS_SN}
+                            Head Object    ${WALLET_SN}    ${PUBLIC_CID}    ${S_OID_SYS_SN}
 
 
     # Delete
-                            Delete object            ${USER_KEY}    ${PUBLIC_CID}    ${S_OID_SYS_IR}
-                            Delete Object            ${OTHER_KEY}    ${PUBLIC_CID}    ${S_OID_SYS_SN}
+                            Delete object            ${USER_WALLET}    ${PUBLIC_CID}    ${S_OID_SYS_IR}
+                            Delete Object            ${WALLET_OTH}    ${PUBLIC_CID}    ${S_OID_SYS_SN}
                             Run Keyword And Expect Error        *
-                            ...    Delete object     ${NEOFS_IR_WIF}    ${PUBLIC_CID}    ${S_OID_USER}
+                            ...    Delete object     ${WALLET_IR}    ${PUBLIC_CID}    ${S_OID_USER}
                             Run Keyword And Expect Error        *
-                            ...    Delete object     ${NEOFS_SN_WIF}    ${PUBLIC_CID}    ${S_OID_OTHER}
+                            ...    Delete object     ${WALLET_SN}    ${PUBLIC_CID}    ${S_OID_OTHER}

--- a/robot/testsuites/integration/acl/acl_basic_readonly_container.robot
+++ b/robot/testsuites/integration/acl/acl_basic_readonly_container.robot
@@ -19,103 +19,105 @@ Basic ACL Operations for Read-Only Container
 
     [Setup]                 Setup
 
-    ${_}   ${_}     ${USER_KEY} =   Prepare Wallet And Deposit
-    ${_}   ${_}     ${OTHER_KEY} =   Prepare Wallet And Deposit
+    ${WALLET}   ${_}     ${_} =   Prepare Wallet And Deposit
+    ${WALLET_OTH}   ${_}     ${_} =   Prepare Wallet And Deposit
 
-    ${READONLY_CID} =       Create Read-Only Container    ${USER_KEY}
+    ${READONLY_CID} =       Create Read-Only Container    ${WALLET}
     ${FILE_S}    ${_} =     Generate file    ${SIMPLE_OBJ_SIZE}
-                            Check Read-Only Container    Simple    ${USER_KEY}    ${FILE_S}    ${READONLY_CID}    ${OTHER_KEY}
+                            Check Read-Only Container    Simple    ${WALLET}    ${FILE_S}    ${READONLY_CID}    ${WALLET_OTH}
 
-    ${READONLY_CID} =       Create Read-Only Container    ${USER_KEY}
+    ${READONLY_CID} =       Create Read-Only Container    ${WALLET}
     ${FILE_S}    ${_} =     Generate file    ${COMPLEX_OBJ_SIZE}
-                            Check Read-Only Container    Complex    ${USER_KEY}    ${FILE_S}    ${READONLY_CID}    ${OTHER_KEY}
+                            Check Read-Only Container    Complex    ${WALLET}    ${FILE_S}    ${READONLY_CID}    ${WALLET_OTH}
 
     [Teardown]              Teardown    acl_basic_readonly_container
 
 
 *** Keywords ***
 
-
 Check Read-Only Container
-    [Arguments]     ${RUN_TYPE}    ${USER_KEY}    ${FILE_S}    ${READONLY_CID}    ${OTHER_KEY}
+    [Arguments]     ${RUN_TYPE}    ${USER_WALLET}    ${FILE_S}    ${READONLY_CID}    ${WALLET_OTH}
+
+    ${WALLET_SN}    ${ADDR_SN} =     Prepare Wallet with WIF And Deposit    ${NEOFS_SN_WIF}
+    ${WALLET_IR}    ${ADDR_IR} =     Prepare Wallet with WIF And Deposit    ${NEOFS_IR_WIF}
 
     # Put
-    ${S_OID_USER} =         Put Object         ${USER_KEY}    ${FILE_S}    ${READONLY_CID}
+    ${S_OID_USER} =         Put Object         ${USER_WALLET}    ${FILE_S}    ${READONLY_CID}
                             Run Keyword And Expect Error        *
-                            ...  Put object    ${OTHER_KEY}    ${FILE_S}    ${READONLY_CID}
-    ${S_OID_SYS_IR} =       Put Object         ${NEOFS_IR_WIF}    ${FILE_S}    ${READONLY_CID}
-    ${S_OID_SYS_SN} =       Put object         ${NEOFS_SN_WIF}    ${FILE_S}    ${READONLY_CID}
+                            ...  Put object    ${WALLET_OTH}    ${FILE_S}    ${READONLY_CID}
+    ${S_OID_SYS_IR} =       Put Object         ${WALLET_IR}    ${FILE_S}    ${READONLY_CID}
+    ${S_OID_SYS_SN} =       Put object         ${WALLET_SN}    ${FILE_S}    ${READONLY_CID}
 
 
     # Storage group Operations (Put, List, Get, Delete)
-    ${SG_OID_INV} =     Put Storagegroup    ${USER_KEY}    ${READONLY_CID}   ${EMPTY}    ${S_OID_USER}
-    ${SG_OID_1} =       Put Storagegroup    ${USER_KEY}    ${READONLY_CID}   ${EMPTY}    ${S_OID_USER}
-                        List Storagegroup    ${USER_KEY}    ${READONLY_CID}   ${EMPTY}    ${SG_OID_1}  ${SG_OID_INV}
+    ${SG_OID_INV} =     Put Storagegroup    ${USER_WALLET}    ${READONLY_CID}   ${EMPTY}    ${S_OID_USER}
+    ${SG_OID_1} =       Put Storagegroup    ${USER_WALLET}    ${READONLY_CID}   ${EMPTY}    ${S_OID_USER}
+                        List Storagegroup    ${USER_WALLET}    ${READONLY_CID}   ${EMPTY}    ${SG_OID_1}  ${SG_OID_INV}
     @{EXPECTED_OIDS} =  Run Keyword If    "${RUN_TYPE}" == "Complex"
-                        ...     Get Object Parts By Link Object    ${USER_KEY}    ${READONLY_CID}   ${S_OID_USER}
+                        ...     Get Object Parts By Link Object    ${USER_WALLET}    ${READONLY_CID}   ${S_OID_USER}
                         ...     ELSE IF   "${RUN_TYPE}" == "Simple"    Create List   ${S_OID_USER}
-                        Get Storagegroup    ${USER_KEY}    ${READONLY_CID}    ${SG_OID_1}   ${EMPTY}    ${EMPTY}    @{EXPECTED_OIDS}
-                        Delete Storagegroup    ${USER_KEY}    ${READONLY_CID}    ${SG_OID_1}    ${EMPTY}
+                        Get Storagegroup    ${USER_WALLET}    ${READONLY_CID}    ${SG_OID_1}   ${EMPTY}    ${EMPTY}    @{EXPECTED_OIDS}
+                        Delete Storagegroup    ${USER_WALLET}    ${READONLY_CID}    ${SG_OID_1}    ${EMPTY}
 
                         Run Keyword And Expect Error        *
-                        ...  Put Storagegroup    ${OTHER_KEY}    ${READONLY_CID}   ${EMPTY}    ${S_OID_USER}
-                        List Storagegroup    ${OTHER_KEY}    ${READONLY_CID}   ${EMPTY}    ${SG_OID_INV}
+                        ...  Put Storagegroup    ${WALLET_OTH}    ${READONLY_CID}   ${EMPTY}    ${S_OID_USER}
+                        List Storagegroup    ${WALLET_OTH}    ${READONLY_CID}   ${EMPTY}    ${SG_OID_INV}
     @{EXPECTED_OIDS} =  Run Keyword If    "${RUN_TYPE}" == "Complex"
-                        ...     Get Object Parts By Link Object    ${USER_KEY}    ${READONLY_CID}   ${S_OID_USER}
+                        ...     Get Object Parts By Link Object    ${USER_WALLET}    ${READONLY_CID}   ${S_OID_USER}
                         ...     ELSE IF   "${RUN_TYPE}" == "Simple"    Create List   ${S_OID_USER}
-                        Get Storagegroup    ${OTHER_KEY}    ${READONLY_CID}    ${SG_OID_INV}   ${EMPTY}    ${EMPTY}    @{EXPECTED_OIDS}
+                        Get Storagegroup    ${WALLET_OTH}    ${READONLY_CID}    ${SG_OID_INV}   ${EMPTY}    ${EMPTY}    @{EXPECTED_OIDS}
                         Run Keyword And Expect Error        *
-                        ...  Delete Storagegroup    ${OTHER_KEY}    ${READONLY_CID}    ${SG_OID_INV}    ${EMPTY}
+                        ...  Delete Storagegroup    ${WALLET_OTH}    ${READONLY_CID}    ${SG_OID_INV}    ${EMPTY}
 
-    ${SG_OID_IR} =      Put Storagegroup    ${NEOFS_IR_WIF}    ${READONLY_CID}   ${EMPTY}    ${S_OID_USER}
-                        List Storagegroup    ${NEOFS_IR_WIF}    ${READONLY_CID}   ${EMPTY}    ${SG_OID_INV}    ${SG_OID_IR}
+    ${SG_OID_IR} =      Put Storagegroup    ${WALLET_IR}    ${READONLY_CID}   ${EMPTY}    ${S_OID_USER}
+                        List Storagegroup    ${WALLET_IR}    ${READONLY_CID}   ${EMPTY}    ${SG_OID_INV}    ${SG_OID_IR}
     @{EXPECTED_OIDS} =  Run Keyword If    "${RUN_TYPE}" == "Complex"
-                        ...     Get Object Parts By Link Object    ${USER_KEY}    ${READONLY_CID}   ${S_OID_USER}
+                        ...     Get Object Parts By Link Object    ${USER_WALLET}    ${READONLY_CID}   ${S_OID_USER}
                         ...     ELSE IF   "${RUN_TYPE}" == "Simple"    Create List   ${S_OID_USER}
-                        Get Storagegroup    ${NEOFS_IR_WIF}    ${READONLY_CID}    ${SG_OID_IR}   ${EMPTY}    ${EMPTY}    @{EXPECTED_OIDS}
+                        Get Storagegroup    ${WALLET_IR}    ${READONLY_CID}    ${SG_OID_IR}   ${EMPTY}    ${EMPTY}    @{EXPECTED_OIDS}
                         Run Keyword And Expect Error        *
-                        ...  Delete Storagegroup    ${NEOFS_IR_WIF}    ${READONLY_CID}    ${SG_OID_IR}    ${EMPTY}
+                        ...  Delete Storagegroup    ${WALLET_IR}    ${READONLY_CID}    ${SG_OID_IR}    ${EMPTY}
 
     # Get
-                        Get object    ${USER_KEY}    ${READONLY_CID}    ${S_OID_USER}    ${EMPTY}    s_file_read
-                        Get Object    ${OTHER_KEY}    ${READONLY_CID}    ${S_OID_USER}    ${EMPTY}    s_file_read
-                        Get Object    ${NEOFS_IR_WIF}    ${READONLY_CID}    ${S_OID_USER}    ${EMPTY}    s_file_read
-                        Get Object    ${NEOFS_SN_WIF}    ${READONLY_CID}    ${S_OID_USER}    ${EMPTY}    s_file_read
+                        Get object    ${USER_WALLET}    ${READONLY_CID}    ${S_OID_USER}    ${EMPTY}    s_file_read
+                        Get Object    ${WALLET_OTH}    ${READONLY_CID}    ${S_OID_USER}    ${EMPTY}    s_file_read
+                        Get Object    ${WALLET_IR}    ${READONLY_CID}    ${S_OID_USER}    ${EMPTY}    s_file_read
+                        Get Object    ${WALLET_SN}    ${READONLY_CID}    ${S_OID_USER}    ${EMPTY}    s_file_read
 
     # Get Range
-                        Get Range           ${USER_KEY}    ${READONLY_CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
-                        Get Range           ${OTHER_KEY}    ${READONLY_CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+                        Get Range           ${USER_WALLET}    ${READONLY_CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+                        Get Range           ${WALLET_OTH}    ${READONLY_CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
                         Run Keyword And Expect Error        *
-                        ...    Get Range    ${NEOFS_IR_WIF}    ${READONLY_CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+                        ...    Get Range    ${WALLET_IR}    ${READONLY_CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
                         Run Keyword And Expect Error        *
-                        ...    Get Range    ${NEOFS_SN_WIF}    ${READONLY_CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+                        ...    Get Range    ${WALLET_SN}    ${READONLY_CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
 
 
     # Get Range Hash
-                        Get Range hash    ${USER_KEY}    ${READONLY_CID}    ${S_OID_USER}    ${EMPTY}    0:256
-                        Get Range hash    ${OTHER_KEY}    ${READONLY_CID}    ${S_OID_USER}    ${EMPTY}    0:256
-                        Get Range hash    ${NEOFS_IR_WIF}    ${READONLY_CID}    ${S_OID_USER}    ${EMPTY}    0:256
-                        Get Range hash    ${NEOFS_SN_WIF}    ${READONLY_CID}    ${S_OID_USER}    ${EMPTY}    0:256
+                        Get Range hash    ${USER_WALLET}    ${READONLY_CID}    ${S_OID_USER}    ${EMPTY}    0:256
+                        Get Range hash    ${WALLET_OTH}    ${READONLY_CID}    ${S_OID_USER}    ${EMPTY}    0:256
+                        Get Range hash    ${WALLET_IR}    ${READONLY_CID}    ${S_OID_USER}    ${EMPTY}    0:256
+                        Get Range hash    ${WALLET_SN}    ${READONLY_CID}    ${S_OID_USER}    ${EMPTY}    0:256
 
     # Search
     @{S_OBJ_RO} =       Create List       ${S_OID_USER}    ${S_OID_SYS_SN}    ${S_OID_SYS_IR}
-                        Search Object     ${USER_KEY}    ${READONLY_CID}    keys=--root    expected_objects_list=${S_OBJ_RO}
-                        Search Object     ${OTHER_KEY}    ${READONLY_CID}    keys=--root    expected_objects_list=${S_OBJ_RO}
-                        Search Object     ${NEOFS_IR_WIF}    ${READONLY_CID}    keys=--root    expected_objects_list=${S_OBJ_RO}
-                        Search Object     ${NEOFS_SN_WIF}    ${READONLY_CID}    keys=--root    expected_objects_list=${S_OBJ_RO}
+                        Search Object     ${USER_WALLET}    ${READONLY_CID}    keys=--root    expected_objects_list=${S_OBJ_RO}
+                        Search Object     ${WALLET_OTH}    ${READONLY_CID}    keys=--root    expected_objects_list=${S_OBJ_RO}
+                        Search Object     ${WALLET_IR}    ${READONLY_CID}    keys=--root    expected_objects_list=${S_OBJ_RO}
+                        Search Object     ${WALLET_SN}    ${READONLY_CID}    keys=--root    expected_objects_list=${S_OBJ_RO}
 
 
     # Head
-                        Head Object    ${USER_KEY}    ${READONLY_CID}    ${S_OID_USER}
-                        Head Object    ${OTHER_KEY}    ${READONLY_CID}    ${S_OID_USER}
-                        Head Object    ${NEOFS_IR_WIF}    ${READONLY_CID}    ${S_OID_USER}
-                        Head Object    ${NEOFS_SN_WIF}    ${READONLY_CID}    ${S_OID_USER}
+                        Head Object    ${USER_WALLET}    ${READONLY_CID}    ${S_OID_USER}
+                        Head Object    ${WALLET_OTH}    ${READONLY_CID}    ${S_OID_USER}
+                        Head Object    ${WALLET_IR}    ${READONLY_CID}    ${S_OID_USER}
+                        Head Object    ${WALLET_SN}    ${READONLY_CID}    ${S_OID_USER}
 
     # Delete
                         Run Keyword And Expect Error        *
-                        ...  Delete object    ${OTHER_KEY}    ${READONLY_CID}    ${S_OID_USER}
+                        ...  Delete object    ${WALLET_OTH}    ${READONLY_CID}    ${S_OID_USER}
                         Run Keyword And Expect Error        *
-                        ...  Delete object    ${NEOFS_IR_WIF}    ${READONLY_CID}    ${S_OID_USER}
+                        ...  Delete object    ${WALLET_IR}    ${READONLY_CID}    ${S_OID_USER}
                         Run Keyword And Expect Error        *
-                        ...  Delete object    ${NEOFS_SN_WIF}    ${READONLY_CID}    ${S_OID_USER}
-                        Delete Object         ${USER_KEY}    ${READONLY_CID}    ${S_OID_USER}
+                        ...  Delete object    ${WALLET_SN}    ${READONLY_CID}    ${S_OID_USER}
+                        Delete Object         ${USER_WALLET}    ${READONLY_CID}    ${S_OID_USER}

--- a/robot/testsuites/integration/acl/acl_basic_readonly_container_storagegroup.robot
+++ b/robot/testsuites/integration/acl/acl_basic_readonly_container_storagegroup.robot
@@ -19,17 +19,16 @@ Basic ACL Operations for Read-Only Container
 
     [Setup]                 Setup
 
-    ${_}   ${_}     ${USER_KEY} =   Prepare Wallet And Deposit
-    ${_}   ${_}     ${OTHER_KEY} =   Prepare Wallet And Deposit
+    ${WALLET}   ${_}     ${_} =   Prepare Wallet And Deposit
+    ${WALLET_OTH}   ${_}     ${_} =   Prepare Wallet And Deposit
 
-    ${READONLY_CID} =       Create Read-Only Container    ${USER_KEY}
+    ${READONLY_CID} =       Create Read-Only Container    ${WALLET}
     ${FILE_S}    ${_} =     Generate file    ${SIMPLE_OBJ_SIZE}
-                            Check Read-Only Container    Simple    ${USER_KEY}    ${FILE_S}    ${READONLY_CID}    ${OTHER_KEY}
+                            Check Read-Only Container    Simple    ${WALLET}    ${FILE_S}    ${READONLY_CID}    ${WALLET_OTH}
 
-    ${READONLY_CID} =       Create Read-Only Container    ${USER_KEY}
+    ${READONLY_CID} =       Create Read-Only Container    ${WALLET}
     ${FILE_S}    ${_} =     Generate file    ${COMPLEX_OBJ_SIZE}
-                            Check Read-Only Container    Complex    ${USER_KEY}    ${FILE_S}    ${READONLY_CID}    ${OTHER_KEY}
-
+                            Check Read-Only Container    Complex    ${WALLET}    ${FILE_S}    ${READONLY_CID}    ${WALLET_OTH}
 
     [Teardown]              Teardown    acl_basic_readonly_container_storagegroup
 
@@ -38,39 +37,41 @@ Basic ACL Operations for Read-Only Container
 
 
 Check Read-Only Container
-    [Arguments]     ${RUN_TYPE}    ${USER_KEY}    ${FILE_S}    ${READONLY_CID}    ${OTHER_KEY}
+    [Arguments]     ${RUN_TYPE}    ${USER_WALLET}    ${FILE_S}    ${READONLY_CID}    ${WALLET_OTH}
+
+    ${WALLET_IR}    ${ADDR_IR} =     Prepare Wallet with WIF And Deposit    ${NEOFS_IR_WIF}
 
     # Put target object to use in storage groups
-    ${S_OID_USER} =     Put object    ${USER_KEY}    ${FILE_S}    ${READONLY_CID}
+    ${S_OID_USER} =     Put object    ${USER_WALLET}    ${FILE_S}    ${READONLY_CID}
 
     # Storage group Operations (Put, List, Get, Delete) for Read-only container
 
-    ${SG_OID_INV} =     Put Storagegroup    ${USER_KEY}    ${READONLY_CID}   ${EMPTY}    ${S_OID_USER}
-    ${SG_OID_1} =       Put Storagegroup    ${USER_KEY}    ${READONLY_CID}   ${EMPTY}    ${S_OID_USER}
-                        List Storagegroup    ${USER_KEY}    ${READONLY_CID}   ${EMPTY}    ${SG_OID_1}  ${SG_OID_INV}
+    ${SG_OID_INV} =     Put Storagegroup    ${USER_WALLET}    ${READONLY_CID}   ${EMPTY}    ${S_OID_USER}
+    ${SG_OID_1} =       Put Storagegroup    ${USER_WALLET}    ${READONLY_CID}   ${EMPTY}    ${S_OID_USER}
+                        List Storagegroup    ${USER_WALLET}    ${READONLY_CID}   ${EMPTY}    ${SG_OID_1}  ${SG_OID_INV}
     @{EXPECTED_OIDS} =  Run Keyword If    "${RUN_TYPE}" == "Complex"
-                        ...     Get Object Parts By Link Object    ${USER_KEY}    ${READONLY_CID}   ${S_OID_USER}
+                        ...     Get Object Parts By Link Object    ${USER_WALLET}    ${READONLY_CID}   ${S_OID_USER}
                         ...     ELSE IF   "${RUN_TYPE}" == "Simple"    Create List   ${S_OID_USER}
-                        Get Storagegroup    ${USER_KEY}    ${READONLY_CID}    ${SG_OID_1}   ${EMPTY}    ${EMPTY}    @{EXPECTED_OIDS}
-                        Delete Storagegroup    ${USER_KEY}    ${READONLY_CID}    ${SG_OID_1}    ${EMPTY}
+                        Get Storagegroup    ${USER_WALLET}    ${READONLY_CID}    ${SG_OID_1}   ${EMPTY}    ${EMPTY}    @{EXPECTED_OIDS}
+                        Delete Storagegroup    ${USER_WALLET}    ${READONLY_CID}    ${SG_OID_1}    ${EMPTY}
 
 
                         Run Keyword And Expect Error        *
-                        ...  Put Storagegroup    ${OTHER_KEY}    ${READONLY_CID}   ${EMPTY}    ${S_OID_USER}
-                        List Storagegroup    ${OTHER_KEY}    ${READONLY_CID}   ${EMPTY}    ${SG_OID_INV}
+                        ...  Put Storagegroup    ${WALLET_OTH}    ${READONLY_CID}   ${EMPTY}    ${S_OID_USER}
+                        List Storagegroup    ${WALLET_OTH}    ${READONLY_CID}   ${EMPTY}    ${SG_OID_INV}
     @{EXPECTED_OIDS} =  Run Keyword If    "${RUN_TYPE}" == "Complex"
-                        ...     Get Object Parts By Link Object    ${USER_KEY}    ${READONLY_CID}   ${S_OID_USER}
+                        ...     Get Object Parts By Link Object    ${USER_WALLET}    ${READONLY_CID}   ${S_OID_USER}
                         ...     ELSE IF   "${RUN_TYPE}" == "Simple"    Create List   ${S_OID_USER}
-                        Get Storagegroup    ${OTHER_KEY}    ${READONLY_CID}    ${SG_OID_INV}   ${EMPTY}    ${EMPTY}    @{EXPECTED_OIDS}
+                        Get Storagegroup    ${WALLET_OTH}    ${READONLY_CID}    ${SG_OID_INV}   ${EMPTY}    ${EMPTY}    @{EXPECTED_OIDS}
                         Run Keyword And Expect Error        *
-                        ...  Delete Storagegroup    ${OTHER_KEY}    ${READONLY_CID}    ${SG_OID_INV}    ${EMPTY}
+                        ...  Delete Storagegroup    ${WALLET_OTH}    ${READONLY_CID}    ${SG_OID_INV}    ${EMPTY}
 
 
-    ${SG_OID_IR} =      Put Storagegroup    ${NEOFS_IR_WIF}    ${READONLY_CID}   ${EMPTY}    ${S_OID_USER}
-                        List Storagegroup    ${NEOFS_IR_WIF}    ${READONLY_CID}   ${EMPTY}    ${SG_OID_INV}    ${SG_OID_IR}
+    ${SG_OID_IR} =      Put Storagegroup    ${WALLET_IR}    ${READONLY_CID}   ${EMPTY}    ${S_OID_USER}
+                        List Storagegroup    ${WALLET_IR}    ${READONLY_CID}   ${EMPTY}    ${SG_OID_INV}    ${SG_OID_IR}
     @{EXPECTED_OIDS} =  Run Keyword If    "${RUN_TYPE}" == "Complex"
-                        ...     Get Object Parts By Link Object    ${USER_KEY}    ${READONLY_CID}   ${S_OID_USER}
+                        ...     Get Object Parts By Link Object    ${USER_WALLET}    ${READONLY_CID}   ${S_OID_USER}
                         ...     ELSE IF   "${RUN_TYPE}" == "Simple"    Create List   ${S_OID_USER}
-                        Get Storagegroup    ${NEOFS_IR_WIF}    ${READONLY_CID}    ${SG_OID_IR}   ${EMPTY}    ${EMPTY}    @{EXPECTED_OIDS}
+                        Get Storagegroup    ${WALLET_IR}    ${READONLY_CID}    ${SG_OID_IR}   ${EMPTY}    ${EMPTY}    @{EXPECTED_OIDS}
                         Run Keyword And Expect Error        *
-                        ...  Delete Storagegroup    ${NEOFS_IR_WIF}    ${READONLY_CID}    ${SG_OID_INV}    ${EMPTY}
+                        ...  Delete Storagegroup    ${WALLET_IR}    ${READONLY_CID}    ${SG_OID_INV}    ${EMPTY}

--- a/robot/testsuites/integration/acl/acl_bearer_allow.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_allow.robot
@@ -25,15 +25,15 @@ BearerToken Operations
 
     [Setup]                 Setup
 
-    ${_}   ${_}     ${USER_KEY} =   Prepare Wallet And Deposit
+    ${WALLET}   ${_}     ${_} =   Prepare Wallet And Deposit
 
                             Log    Check Bearer token with simple object
     ${FILE_S} =             Generate file    ${SIMPLE_OBJ_SIZE}
-                            Check eACL Deny and Allow All Bearer    ${USER_KEY}    ${FILE_S}
+                            Check eACL Deny and Allow All Bearer    ${WALLET}    ${FILE_S}
 
                             Log    Check Bearer token with complex object
     ${FILE_S} =             Generate file    ${COMPLEX_OBJ_SIZE}
-                            Check eACL Deny and Allow All Bearer    ${USER_KEY}    ${FILE_S}
+                            Check eACL Deny and Allow All Bearer    ${WALLET}    ${FILE_S}
 
 
     [Teardown]              Teardown    acl_bearer_allow
@@ -43,22 +43,21 @@ BearerToken Operations
 *** Keywords ***
 
 Check eACL Deny and Allow All Bearer
-    [Arguments]    ${USER_KEY}    ${FILE_S}
+    [Arguments]    ${WALLET}    ${FILE_S}
 
-    ${CID} =            Create Container Public    ${USER_KEY}
-                        Prepare eACL Role rules    ${CID}
-    ${S_OID_USER} =     Put object      ${USER_KEY}    ${FILE_S}    ${CID}    user_headers=${USER_HEADER}
-    ${D_OID_USER} =     Put object      ${USER_KEY}    ${FILE_S}    ${CID}    user_headers=${USER_HEADER_DEL}
-    @{S_OBJ_H} =        Create List     ${S_OID_USER}
+    ${CID} =            Create Container Public    ${WALLET}
+    ${S_OID_USER} =     Put object        ${WALLET}    ${FILE_S}    ${CID}    user_headers=${USER_HEADER}
+    ${D_OID_USER} =     Put object        ${WALLET}    ${FILE_S}    ${CID}    user_headers=${USER_HEADER_DEL}
+    @{S_OBJ_H} =        Create List	      ${S_OID_USER}
 
-                        Put object        ${USER_KEY}    ${FILE_S}     ${CID}           user_headers=${ANOTHER_HEADER}
-                        Get object        ${USER_KEY}    ${CID}        ${S_OID_USER}    ${EMPTY}       local_file_eacl
-                        Search object     ${USER_KEY}    ${CID}        ${EMPTY}         ${EMPTY}       ${USER_HEADER}    ${S_OBJ_H}
-                        Head object       ${USER_KEY}    ${CID}        ${S_OID_USER}
-                        Get Range         ${USER_KEY}    ${CID}        ${S_OID_USER}    s_get_range    ${EMPTY}      0:256
-                        Delete object     ${USER_KEY}    ${CID}        ${D_OID_USER}
+                        Put object        ${WALLET}    ${FILE_S}     ${CID}           user_headers=${ANOTHER_HEADER}
+                        Get object        ${WALLET}    ${CID}        ${S_OID_USER}    ${EMPTY}       local_file_eacl
+                        Search object     ${WALLET}    ${CID}        ${EMPTY}         ${EMPTY}       ${USER_HEADER}    ${S_OBJ_H}
+                        Head object       ${WALLET}    ${CID}        ${S_OID_USER}
+                        Get Range         ${WALLET}    ${CID}        ${S_OID_USER}    s_get_range    ${EMPTY}      0:256
+                        Delete object     ${WALLET}    ${CID}        ${D_OID_USER}
 
-                        Set eACL          ${USER_KEY}    ${CID}        ${EACL_DENY_ALL_USER}
+                        Set eACL          ${WALLET}    ${CID}        ${EACL_DENY_ALL_USER}
 
                         # The current ACL cache lifetime is 30 sec
                         Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}
@@ -73,25 +72,25 @@ Check eACL Deny and Allow All Bearer
 
     ${eACL_gen}=        Create List    ${rule1}    ${rule2}    ${rule3}    ${rule4}    ${rule5}    ${rule6}    ${rule7}
 
-    ${EACL_TOKEN} =     Form BearerToken File       ${USER_KEY}    ${CID}    ${eACL_gen}
+    ${EACL_TOKEN} =     Form BearerToken File       ${WALLET}    ${CID}    ${eACL_gen}
 
                         Run Keyword And Expect Error    *
-                        ...  Put object     ${USER_KEY}    ${FILE_S}    ${CID}
+                        ...  Put object     ${WALLET}    ${FILE_S}    ${CID}
                         Run Keyword And Expect Error    *
-                        ...  Get object     ${USER_KEY}    ${CID}       ${S_OID_USER}    ${EMPTY}       local_file_eacl
+                        ...  Get object     ${WALLET}    ${CID}       ${S_OID_USER}    ${EMPTY}       local_file_eacl
                         Run Keyword And Expect Error    *
-                        ...  Search object  ${USER_KEY}    ${CID}       ${EMPTY}         ${EMPTY}       ${USER_HEADER}    ${S_OBJ_H}
+                        ...  Search object  ${WALLET}    ${CID}       ${EMPTY}         ${EMPTY}       ${USER_HEADER}    ${S_OBJ_H}
                         Run Keyword And Expect Error    *
-                        ...  Head object    ${USER_KEY}    ${CID}       ${S_OID_USER}
+                        ...  Head object    ${WALLET}    ${CID}       ${S_OID_USER}
                         Run Keyword And Expect Error    *
-                        ...  Get Range      ${USER_KEY}    ${CID}       ${S_OID_USER}    s_get_range    ${EMPTY}      0:256
+                        ...  Get Range      ${WALLET}    ${CID}       ${S_OID_USER}    s_get_range    ${EMPTY}      0:256
                         Run Keyword And Expect Error    *
-                        ...  Delete object  ${USER_KEY}    ${CID}       ${S_OID_USER}
+                        ...  Delete object  ${WALLET}    ${CID}       ${S_OID_USER}
 
                         # All operations on object should be passed with bearer token
-                        Put object          ${USER_KEY}    ${FILE_S}    ${CID}           bearer=${EACL_TOKEN}
-                        Get object          ${USER_KEY}    ${CID}       ${S_OID_USER}    ${EACL_TOKEN}    local_file_eacl
-                        Search object       ${USER_KEY}    ${CID}       ${EMPTY}         ${EACL_TOKEN}    ${USER_HEADER}       ${S_OBJ_H}
-                        Head object         ${USER_KEY}    ${CID}       ${S_OID_USER}    bearer_token=${EACL_TOKEN}
-                        Get Range           ${USER_KEY}    ${CID}       ${S_OID_USER}    s_get_range      ${EACL_TOKEN}    0:256
-                        Delete object       ${USER_KEY}    ${CID}       ${S_OID_USER}    bearer=${EACL_TOKEN}
+                        Put object          ${WALLET}    ${FILE_S}    ${CID}           bearer=${EACL_TOKEN}
+                        Get object          ${WALLET}    ${CID}       ${S_OID_USER}    ${EACL_TOKEN}    local_file_eacl
+                        Search object       ${WALLET}    ${CID}       ${EMPTY}         ${EACL_TOKEN}    ${USER_HEADER}       ${S_OBJ_H}
+                        Head object         ${WALLET}    ${CID}       ${S_OID_USER}    bearer_token=${EACL_TOKEN}
+                        Get Range           ${WALLET}    ${CID}       ${S_OID_USER}    s_get_range      ${EACL_TOKEN}    0:256
+                        Delete object       ${WALLET}    ${CID}       ${S_OID_USER}    bearer=${EACL_TOKEN}

--- a/robot/testsuites/integration/acl/acl_bearer_allow_storagegroup.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_allow_storagegroup.robot
@@ -22,15 +22,15 @@ BearerToken Operations
 
     [Setup]                 Setup
 
-    ${_}   ${_}     ${USER_KEY} =   Prepare Wallet And Deposit
+    ${WALLET}   ${_}     ${_} =   Prepare Wallet And Deposit
 
                             Log    Check Bearer token with simple object
     ${FILE_S} =             Generate file    ${SIMPLE_OBJ_SIZE}
-                            Check eACL Deny and Allow All Bearer    Simple    ${USER_KEY}    ${FILE_S}
+                            Check eACL Deny and Allow All Bearer    Simple    ${WALLET}    ${FILE_S}
 
                             Log    Check Bearer token with complex object
     ${FILE_S} =             Generate file    ${COMPLEX_OBJ_SIZE}
-                            Check eACL Deny and Allow All Bearer    Complex    ${USER_KEY}    ${FILE_S}
+                            Check eACL Deny and Allow All Bearer    Complex    ${WALLET}    ${FILE_S}
 
 
     [Teardown]              Teardown    acl_bearer_allow_storagegroup
@@ -40,24 +40,24 @@ BearerToken Operations
 *** Keywords ***
 
 Check eACL Deny and Allow All Bearer
-    [Arguments]     ${RUN_TYPE}    ${USER_KEY}    ${FILE_S}
+    [Arguments]     ${RUN_TYPE}    ${WALLET}    ${FILE_S}
 
-    ${CID} =                Create Container Public    ${USER_KEY}
-    ${S_OID_USER} =         Put object    ${USER_KEY}    ${FILE_S}    ${CID}
+    ${CID} =                Create Container Public    ${WALLET}
+    ${S_OID_USER} =         Put object    ${WALLET}    ${FILE_S}    ${CID}
                             Prepare eACL Role rules    ${CID}
 
 
     # Storage group Operations (Put, List, Get, Delete)
-    ${SG_OID_INV} =     Put Storagegroup    ${USER_KEY}    ${CID}   ${EMPTY}    ${S_OID_USER}
-    ${SG_OID_1} =       Put Storagegroup    ${USER_KEY}    ${CID}   ${EMPTY}    ${S_OID_USER}
-                        List Storagegroup    ${USER_KEY}    ${CID}   ${EMPTY}    ${SG_OID_1}  ${SG_OID_INV}
+    ${SG_OID_INV} =     Put Storagegroup    ${WALLET}    ${CID}   ${EMPTY}    ${S_OID_USER}
+    ${SG_OID_1} =       Put Storagegroup    ${WALLET}    ${CID}   ${EMPTY}    ${S_OID_USER}
+                        List Storagegroup    ${WALLET}    ${CID}   ${EMPTY}    ${SG_OID_1}  ${SG_OID_INV}
     @{EXPECTED_OIDS} =  Run Keyword If      "${RUN_TYPE}" == "Complex"
-                        ...     Get Object Parts By Link Object    ${USER_KEY}    ${CID}   ${S_OID_USER}
+                        ...     Get Object Parts By Link Object    ${WALLET}    ${CID}   ${S_OID_USER}
                         ...     ELSE IF      "${RUN_TYPE}" == "Simple"   Create List   ${S_OID_USER}
-                        Get Storagegroup    ${USER_KEY}    ${CID}    ${SG_OID_1}   ${EMPTY}    ${EMPTY}    @{EXPECTED_OIDS}
-                        Delete Storagegroup    ${USER_KEY}    ${CID}    ${SG_OID_1}    ${EMPTY}
+                        Get Storagegroup    ${WALLET}    ${CID}    ${SG_OID_1}   ${EMPTY}    ${EMPTY}    @{EXPECTED_OIDS}
+                        Delete Storagegroup    ${WALLET}    ${CID}    ${SG_OID_1}    ${EMPTY}
 
-                        Set eACL            ${USER_KEY}    ${CID}        ${EACL_DENY_ALL_USER}
+                        Set eACL            ${WALLET}    ${CID}        ${EACL_DENY_ALL_USER}
 
                         # The current ACL cache lifetime is 30 sec
                         Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}
@@ -72,20 +72,20 @@ Check eACL Deny and Allow All Bearer
 
     ${eACL_gen}=        Create List    ${rule1}    ${rule2}    ${rule3}    ${rule4}    ${rule5}    ${rule6}    ${rule7}
 
-    ${EACL_TOKEN} =     Form BearerToken File       ${USER_KEY}    ${CID}    ${eACL_gen}
+    ${EACL_TOKEN} =     Form BearerToken File       ${WALLET}    ${CID}    ${eACL_gen}
 
                         # All storage groups should fail without bearer token
                         Run Keyword And Expect Error        *
-                        ...  Put Storagegroup    ${USER_KEY}    ${CID}   ${EMPTY}    ${S_OID_USER}
+                        ...  Put Storagegroup    ${WALLET}    ${CID}   ${EMPTY}    ${S_OID_USER}
                         Run Keyword And Expect Error        *
-                        ...  List Storagegroup    ${USER_KEY}    ${CID}   ${EMPTY}    ${SG_OID_1}  ${SG_OID_INV}
+                        ...  List Storagegroup    ${WALLET}    ${CID}   ${EMPTY}    ${SG_OID_1}  ${SG_OID_INV}
                         Run Keyword And Expect Error        *
-                        ...  Get Storagegroup    ${USER_KEY}    ${CID}    ${SG_OID_1}   ${EMPTY}    ${EMPTY}    @{EXPECTED_OIDS}
+                        ...  Get Storagegroup    ${WALLET}    ${CID}    ${SG_OID_1}   ${EMPTY}    ${EMPTY}    @{EXPECTED_OIDS}
                         Run Keyword And Expect Error        *
-                        ...  Delete Storagegroup    ${USER_KEY}    ${CID}    ${SG_OID_1}    ${EMPTY}
+                        ...  Delete Storagegroup    ${WALLET}    ${CID}    ${SG_OID_1}    ${EMPTY}
 
     # Storagegroup should passed with User group key and bearer token
-    ${SG_OID_NEW} =     Put Storagegroup        ${USER_KEY}    ${CID}    ${EACL_TOKEN}    ${S_OID_USER}
-                        List Storagegroup       ${USER_KEY}    ${CID}    ${EACL_TOKEN}    ${SG_OID_NEW}     ${SG_OID_INV}
-                        Get Storagegroup        ${USER_KEY}    ${CID}    ${SG_OID_INV}    ${EACL_TOKEN}     ${EMPTY}    @{EXPECTED_OIDS}
-                        Delete Storagegroup     ${USER_KEY}    ${CID}    ${SG_OID_INV}    ${EACL_TOKEN}
+    ${SG_OID_NEW} =     Put Storagegroup        ${WALLET}    ${CID}    ${EACL_TOKEN}    ${S_OID_USER}
+                        List Storagegroup       ${WALLET}    ${CID}    ${EACL_TOKEN}    ${SG_OID_NEW}     ${SG_OID_INV}
+                        Get Storagegroup        ${WALLET}    ${CID}    ${SG_OID_INV}    ${EACL_TOKEN}     ${EMPTY}    @{EXPECTED_OIDS}
+                        Delete Storagegroup     ${WALLET}    ${CID}    ${SG_OID_INV}    ${EACL_TOKEN}

--- a/robot/testsuites/integration/acl/acl_bearer_compound.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_compound.robot
@@ -25,16 +25,16 @@ BearerToken Operations for Сompound Operations
 
     [Setup]             Setup
 
-    ${_}   ${_}     ${USER_KEY} =   Prepare Wallet And Deposit
-    ${_}   ${_}     ${OTHER_KEY} =   Prepare Wallet And Deposit
+    ${WALLET}   ${_}     ${_} =   Prepare Wallet And Deposit
+    ${WALLET_OTH}   ${_}     ${_} =   Prepare Wallet And Deposit
 
                         Log    Check Bearer token with simple object
     ${FILE_S} =         Generate file    ${SIMPLE_OBJ_SIZE}
-                        Check Сompound Operations    ${USER_KEY}    ${OTHER_KEY}    ${FILE_S}
+                        Check Сompound Operations    ${WALLET}    ${WALLET_OTH}    ${FILE_S}
 
                         Log    Check Bearer token with complex object
     ${FILE_S} =         Generate file    ${COMPLEX_OBJ_SIZE}
-                        Check Сompound Operations    ${USER_KEY}    ${OTHER_KEY}    ${FILE_S}
+                        Check Сompound Operations    ${WALLET}    ${WALLET_OTH}    ${FILE_S}
 
     [Teardown]          Teardown    acl_bearer_compound
 
@@ -42,30 +42,33 @@ BearerToken Operations for Сompound Operations
 *** Keywords ***
 
 Check Сompound Operations
-    [Arguments]    ${USER_KEY}    ${OTHER_KEY}    ${FILE_S}
-                        Check Bearer Сompound Get    ${OTHER_KEY}     OTHERS    ${EACL_DENY_ALL_OTHERS}    ${FILE_S}    ${USER_KEY}
-                        Check Bearer Сompound Get    ${USER_KEY}      USER      ${EACL_DENY_ALL_USER}    ${FILE_S}     ${USER_KEY}
-                        Check Bearer Сompound Get    ${SYSTEM_KEY}    SYSTEM    ${EACL_DENY_ALL_SYSTEM}    ${FILE_S}     ${USER_KEY}
+    [Arguments]         ${USER_WALLET}    ${OTHER_WALLET}    ${FILE_S}
 
-                        Check Bearer Сompound Delete    ${OTHER_KEY}     OTHERS    ${EACL_DENY_ALL_OTHERS}    ${FILE_S}     ${USER_KEY}
-                        Check Bearer Сompound Delete    ${USER_KEY}      USER      ${EACL_DENY_ALL_USER}    ${FILE_S}     ${USER_KEY}
-                        Check Bearer Сompound Delete    ${SYSTEM_KEY}    SYSTEM    ${EACL_DENY_ALL_SYSTEM}    ${FILE_S}    ${USER_KEY}
+    ${WALLET_SYS}    ${ADDR_SYS} =     Prepare Wallet with WIF And Deposit    ${SYSTEM_KEY}
 
-                        Check Bearer Сompound Get Range Hash    ${OTHER_KEY}     OTHERS    ${EACL_DENY_ALL_OTHERS}    ${FILE_S}    ${USER_KEY}
-                        Check Bearer Сompound Get Range Hash    ${USER_KEY}      USER      ${EACL_DENY_ALL_USER}    ${FILE_S}    ${USER_KEY}
-                        Check Bearer Сompound Get Range Hash    ${SYSTEM_KEY}    SYSTEM    ${EACL_DENY_ALL_SYSTEM}    ${FILE_S}    ${USER_KEY}
+                        Check Bearer Сompound Get    ${OTHER_WALLET}     OTHERS    ${EACL_DENY_ALL_OTHERS}    ${FILE_S}    ${USER_WALLET}    ${WALLET_SYS}
+                        Check Bearer Сompound Get    ${USER_WALLET}      USER      ${EACL_DENY_ALL_USER}    ${FILE_S}     ${USER_WALLET}    ${WALLET_SYS}
+                        Check Bearer Сompound Get    ${WALLET_SYS}    SYSTEM    ${EACL_DENY_ALL_SYSTEM}    ${FILE_S}     ${USER_WALLET}    ${WALLET_SYS}
+
+                        Check Bearer Сompound Delete    ${OTHER_WALLET}     OTHERS    ${EACL_DENY_ALL_OTHERS}    ${FILE_S}     ${USER_WALLET}    ${WALLET_SYS}
+                        Check Bearer Сompound Delete    ${USER_WALLET}      USER      ${EACL_DENY_ALL_USER}    ${FILE_S}     ${USER_WALLET}    ${WALLET_SYS}
+                        Check Bearer Сompound Delete    ${WALLET_SYS}    SYSTEM    ${EACL_DENY_ALL_SYSTEM}    ${FILE_S}    ${USER_WALLET}    ${WALLET_SYS}
+
+                        Check Bearer Сompound Get Range Hash    ${OTHER_WALLET}     OTHERS    ${EACL_DENY_ALL_OTHERS}    ${USER_WALLET}    ${FILE_S}    ${WALLET_SYS}   
+                        Check Bearer Сompound Get Range Hash    ${USER_WALLET}      USER      ${EACL_DENY_ALL_USER}    ${USER_WALLET}    ${FILE_S}    ${WALLET_SYS}
+                        Check Bearer Сompound Get Range Hash    ${WALLET_SYS}    SYSTEM    ${EACL_DENY_ALL_SYSTEM}    ${USER_WALLET}    ${FILE_S}    ${WALLET_SYS}
 Check Bearer Сompound Get
-    [Arguments]         ${KEY}    ${DENY_GROUP}    ${DENY_EACL}    ${FILE_S}    ${USER_KEY}
+    [Arguments]         ${WALLET}    ${DENY_GROUP}    ${DENY_EACL}    ${FILE_S}    ${USER_WALLET}    ${WALLET_SYS}
 
-    ${CID} =            Create Container Public    ${USER_KEY}
+    ${CID} =            Create Container Public    ${USER_WALLET}
                         Prepare eACL Role rules    ${CID}
-    ${S_OID_USER} =     Put object                 ${USER_KEY}     ${FILE_S}   ${CID}  user_headers=${USER_HEADER}
+    ${S_OID_USER} =     Put object                 ${USER_WALLET}     ${FILE_S}   ${CID}  user_headers=${USER_HEADER}
     @{S_OBJ_H} =        Create List	           ${S_OID_USER}
 
-    ${S_OID_USER} =     Put object     ${USER_KEY}    ${FILE_S}    ${CID}           user_headers=${USER_HEADER}
-                        Put object     ${KEY}         ${FILE_S}    ${CID}           user_headers=${ANOTHER_HEADER}
-                        Get object     ${KEY}         ${CID}       ${S_OID_USER}    ${EMPTY}    local_file_eacl
-                        Set eACL       ${USER_KEY}    ${CID}       ${DENY_EACL}
+    ${S_OID_USER} =     Put object     ${USER_WALLET}     ${FILE_S}    ${CID}           user_headers=${USER_HEADER}
+                        Put object     ${WALLET}    ${FILE_S}    ${CID}           user_headers=${ANOTHER_HEADER}
+                        Get object     ${WALLET}    ${CID}       ${S_OID_USER}    ${EMPTY}    local_file_eacl
+                        Set eACL       ${USER_WALLET}     ${CID}       ${DENY_EACL}
 
                         # The current ACL cache lifetime is 30 sec
                         Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}
@@ -74,37 +77,37 @@ Check Bearer Сompound Get
     ${rule2}=           Create Dictionary    Operation=GETRANGE        Access=ALLOW    Role=${DENY_GROUP}
     ${rule3}=           Create Dictionary    Operation=GETRANGEHASH    Access=ALLOW    Role=${DENY_GROUP}
     ${eACL_gen}=        Create List    ${rule1}    ${rule2}    ${rule3}
-    ${EACL_TOKEN} =     Form BearerToken File      ${USER_KEY}    ${CID}    ${eACL_gen}
+    ${EACL_TOKEN} =     Form BearerToken File      ${USER_WALLET}    ${CID}    ${eACL_gen}
 
                         Run Keyword And Expect Error    *
-                        ...  Head object     ${KEY}    ${CID}    ${S_OID_USER}    bearer_token=${EACL_TOKEN}
+                        ...  Head object     ${WALLET}    ${CID}    ${S_OID_USER}    bearer_token=${EACL_TOKEN}
 
-                        Get object           ${KEY}    ${CID}    ${S_OID_USER}    ${EACL_TOKEN}      local_file_eacl
-                        IF    "${KEY}" == "${NEOFS_IR_WIF}"
+                        Get Object    ${WALLET}    ${CID}    ${S_OID_USER}    ${EACL_TOKEN}      local_file_eacl
+                        IF    "${WALLET}" == "${WALLET_SYS}"
                             Run Keyword And Expect Error    *
-                            ...    Get Range            ${KEY}    ${CID}    ${S_OID_USER}    s_get_range        ${EACL_TOKEN}       0:256
+                            ...    Get Range    ${WALLET}    ${CID}    ${S_OID_USER}    s_get_range        ${EACL_TOKEN}       0:256
                         ELSE
-                            Get Range            ${KEY}    ${CID}    ${S_OID_USER}    s_get_range        ${EACL_TOKEN}       0:256
+                            Get Range    ${WALLET}    ${CID}    ${S_OID_USER}    s_get_range        ${EACL_TOKEN}       0:256
                         END
-                        Get Range Hash       ${KEY}    ${CID}    ${S_OID_USER}    ${EACL_TOKEN}      0:256
+                        Get Range Hash    ${WALLET}    ${CID}    ${S_OID_USER}    ${EACL_TOKEN}      0:256
 
 
 Check Bearer Сompound Delete
-    [Arguments]         ${KEY}    ${DENY_GROUP}    ${DENY_EACL}    ${FILE_S}    ${USER_KEY}
+    [Arguments]         ${WALLET}    ${DENY_GROUP}    ${DENY_EACL}    ${FILE_S}    ${USER_WALLET}    ${WALLET_SYS}
 
-    ${CID} =            Create Container Public    ${USER_KEY}
+    ${CID} =            Create Container Public    ${USER_WALLET}
                         Prepare eACL Role rules    ${CID}
-    ${S_OID_USER} =     Put object         ${USER_KEY}    ${FILE_S}    ${CID}    user_headers=${USER_HEADER}
-    ${D_OID_USER} =     Put object         ${USER_KEY}    ${FILE_S}    ${CID}
-                        Put object         ${KEY}         ${FILE_S}    ${CID}    user_headers=${ANOTHER_HEADER}
-                        IF    "${KEY}" == "${NEOFS_IR_WIF}"
+    ${S_OID_USER} =     Put object         ${USER_WALLET}    ${FILE_S}    ${CID}    user_headers=${USER_HEADER}
+    ${D_OID_USER} =     Put object         ${USER_WALLET}    ${FILE_S}    ${CID}
+                        Put object         ${WALLET}    ${FILE_S}    ${CID}    user_headers=${ANOTHER_HEADER}
+                        IF    "${WALLET}" == "${WALLET_SYS}"
                             Run Keyword And Expect Error    *
-                            ...    Delete object                   ${KEY}    ${CID}       ${D_OID_USER}
+                            ...    Delete object    ${WALLET}    ${CID}       ${D_OID_USER}    ${EMPTY}
                         ELSE
-                            Delete object                   ${KEY}    ${CID}       ${D_OID_USER}
+                            Delete object    ${WALLET}    ${CID}       ${D_OID_USER}    ${EMPTY}
                         END
 
-                        Set eACL           ${USER_KEY}    ${CID}       ${DENY_EACL}
+                        Set eACL    ${USER_WALLET}    ${CID}       ${DENY_EACL}
 
                         # The current ACL cache lifetime is 30 sec
                         Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}
@@ -113,27 +116,27 @@ Check Bearer Сompound Delete
     ${rule2} =          Create Dictionary    Operation=PUT             Access=DENY     Role=${DENY_GROUP}
     ${rule3} =          Create Dictionary    Operation=HEAD            Access=DENY     Role=${DENY_GROUP}
     ${eACL_gen} =       Create List    ${rule1}    ${rule2}    ${rule3}
-    ${EACL_TOKEN} =     Form BearerToken File           ${USER_KEY}    ${CID}    ${eACL_gen}
+    ${EACL_TOKEN} =     Form BearerToken File           ${USER_WALLET}    ${CID}    ${eACL_gen}
 
                         Run Keyword And Expect Error    *
-                        ...  Head object   ${KEY}    ${CID}       ${S_OID_USER}    bearer_token=${EACL_TOKEN}
+                        ...  Head object   ${WALLET}    ${CID}       ${S_OID_USER}    bearer_token=${EACL_TOKEN}
                         Run Keyword And Expect Error    *
-                        ...  Put object    ${KEY}    ${FILE_S}    ${CID}    bearer=${EACL_TOKEN}    user_headers=${ANOTHER_HEADER}
+                        ...  Put object    ${WALLET}    ${FILE_S}    ${CID}   bearer=${EACL_TOKEN}    user_headers=${ANOTHER_HEADER}
 
-                        Delete object      ${USER_KEY}    ${CID}       ${S_OID_USER}    bearer=${EACL_TOKEN}
+                        Delete object      ${USER_WALLET}    ${CID}       ${S_OID_USER}    bearer=${EACL_TOKEN}
 
 
 
 Check Bearer Сompound Get Range Hash
-    [Arguments]         ${KEY}    ${DENY_GROUP}    ${DENY_EACL}    ${FILE_S}    ${USER_KEY}
+    [Arguments]         ${WALLET}    ${DENY_GROUP}    ${DENY_EACL}    ${USER_WALLET}    ${FILE_S}    ${WALLET_SYS}
 
-    ${CID} =            Create Container Public    ${USER_KEY}
+    ${CID} =            Create Container Public    ${USER_WALLET}
                         Prepare eACL Role rules    ${CID}
 
-    ${S_OID_USER} =     Put object             ${USER_KEY}         ${FILE_S}    ${CID}    user_headers=${USER_HEADER}
-                        Put object             ${KEY}              ${FILE_S}    ${CID}    user_headers=${ANOTHER_HEADER}
-                        Get Range Hash         ${NEOFS_SN_WIF}     ${CID}       ${S_OID_USER}    ${EMPTY}    0:256
-                        Set eACL           ${USER_KEY}         ${CID}       ${DENY_EACL}
+    ${S_OID_USER} =     Put object             ${USER_WALLET}     ${FILE_S}    ${CID}    user_headers=${USER_HEADER}
+                        Put object             ${WALLET}    ${FILE_S}    ${CID}    user_headers=${ANOTHER_HEADER}
+                        Get Range hash         ${WALLET_SYS}    ${CID}       ${S_OID_USER}    ${EMPTY}    0:256
+                        Set eACL           ${USER_WALLET}         ${CID}       ${DENY_EACL}
 
                         # The current ACL cache lifetime is 30 sec
                         Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}
@@ -142,11 +145,11 @@ Check Bearer Сompound Get Range Hash
     ${rule2} =          Create Dictionary    Operation=GETRANGE        Access=DENY     Role=${DENY_GROUP}
     ${rule3} =          Create Dictionary    Operation=GET             Access=DENY     Role=${DENY_GROUP}
     ${eACL_gen} =       Create List    ${rule1}    ${rule2}    ${rule3}
-    ${EACL_TOKEN} =     Form BearerToken File      ${USER_KEY}    ${CID}    ${eACL_gen}
+    ${EACL_TOKEN} =     Form BearerToken File      ${USER_WALLET}    ${CID}    ${eACL_gen}
 
                         Run Keyword And Expect Error    *
-                        ...  Get Range      ${KEY}    ${CID}    ${S_OID_USER}    s_get_range    ${EACL_TOKEN}    0:256
+                        ...  Get Range      ${WALLET}    ${CID}    ${S_OID_USER}    s_get_range    ${EACL_TOKEN}    0:256
                         Run Keyword And Expect Error    *
-                        ...  Get object     ${KEY}    ${CID}    ${S_OID_USER}    ${EACL_TOKEN}    local_file_eacl
+                        ...  Get object     ${WALLET}    ${CID}    ${S_OID_USER}    ${EACL_TOKEN}    local_file_eacl
 
-                        Get Range Hash      ${KEY}    ${CID}    ${S_OID_USER}    ${EACL_TOKEN}    0:256
+                        Get Range Hash      ${WALLET}    ${CID}    ${S_OID_USER}    ${EACL_TOKEN}    0:256

--- a/robot/testsuites/integration/acl/acl_bearer_filter_oid_equal.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_filter_oid_equal.robot
@@ -25,17 +25,16 @@ BearerToken Operations with Filter OID Equal
 
     [Setup]                 Setup
 
-    ${WALLET}   ${ADDR}     ${USER_KEY} =   Prepare Wallet And Deposit
-    ${WALLET_OTH}   ${ADDR_OTH}     ${OTHER_KEY} =   Prepare Wallet And Deposit
+    ${WALLET}   ${_}     ${_} =   Prepare Wallet And Deposit
 
                             Log    Check Bearer token with simple object
     ${FILE_S} =             Generate file    ${SIMPLE_OBJ_SIZE}
-                            Check eACL Deny and Allow All Bearer Filter OID Equal    ${USER_KEY}    ${FILE_S}
+                            Check eACL Deny and Allow All Bearer Filter OID Equal    ${WALLET}    ${FILE_S}
 
                             Log    Check Bearer token with complex object
 
     ${FILE_S} =             Generate file    ${COMPLEX_OBJ_SIZE}
-                            Check eACL Deny and Allow All Bearer Filter OID Equal    ${USER_KEY}    ${FILE_S}
+                            Check eACL Deny and Allow All Bearer Filter OID Equal    ${WALLET}    ${FILE_S}
 
     [Teardown]              Teardown    acl_bearer_filter_oid_equal
 
@@ -44,23 +43,23 @@ BearerToken Operations with Filter OID Equal
 *** Keywords ***
 
 Check eACL Deny and Allow All Bearer Filter OID Equal
-    [Arguments]    ${USER_KEY}    ${FILE_S}
+    [Arguments]    ${WALLET}    ${FILE_S}
 
-    ${CID} =                Create Container Public    ${USER_KEY}
+    ${CID} =                Create Container Public    ${WALLET}
                             Prepare eACL Role rules    ${CID}
-    ${S_OID_USER} =         Put object         ${USER_KEY}     ${FILE_S}   ${CID}  user_headers=${USER_HEADER}
-    ${S_OID_USER_2} =       Put object         ${USER_KEY}     ${FILE_S}   ${CID}
-    ${D_OID_USER} =         Put object         ${USER_KEY}     ${FILE_S}   ${CID}  user_headers=${USER_HEADER_DEL}
+    ${S_OID_USER} =         Put object         ${WALLET}     ${FILE_S}   ${CID}  user_headers=${USER_HEADER}
+    ${S_OID_USER_2} =       Put object         ${WALLET}     ${FILE_S}   ${CID}
+    ${D_OID_USER} =         Put object         ${WALLET}     ${FILE_S}   ${CID}  user_headers=${USER_HEADER_DEL}
     @{S_OBJ_H} =	    Create List	       ${S_OID_USER}
 
-                            Put object         ${USER_KEY}    ${FILE_S}     ${CID}               user_headers=${ANOTHER_HEADER}
-                            Get object         ${USER_KEY}    ${CID}        ${S_OID_USER}        ${EMPTY}      local_file_eacl
-                            Search object      ${USER_KEY}    ${CID}        ${EMPTY}             ${EMPTY}      ${USER_HEADER}    ${S_OBJ_H}
-                            Head object        ${USER_KEY}    ${CID}        ${S_OID_USER}
-                            Get Range          ${USER_KEY}    ${CID}        ${S_OID_USER}        s_get_range       ${EMPTY}          0:256
-                            Delete object      ${USER_KEY}    ${CID}        ${D_OID_USER}
+                            Put object         ${WALLET}    ${FILE_S}     ${CID}               user_headers=${ANOTHER_HEADER}
+                            Get object         ${WALLET}    ${CID}        ${S_OID_USER}        ${EMPTY}      local_file_eacl
+                            Search object      ${WALLET}    ${CID}        ${EMPTY}             ${EMPTY}      ${USER_HEADER}    ${S_OBJ_H}
+                            Head object        ${WALLET}    ${CID}        ${S_OID_USER}
+                            Get Range          ${WALLET}    ${CID}        ${S_OID_USER}        s_get_range       ${EMPTY}          0:256
+                            Delete object      ${WALLET}    ${CID}        ${D_OID_USER}
 
-                            Set eACL           ${USER_KEY}    ${CID}        ${EACL_DENY_ALL_USER}
+                            Set eACL           ${WALLET}    ${CID}        ${EACL_DENY_ALL_USER}
 
                             # The current ACL cache lifetime is 30 sec
                             Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}
@@ -77,31 +76,31 @@ Check eACL Deny and Allow All Bearer Filter OID Equal
 
     ${eACL_gen}=        Create List    ${rule1}    ${rule2}    ${rule3}    ${rule4}    ${rule5}    ${rule6}    ${rule7}
 
-    ${EACL_TOKEN} =     Form BearerToken File      ${USER_KEY}    ${CID}    ${eACL_gen}
+    ${EACL_TOKEN} =     Form BearerToken File      ${WALLET}    ${CID}    ${eACL_gen}
 
                         Run Keyword And Expect Error        *
-                        ...  Put object     ${USER_KEY}    ${FILE_S}     ${CID}       user_headers=${USER_HEADER}
+                        ...  Put object     ${WALLET}    ${FILE_S}     ${CID}    user_headers=${USER_HEADER}
                         Run Keyword And Expect Error        *
-                        ...  Get object     ${USER_KEY}    ${CID}        ${S_OID_USER}    ${EMPTY}      local_file_eacl
+                        ...  Get object     ${WALLET}    ${CID}        ${S_OID_USER}    ${EMPTY}      local_file_eacl
                         Run Keyword And Expect Error        *
-                        ...  Search object  ${USER_KEY}    ${CID}    ${EMPTY}     ${EMPTY}      ${USER_HEADER}      ${S_OBJ_H}
+                        ...  Search object  ${WALLET}    ${CID}    ${EMPTY}     ${EMPTY}      ${USER_HEADER}      ${S_OBJ_H}
                         Run Keyword And Expect Error        *
-                        ...  Head object    ${USER_KEY}    ${CID}    ${S_OID_USER}
+                        ...  Head object    ${WALLET}    ${CID}    ${S_OID_USER}
                         Run Keyword And Expect Error        *
-                        ...  Get Range      ${USER_KEY}    ${CID}    ${S_OID_USER}    s_get_range    ${EMPTY}      0:256
+                        ...  Get Range      ${WALLET}    ${CID}    ${S_OID_USER}    s_get_range    ${EMPTY}      0:256
                         Run Keyword And Expect Error        *
-                        ...  Delete object  ${USER_KEY}    ${CID}    ${S_OID_USER}
+                        ...  Delete object  ${WALLET}    ${CID}    ${S_OID_USER}
                         Run Keyword And Expect Error        *
-                        ...  Search object  ${USER_KEY}    ${CID}    ${EMPTY}    ${EACL_TOKEN}    ${USER_HEADER}    ${S_OBJ_H}
+                        ...  Search object  ${WALLET}    ${CID}    ${EMPTY}    ${EACL_TOKEN}    ${USER_HEADER}    ${S_OBJ_H}
                         Run Keyword And Expect Error        *
-                        ...  Put object     ${USER_KEY}    ${FILE_S}     ${CID}     bearer=${EACL_TOKEN}     user_headers=${ANOTHER_HEADER}
+                        ...  Put object     ${WALLET}    ${FILE_S}     ${CID}     bearer=${EACL_TOKEN}     user_headers=${ANOTHER_HEADER}
                         Run Keyword And Expect Error        *
-                        ...  Get object     ${USER_KEY}    ${CID}      ${S_OID_USER_2}    ${EACL_TOKEN}       local_file_eacl
+                        ...  Get object     ${WALLET}    ${CID}      ${S_OID_USER_2}    ${EACL_TOKEN}       local_file_eacl
 
-                        Get object       ${USER_KEY}    ${CID}      ${S_OID_USER}      ${EACL_TOKEN}       local_file_eacl
-                        Get Range        ${USER_KEY}    ${CID}      ${S_OID_USER}      s_get_range     ${EACL_TOKEN}   0:256
+                        Get object       ${WALLET}    ${CID}      ${S_OID_USER}      ${EACL_TOKEN}       local_file_eacl
+                        Get Range        ${WALLET}    ${CID}      ${S_OID_USER}      s_get_range     ${EACL_TOKEN}   0:256
 
-                        Head object      ${USER_KEY}    ${CID}      ${S_OID_USER}      bearer_token=${EACL_TOKEN}
-                        Delete object    ${USER_KEY}    ${CID}      ${S_OID_USER}      bearer=${EACL_TOKEN}
+                        Head object      ${WALLET}    ${CID}      ${S_OID_USER}      bearer_token=${EACL_TOKEN}
+                        Delete object    ${WALLET}    ${CID}      ${S_OID_USER}      bearer=${EACL_TOKEN}
                         Run Keyword And Expect Error        *
-                        ...  Delete object              ${USER_KEY}    ${CID}        ${D_OID_USER}        bearer=${EACL_TOKEN}
+                        ...  Delete object              ${WALLET}    ${CID}        ${D_OID_USER}        bearer=${EACL_TOKEN}

--- a/robot/testsuites/integration/acl/acl_bearer_filter_oid_not_equal.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_filter_oid_not_equal.robot
@@ -24,15 +24,15 @@ BearerToken Operations with Filter OID NotEqual
 
     [Setup]                 Setup
 
-    ${_}   ${_}     ${USER_KEY} =   Prepare Wallet And Deposit
+    ${WALLET}   ${_}     ${_} =   Prepare Wallet And Deposit
 
                             Log    Check Bearer token with simple object
     ${FILE_S} =             Generate file    ${SIMPLE_OBJ_SIZE}
-                            Check eACL Deny and Allow All Bearer Filter OID NotEqual    ${USER_KEY}    ${FILE_S}
+                            Check eACL Deny and Allow All Bearer Filter OID NotEqual    ${WALLET}    ${FILE_S}
 
                             Log    Check Bearer token with complex object
     ${FILE_S} =             Generate file    ${COMPLEX_OBJ_SIZE}
-                            Check eACL Deny and Allow All Bearer Filter OID NotEqual    ${USER_KEY}    ${FILE_S}
+                            Check eACL Deny and Allow All Bearer Filter OID NotEqual    ${WALLET}    ${FILE_S}
 
     [Teardown]              Teardown    acl_bearer_filter_oid_not_equal
 
@@ -41,23 +41,23 @@ BearerToken Operations with Filter OID NotEqual
 *** Keywords ***
 
 Check eACL Deny and Allow All Bearer Filter OID NotEqual
-    [Arguments]    ${USER_KEY}    ${FILE_S}
+    [Arguments]    ${WALLET}    ${FILE_S}
 
-    ${CID} =                Create Container Public    ${USER_KEY}
+    ${CID} =                Create Container Public    ${WALLET}
                             Prepare eACL Role rules    ${CID}
-    ${S_OID_USER} =         Put object                 ${USER_KEY}     ${FILE_S}   ${CID}  user_headers=${USER_HEADER}
-    ${S_OID_USER_2} =       Put object                 ${USER_KEY}     ${FILE_S}   ${CID}
-    ${D_OID_USER} =         Put object                 ${USER_KEY}     ${FILE_S}   ${CID}
+    ${S_OID_USER} =         Put object                 ${WALLET}     ${FILE_S}   ${CID}  user_headers=${USER_HEADER}
+    ${S_OID_USER_2} =       Put object                 ${WALLET}     ${FILE_S}   ${CID}
+    ${D_OID_USER} =         Put object                 ${WALLET}     ${FILE_S}   ${CID}
     @{S_OBJ_H} =	    Create List	               ${S_OID_USER}
 
-                            Put object          ${USER_KEY}    ${FILE_S}     ${CID}
-                            Get object          ${USER_KEY}    ${CID}        ${S_OID_USER}    ${EMPTY}       local_file_eacl
-                            Search object       ${USER_KEY}    ${CID}        ${EMPTY}         ${EMPTY}       ${USER_HEADER}     ${S_OBJ_H}
-                            Head object         ${USER_KEY}    ${CID}        ${S_OID_USER}
-                            Get Range           ${USER_KEY}    ${CID}        ${S_OID_USER}    s_get_range    ${EMPTY}      0:256
-                            Delete object       ${USER_KEY}    ${CID}        ${D_OID_USER}
+                            Put object          ${WALLET}    ${FILE_S}     ${CID}
+                            Get object          ${WALLET}    ${CID}        ${S_OID_USER}    ${EMPTY}       local_file_eacl
+                            Search object       ${WALLET}    ${CID}        ${EMPTY}         ${EMPTY}       ${USER_HEADER}     ${S_OBJ_H}
+                            Head object         ${WALLET}    ${CID}        ${S_OID_USER}
+                            Get Range           ${WALLET}    ${CID}        ${S_OID_USER}    s_get_range    ${EMPTY}      0:256
+                            Delete object       ${WALLET}    ${CID}        ${D_OID_USER}
 
-                            Set eACL            ${USER_KEY}    ${CID}        ${EACL_DENY_ALL_USER}
+                            Set eACL            ${WALLET}    ${CID}        ${EACL_DENY_ALL_USER}
 
                         # The current ACL cache lifetime is 30 sec
                         Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}
@@ -74,39 +74,37 @@ Check eACL Deny and Allow All Bearer Filter OID NotEqual
 
     ${eACL_gen}=        Create List    ${rule1}    ${rule2}    ${rule3}    ${rule4}    ${rule5}    ${rule6}    ${rule7}
 
-    ${EACL_TOKEN} =     Form BearerToken File   ${USER_KEY}    ${CID}      ${eACL_gen}
+    ${EACL_TOKEN} =     Form BearerToken File   ${WALLET}    ${CID}      ${eACL_gen}
 
                         Run Keyword And Expect Error        *
-                        ...  Put object      ${USER_KEY}    ${FILE_S}     ${CID}       user_headers=${USER_HEADER}
+                        ...  Put object      ${WALLET}    ${FILE_S}     ${CID}    user_headers=${USER_HEADER}
                         Run Keyword And Expect Error        *
-                        ...  Get object      ${USER_KEY}    ${CID}        ${S_OID_USER}        ${EMPTY}         local_file_eacl
+                        ...  Get object      ${WALLET}    ${CID}        ${S_OID_USER}        ${EMPTY}         local_file_eacl
                         Run Keyword And Expect Error        *
-                        ...  Search object   ${USER_KEY}    ${CID}        ${EMPTY}     ${EMPTY}      ${USER_HEADER}          ${S_OBJ_H}
+                        ...  Search object   ${WALLET}    ${CID}        ${EMPTY}     ${EMPTY}      ${USER_HEADER}          ${S_OBJ_H}
                         Run Keyword And Expect Error        *
-                        ...  Head object     ${USER_KEY}    ${CID}        ${S_OID_USER}
+                        ...  Head object     ${WALLET}    ${CID}        ${S_OID_USER}
                         Run Keyword And Expect Error        *
-                        ...  Get Range       ${USER_KEY}    ${CID}        ${S_OID_USER}        s_get_range        ${EMPTY}      0:256
+                        ...  Get Range       ${WALLET}    ${CID}        ${S_OID_USER}        s_get_range        ${EMPTY}      0:256
                         Run Keyword And Expect Error        *
-                        ...  Delete object   ${USER_KEY}    ${CID}        ${S_OID_USER}
+                        ...  Delete object   ${WALLET}    ${CID}        ${S_OID_USER}
 
-                        Put object     ${USER_KEY}    ${FILE_S}     ${CID}       bearer=${EACL_TOKEN}
+                        Put object     ${WALLET}    ${FILE_S}     ${CID}    bearer=${EACL_TOKEN}
 
-                        Get object     ${USER_KEY}    ${CID}        ${S_OID_USER}        ${EACL_TOKEN}       local_file_eacl
+                        Get object     ${WALLET}    ${CID}        ${S_OID_USER}        ${EACL_TOKEN}       local_file_eacl
                         Run Keyword And Expect Error        *
-                        ...  Get object      ${USER_KEY}    ${CID}     ${S_OID_USER_2}      ${EACL_TOKEN}       local_file_eacl
+                        ...  Get object      ${WALLET}    ${CID}     ${S_OID_USER_2}      ${EACL_TOKEN}       local_file_eacl
 
-                        Get Range      ${USER_KEY}    ${CID}        ${S_OID_USER}        s_get_range        ${EACL_TOKEN}       0:256
+                        Get Range      ${WALLET}    ${CID}        ${S_OID_USER}        s_get_range        ${EACL_TOKEN}       0:256
                         Run Keyword And Expect Error        *
-                        ...  Get Range      ${USER_KEY}    ${CID}        ${S_OID_USER_2}      s_get_range        ${EACL_TOKEN}       0:256
+                        ...  Get Range      ${WALLET}    ${CID}        ${S_OID_USER_2}      s_get_range        ${EACL_TOKEN}       0:256
 
-                        Head object         ${USER_KEY}    ${CID}        ${S_OID_USER}        bearer_token=${EACL_TOKEN}
+                        Head object         ${WALLET}    ${CID}        ${S_OID_USER}    bearer_token=${EACL_TOKEN}
                         Run Keyword And Expect Error        *
-                        ...  Head object    ${USER_KEY}    ${CID}        ${S_OID_USER_2}      bearer_token=${EACL_TOKEN}
-
+                        ...  Head object    ${WALLET}    ${CID}        ${S_OID_USER_2}    bearer_token=${EACL_TOKEN}
                         Run Keyword And Expect Error        *
-                        ...  Search object      ${USER_KEY}    ${CID}        ${EMPTY}     ${EACL_TOKEN}       ${USER_HEADER}     ${S_OBJ_H}
+                        ...  Search object      ${WALLET}    ${CID}        ${EMPTY}     ${EACL_TOKEN}       ${USER_HEADER}     ${S_OBJ_H}
 
-                        Delete object       ${USER_KEY}    ${CID}        ${S_OID_USER}        bearer=${EACL_TOKEN}
-
+                        Delete object       ${WALLET}    ${CID}        ${S_OID_USER}    bearer=${EACL_TOKEN}
                         Run Keyword And Expect Error        *
-                        ...  Delete object      ${USER_KEY}    ${CID}        ${D_OID_USER_2}      bearer=${EACL_TOKEN}
+                        ...  Delete object      ${WALLET}    ${CID}        ${S_OID_USER_2}      bearer=${EACL_TOKEN}

--- a/robot/testsuites/integration/acl/acl_bearer_filter_userheader_equal.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_filter_userheader_equal.robot
@@ -21,41 +21,41 @@ Resource    setup_teardown.robot
 BearerToken Operations with Filter UserHeader Equal
     [Documentation]         Testcase to validate NeoFS operations with BearerToken with Filter UserHeader Equal.
     [Tags]                  ACL   BearerToken
-    [Timeout]               20 min
+    [Timeout]               10 min
 
     [Setup]                 Setup
 
-    ${_}   ${_}     ${USER_KEY} =   Prepare Wallet And Deposit
+    ${WALLET}   ${_}     ${_} =   Prepare Wallet And Deposit
 
                             Log    Check Bearer token with simple object
     ${FILE_S} =             Generate file    ${SIMPLE_OBJ_SIZE}
-                            Check eACL Deny and Allow All Bearer Filter UserHeader Equal    ${USER_KEY}    ${FILE_S}
+                            Check eACL Deny and Allow All Bearer Filter UserHeader Equal    ${WALLET}    ${FILE_S}
 
 
                             Log    Check Bearer token with complex object
     ${FILE_S} =             Generate file    ${COMPLEX_OBJ_SIZE}
-                            Check eACL Deny and Allow All Bearer Filter UserHeader Equal    ${USER_KEY}    ${FILE_S}
+                            Check eACL Deny and Allow All Bearer Filter UserHeader Equal    ${WALLET}    ${FILE_S}
 
     [Teardown]              Teardown    acl_bearer_filter_userheader_equal
 
 *** Keywords ***
 Check eACL Deny and Allow All Bearer Filter UserHeader Equal
-    [Arguments]    ${USER_KEY}    ${FILE_S}
-    ${CID} =                Create Container Public    ${USER_KEY}
+    [Arguments]    ${WALLET}    ${FILE_S}
+    ${CID} =                Create Container Public    ${WALLET}
                             Prepare eACL Role rules    ${CID}
-    ${S_OID_USER} =         Put object                 ${USER_KEY}     ${FILE_S}   ${CID}  user_headers=${USER_HEADER}
-    ${S_OID_USER_2} =       Put object                 ${USER_KEY}     ${FILE_S}   ${CID}
-    ${D_OID_USER} =         Put object                 ${USER_KEY}     ${FILE_S}   ${CID}  user_headers=${USER_HEADER_DEL}
+    ${S_OID_USER} =         Put object                 ${WALLET}     ${FILE_S}   ${CID}  user_headers=${USER_HEADER}
+    ${S_OID_USER_2} =       Put object                 ${WALLET}     ${FILE_S}   ${CID}
+    ${D_OID_USER} =         Put object                 ${WALLET}     ${FILE_S}   ${CID}  user_headers=${USER_HEADER_DEL}
     @{S_OBJ_H} =	    Create List	               ${S_OID_USER}
 
-                            Put object       ${USER_KEY}    ${FILE_S}    ${CID}               user_headers=${ANOTHER_HEADER}
-                            Get object       ${USER_KEY}    ${CID}       ${S_OID_USER}        ${EMPTY}      local_file_eacl
-                            Search object    ${USER_KEY}    ${CID}       ${EMPTY}             ${EMPTY}      ${USER_HEADER}     ${S_OBJ_H}
-                            Head object      ${USER_KEY}    ${CID}       ${S_OID_USER}
-                            Get Range        ${USER_KEY}    ${CID}       ${S_OID_USER}        s_get_range       ${EMPTY}      0:256
-                            Delete object    ${USER_KEY}    ${CID}       ${D_OID_USER}
+                            Put object       ${WALLET}    ${FILE_S}    ${CID}               user_headers=${ANOTHER_HEADER}
+                            Get object       ${WALLET}    ${CID}       ${S_OID_USER}        ${EMPTY}      local_file_eacl
+                            Search object    ${WALLET}    ${CID}       ${EMPTY}             ${EMPTY}      ${USER_HEADER}     ${S_OBJ_H}
+                            Head object      ${WALLET}    ${CID}       ${S_OID_USER}
+                            Get Range        ${WALLET}    ${CID}       ${S_OID_USER}        s_get_range       ${EMPTY}      0:256
+                            Delete object    ${WALLET}    ${CID}       ${D_OID_USER}
 
-                            Set eACL         ${USER_KEY}    ${CID}       ${EACL_DENY_ALL_USER}
+                            Set eACL         ${WALLET}    ${CID}       ${EACL_DENY_ALL_USER}
 
                             # The current ACL cache lifetime is 30 sec
                             Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}
@@ -72,42 +72,41 @@ Check eACL Deny and Allow All Bearer Filter UserHeader Equal
 
     ${eACL_gen}=        Create List    ${rule1}    ${rule2}    ${rule3}    ${rule4}    ${rule5}    ${rule6}    ${rule7}
 
-    ${EACL_TOKEN} =     Form BearerToken File      ${USER_KEY}    ${CID}    ${eACL_gen}
+    ${EACL_TOKEN} =     Form BearerToken File      ${WALLET}    ${CID}    ${eACL_gen}
 
                         Run Keyword And Expect Error        *
-                        ...  Put object    ${USER_KEY}    ${FILE_S}    ${CID}           user_headers=${USER_HEADER}
+                        ...  Put object    ${WALLET}    ${FILE_S}    ${CID}    user_headers=${USER_HEADER}
                         Run Keyword And Expect Error        *
-                        ...  Get object    ${USER_KEY}    ${CID}       ${S_OID_USER}    ${EMPTY}      local_file_eacl
+                        ...  Get object    ${WALLET}    ${CID}       ${S_OID_USER}    ${EMPTY}      local_file_eacl
                         Run Keyword And Expect Error        *
-                        ...  Search object  ${USER_KEY}   ${CID}       ${EMPTY}         ${EMPTY}      ${USER_HEADER}      ${S_OBJ_H}
+                        ...  Search object  ${WALLET}   ${CID}       ${EMPTY}         ${EMPTY}      ${USER_HEADER}      ${S_OBJ_H}
                         Run Keyword And Expect Error        *
-                        ...  Head object    ${USER_KEY}    ${CID}      ${S_OID_USER}
+                        ...  Head object    ${WALLET}    ${CID}      ${S_OID_USER}
                         Run Keyword And Expect Error        *
-                        ...  Get Range      ${USER_KEY}    ${CID}      ${S_OID_USER}    s_get_range    ${EMPTY}      0:256
+                        ...  Get Range      ${WALLET}    ${CID}      ${S_OID_USER}    s_get_range    ${EMPTY}      0:256
                         Run Keyword And Expect Error        *
-                        ...  Delete object  ${USER_KEY}    ${CID}      ${S_OID_USER}
+                        ...  Delete object  ${WALLET}    ${CID}      ${S_OID_USER}
                         Run Keyword And Expect Error        *
-                        ...  Search object  ${USER_KEY}    ${CID}      ${EMPTY}         ${EACL_TOKEN}   ${USER_HEADER}     ${S_OBJ_H}
+                        ...  Search object  ${WALLET}    ${CID}      ${EMPTY}         ${EACL_TOKEN}   ${USER_HEADER}     ${S_OBJ_H}
 
                         Run Keyword And Expect Error        *
-                        ...  Put object     ${USER_KEY}    ${FILE_S}     ${CID}    bearer=${EACL_TOKEN}    user_headers=${ANOTHER_HEADER}
+                        ...  Put object     ${WALLET}    ${FILE_S}     ${CID}    bearer=${EACL_TOKEN}    user_headers=${ANOTHER_HEADER}
 
-                        Get object          ${USER_KEY}    ${CID}        ${S_OID_USER}        ${EACL_TOKEN}       local_file_eacl
+                        Get object          ${WALLET}    ${CID}        ${S_OID_USER}        ${EACL_TOKEN}       local_file_eacl
                         Run Keyword And Expect Error        *
-                        ...  Get object     ${USER_KEY}    ${CID}        ${S_OID_USER_2}      ${EACL_TOKEN}       local_file_eacl
-
-                        Run Keyword And Expect Error        *
-                        ...  Get Range      ${USER_KEY}    ${CID}        ${S_OID_USER}        s_get_range         ${EACL_TOKEN}       0:256
+                        ...  Get object     ${WALLET}    ${CID}        ${S_OID_USER_2}      ${EACL_TOKEN}       local_file_eacl
 
                         Run Keyword And Expect Error        *
-                        ...  Get Range Hash     ${USER_KEY}    ${CID}    ${S_OID_USER}        ${EACL_TOKEN}   0:256
+                        ...  Get Range      ${WALLET}    ${CID}        ${S_OID_USER}        s_get_range         ${EACL_TOKEN}       0:256
 
-                        Head object         ${USER_KEY}    ${CID}        ${S_OID_USER}        bearer_token=${EACL_TOKEN}
                         Run Keyword And Expect Error        *
-                        ...  Head object    ${USER_KEY}    ${CID}        ${S_OID_USER_2}      bearer_token=${EACL_TOKEN}
+                        ...  Get Range Hash     ${WALLET}    ${CID}    ${S_OID_USER}        ${EACL_TOKEN}   0:256
 
+                        Head object         ${WALLET}    ${CID}        ${S_OID_USER}        bearer_token=${EACL_TOKEN}
+                        Run Keyword And Expect Error        *
+                        ...  Head object    ${WALLET}    ${CID}        ${S_OID_USER_2}      bearer_token=${EACL_TOKEN}
                         # Delete can not be filtered by UserHeader.
                         Run Keyword And Expect Error        *
-                        ...  Delete object      ${USER_KEY}    ${CID}    ${S_OID_USER}        bearer=${EACL_TOKEN}
+                        ...  Delete object      ${WALLET}    ${CID}    ${S_OID_USER}        bearer=${EACL_TOKEN}
                         Run Keyword And Expect Error        *
-                        ...  Delete object      ${USER_KEY}    ${CID}    ${S_OID_USER_2}      bearer=${EACL_TOKEN}
+                        ...  Delete object      ${WALLET}    ${CID}    ${S_OID_USER_2}      bearer=${EACL_TOKEN}

--- a/robot/testsuites/integration/acl/acl_bearer_filter_userheader_not_equal.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_filter_userheader_not_equal.robot
@@ -25,38 +25,38 @@ BearerToken Operations Filter UserHeader NotEqual
 
     [Setup]                 Setup
 
-    ${_}   ${_}     ${USER_KEY} =   Prepare Wallet And Deposit
+    ${WALLET}   ${_}     ${_} =   Prepare Wallet And Deposit
 
                             Log    Check Bearer token with simple object
     ${FILE_S} =             Generate file    ${SIMPLE_OBJ_SIZE}
-                            Check eACL Deny and Allow All Bearer Filter UserHeader NotEqual    ${USER_KEY}    ${FILE_S}
+                            Check eACL Deny and Allow All Bearer Filter UserHeader NotEqual    ${WALLET}    ${FILE_S}
 
                             Log    Check Bearer token with complex object
     ${FILE_S} =             Generate file    ${COMPLEX_OBJ_SIZE}
-                            Check eACL Deny and Allow All Bearer Filter UserHeader NotEqual    ${USER_KEY}    ${FILE_S}
+                            Check eACL Deny and Allow All Bearer Filter UserHeader NotEqual    ${WALLET}    ${FILE_S}
 
     [Teardown]              Teardown    acl_bearer_filter_userheader_not_equal
 
 *** Keywords ***
 
 Check eACL Deny and Allow All Bearer Filter UserHeader NotEqual
-    [Arguments]    ${USER_KEY}    ${FILE_S}
+    [Arguments]    ${WALLET}    ${FILE_S}
 
-    ${CID} =            Create Container Public    ${USER_KEY}
+    ${CID} =            Create Container Public    ${WALLET}
                         Prepare eACL Role rules    ${CID}
-    ${S_OID_USER} =     Put object         ${USER_KEY}     ${FILE_S}   ${CID}   user_headers=${ANOTHER_HEADER}
-    ${S_OID_USER_2} =   Put object         ${USER_KEY}     ${FILE_S}   ${CID}   user_headers=${USER_HEADER}
-    ${D_OID_USER} =     Put object         ${USER_KEY}     ${FILE_S}   ${CID}   user_headers=${USER_HEADER_DEL}
+    ${S_OID_USER} =     Put object         ${WALLET}     ${FILE_S}   ${CID}   user_headers=${ANOTHER_HEADER}
+    ${S_OID_USER_2} =   Put object         ${WALLET}     ${FILE_S}   ${CID}   user_headers=${USER_HEADER}
+    ${D_OID_USER} =     Put object         ${WALLET}     ${FILE_S}   ${CID}   user_headers=${USER_HEADER_DEL}
     @{S_OBJ_H} =	Create List        ${S_OID_USER_2}
 
-                        Put object          ${USER_KEY}    ${FILE_S}     ${CID}
-                        Get object          ${USER_KEY}    ${CID}        ${S_OID_USER}        ${EMPTY}      local_file_eacl
-                        Search object       ${USER_KEY}    ${CID}        ${EMPTY}             ${EMPTY}      ${USER_HEADER}     ${S_OBJ_H}
-                        Head object         ${USER_KEY}    ${CID}        ${S_OID_USER}
-                        Get Range           ${USER_KEY}    ${CID}        ${S_OID_USER}        s_get_range    ${EMPTY}      0:256
-                        Delete object       ${USER_KEY}    ${CID}        ${D_OID_USER}
+                        Put object          ${WALLET}    ${FILE_S}     ${CID}
+                        Get object          ${WALLET}    ${CID}        ${S_OID_USER}        ${EMPTY}      local_file_eacl
+                        Search object       ${WALLET}    ${CID}        ${EMPTY}             ${EMPTY}      ${USER_HEADER}     ${S_OBJ_H}
+                        Head object         ${WALLET}    ${CID}        ${S_OID_USER}
+                        Get Range           ${WALLET}    ${CID}        ${S_OID_USER}        s_get_range    ${EMPTY}      0:256
+                        Delete object       ${WALLET}    ${CID}        ${D_OID_USER}
 
-                        Set eACL            ${USER_KEY}    ${CID}        ${EACL_DENY_ALL_USER}
+                        Set eACL            ${WALLET}    ${CID}        ${EACL_DENY_ALL_USER}
 
                         # The current ACL cache lifetime is 30 sec
                         Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}
@@ -73,46 +73,46 @@ Check eACL Deny and Allow All Bearer Filter UserHeader NotEqual
 
     ${eACL_gen}=    Create List    ${rule1}    ${rule2}    ${rule3}    ${rule4}      ${rule6}    ${rule7}
 
-    ${EACL_TOKEN} =     Form BearerToken File       ${USER_KEY}    ${CID}   ${eACL_gen}
+    ${EACL_TOKEN} =     Form BearerToken File       ${WALLET}    ${CID}   ${eACL_gen}
 
                     Run Keyword And Expect Error        *
-                    ...  Put object        ${USER_KEY}    ${FILE_S}     ${CID}    user_headers=${USER_HEADER}
+                    ...  Put object        ${WALLET}    ${FILE_S}     ${CID}    user_headers=${USER_HEADER}
                     Run Keyword And Expect Error        *
-                    ...  Get object        ${USER_KEY}    ${CID}        ${S_OID_USER}      ${EMPTY}    local_file_eacl
+                    ...  Get object        ${WALLET}    ${CID}        ${S_OID_USER}      ${EMPTY}    local_file_eacl
                     Run Keyword And Expect Error        *
-                    ...  Search object     ${USER_KEY}    ${CID}        ${EMPTY}           ${EMPTY}    ${USER_HEADER}    ${S_OBJ_H}
+                    ...  Search object     ${WALLET}    ${CID}        ${EMPTY}           ${EMPTY}    ${USER_HEADER}    ${S_OBJ_H}
                     Run Keyword And Expect Error        *
-                    ...  Head object       ${USER_KEY}    ${CID}        ${S_OID_USER}
+                    ...  Head object       ${WALLET}    ${CID}        ${S_OID_USER}
                     Run Keyword And Expect Error        *
-                    ...  Get Range         ${USER_KEY}    ${CID}        ${S_OID_USER}      s_get_range    ${EMPTY}    0:256
+                    ...  Get Range         ${WALLET}    ${CID}        ${S_OID_USER}      s_get_range    ${EMPTY}    0:256
                     Run Keyword And Expect Error        *
-                    ...  Delete object     ${USER_KEY}    ${CID}        ${S_OID_USER}      ${EMPTY}
+                    ...  Delete object     ${WALLET}    ${CID}        ${S_OID_USER}      ${EMPTY}
 
                     # Search can not use filter by headers
                     Run Keyword And Expect Error        *
-                    ...  Search object     ${USER_KEY}    ${CID}        ${EMPTY}       ${EACL_TOKEN}    ${USER_HEADER}    ${S_OBJ_H}
+                    ...  Search object     ${WALLET}    ${CID}        ${EMPTY}       ${EACL_TOKEN}    ${USER_HEADER}    ${S_OBJ_H}
 
                     # Different behaviour for big and small objects!
-                    # Put object                 ${USER_KEY}    ${FILE_S}     ${CID}             ${EACL_TOKEN}    ${ANOTHER_HEADER}
+                    # Put object                 ${WALLET}    ${FILE_S}     ${CID}             ${EACL_TOKEN}    ${FILE_OTH_HEADER}
                     Run Keyword And Expect Error        *
-                    ...  Put object        ${USER_KEY}    ${FILE_S}     ${CID}             ${EACL_TOKEN}    ${EMPTY}
+                    ...  Put object        ${WALLET}    ${FILE_S}     ${CID}             ${EACL_TOKEN}    ${EMPTY}
 
-                    Get object             ${USER_KEY}    ${CID}        ${S_OID_USER}      ${EACL_TOKEN}    local_file_eacl
+                    Get object             ${WALLET}    ${CID}        ${S_OID_USER}      ${EACL_TOKEN}    local_file_eacl
                     Run Keyword And Expect Error        *
-                    ...  Get object        ${USER_KEY}    ${CID}        ${S_OID_USER_2}    ${EACL_TOKEN}    local_file_eacl
-
-                    Run Keyword And Expect Error        *
-                    ...  Get Range         ${USER_KEY}    ${CID}        ${S_OID_USER}      s_get_range    ${EACL_TOKEN}    0:256
+                    ...  Get object        ${WALLET}    ${CID}        ${S_OID_USER_2}    ${EACL_TOKEN}    local_file_eacl
 
                     Run Keyword And Expect Error        *
-                    ...  Get Range Hash    ${USER_KEY}    ${CID}        ${S_OID_USER}      ${EACL_TOKEN}    0:256
+                    ...  Get Range         ${WALLET}    ${CID}        ${S_OID_USER}      s_get_range    ${EACL_TOKEN}    0:256
 
-                    Head object            ${USER_KEY}    ${CID}        ${S_OID_USER}      ${EACL_TOKEN}
                     Run Keyword And Expect Error        *
-                    ...  Head object       ${USER_KEY}    ${CID}        ${S_OID_USER_2}    ${EACL_TOKEN}
+                    ...  Get Range Hash    ${WALLET}    ${CID}        ${S_OID_USER}      ${EACL_TOKEN}    0:256
+
+                    Head object            ${WALLET}    ${CID}        ${S_OID_USER}      ${EACL_TOKEN}
+                    Run Keyword And Expect Error        *
+                    ...  Head object       ${WALLET}    ${CID}        ${S_OID_USER_2}    ${EACL_TOKEN}
 
                     # Delete can not be filtered by UserHeader.
                     Run Keyword And Expect Error        *
-                    ...  Delete object     ${USER_KEY}    ${CID}        ${S_OID_USER}      ${EACL_TOKEN}
+                    ...  Delete object     ${WALLET}    ${CID}        ${S_OID_USER}      ${EACL_TOKEN}
                     Run Keyword And Expect Error        *
-                    ...  Delete object     ${USER_KEY}    ${CID}        ${S_OID_USER_2}    ${EACL_TOKEN}
+                    ...  Delete object     ${WALLET}    ${CID}        ${S_OID_USER_2}    ${EACL_TOKEN}

--- a/robot/testsuites/integration/acl/acl_bearer_inaccessible.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_inaccessible.robot
@@ -20,46 +20,46 @@ BearerToken Operations for Inaccessible Container
 
     [Setup]                 Setup
 
-    ${_}   ${_}     ${USER_KEY} =   Prepare Wallet And Deposit
+    ${WALLET}   ${_}     ${_} =   Prepare Wallet And Deposit
 
                             Log    Check Bearer token with simple object
     ${FILE_S} =             Generate file    ${SIMPLE_OBJ_SIZE}
-                            Check Container Inaccessible and Allow All Bearer    ${USER_KEY}    ${FILE_S}
+                            Check Container Inaccessible and Allow All Bearer    ${WALLET}    ${FILE_S}
 
                             Log    Check Bearer token with complex object
     ${FILE_S} =             Generate file    ${COMPLEX_OBJ_SIZE}
-                            Check Container Inaccessible and Allow All Bearer    ${USER_KEY}    ${FILE_S}
+                            Check Container Inaccessible and Allow All Bearer    ${WALLET}    ${FILE_S}
 
     [Teardown]              Teardown    acl_bearer_inaccessible
 
 *** Keywords ***
 
 Check Container Inaccessible and Allow All Bearer
-    [Arguments]    ${USER_KEY}    ${FILE_S}
+    [Arguments]    ${WALLET}    ${FILE_S}
 
-    ${CID} =    Create Container Inaccessible    ${USER_KEY}
+    ${CID} =    Create Container Inaccessible    ${WALLET}
                 Prepare eACL Role rules    ${CID}
 
                 Run Keyword And Expect Error        *
-                ...  Put object        ${USER_KEY}    ${FILE_S}     ${CID}    user_headers=${FILE_USR_HEADER}
+                ...  Put object        ${WALLET}    ${FILE_S}     ${CID}    user_headers=${FILE_USR_HEADER}
                 Run Keyword And Expect Error        *
-                ...  Get object        ${USER_KEY}    ${CID}        ${S_OID_USER}    ${EMPTY}       local_file_eacl
+                ...  Get object        ${WALLET}    ${CID}        ${S_OID_USER}    ${EMPTY}       local_file_eacl
                 Run Keyword And Expect Error        *
-                ...  Search object     ${USER_KEY}    ${CID}        ${EMPTY}         ${EMPTY}       ${FILE_USR_HEADER}
+                ...  Search object     ${WALLET}    ${CID}        ${EMPTY}         ${EMPTY}       ${FILE_USR_HEADER}
                 Run Keyword And Expect Error        *
-                ...  Head object       ${USER_KEY}    ${CID}        ${S_OID_USER}
+                ...  Head object       ${WALLET}    ${CID}        ${S_OID_USER}
                 Run Keyword And Expect Error        *
-                ...  Get Range         ${USER_KEY}    ${CID}        ${S_OID_USER}    s_get_range    ${EMPTY}      0:256
+                ...  Get Range         ${WALLET}    ${CID}        ${S_OID_USER}    s_get_range    ${EMPTY}      0:256
                 Run Keyword And Expect Error        *
-                ...  Delete object     ${USER_KEY}    ${CID}        ${S_OID_USER}
+                ...  Delete object     ${WALLET}    ${CID}        ${S_OID_USER}
 
     ${rule1} =          Create Dictionary       Operation=PUT           Access=ALLOW    Role=USER
     ${rule2} =          Create Dictionary       Operation=SEARCH        Access=ALLOW    Role=USER
     ${eACL_gen} =       Create List             ${rule1}    ${rule2}
 
-    ${EACL_TOKEN} =     Form BearerToken File       ${USER_KEY}    ${CID}   ${eACL_gen}
+    ${EACL_TOKEN} =     Form BearerToken File       ${WALLET}    ${CID}   ${eACL_gen}
 
                 Run Keyword And Expect Error        *
-                ...  Put object        ${USER_KEY}    ${FILE_S}     ${CID}       bearer=${EACL_TOKEN}       user_headers=${FILE_USR_HEADER}
+                ...  Put object        ${WALLET}    ${FILE_S}     ${CID}       ${EACL_TOKEN}       user_headers=${FILE_USR_HEADER}
                 Run Keyword And Expect Error        *
-                ...  Search object     ${USER_KEY}    ${CID}        ${EMPTY}     ${EACL_TOKEN}       ${FILE_USR_HEADER}
+                ...  Search object     ${WALLET}    ${CID}        ${EMPTY}     ${EACL_TOKEN}       ${FILE_USR_HEADER}

--- a/robot/testsuites/integration/acl/acl_bearer_request_filter_xheader_deny.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_request_filter_xheader_deny.robot
@@ -25,15 +25,15 @@ BearerToken Operations
 
     [Setup]                 Setup
 
-    ${_}   ${_}     ${USER_KEY} =   Prepare Wallet And Deposit
+    ${WALLET}   ${_}     ${_} =   Prepare Wallet And Deposit
 
                             Log    Check Bearer token with simple object
     ${FILE_S} =             Generate file    ${SIMPLE_OBJ_SIZE}
-                            Check eACL Allow All Bearer Filter Requst Equal Deny    ${USER_KEY}    ${FILE_S}
+                            Check eACL Allow All Bearer Filter Requst Equal Deny    ${WALLET}    ${FILE_S}
 
                             Log    Check Bearer token with complex object
     ${FILE_S} =             Generate file    ${COMPLEX_OBJ_SIZE}
-                            Check eACL Allow All Bearer Filter Requst Equal Deny    ${USER_KEY}    ${FILE_S}
+                            Check eACL Allow All Bearer Filter Requst Equal Deny    ${WALLET}    ${FILE_S}
 
     [Teardown]              Teardown    acl_bearer_request_filter_xheader_deny
 
@@ -42,14 +42,14 @@ BearerToken Operations
 *** Keywords ***
 
 Check eACL Allow All Bearer Filter Requst Equal Deny
-    [Arguments]    ${USER_KEY}    ${FILE_S}
+    [Arguments]    ${WALLET}    ${FILE_S}
 
-    ${CID} =                Create Container Public    ${USER_KEY}
+    ${CID} =                Create Container Public    ${WALLET}
                             Prepare eACL Role rules    ${CID}
-    ${S_OID_USER} =         Put object                 ${USER_KEY}     ${FILE_S}   ${CID}  user_headers=${USER_HEADER}
-    ${S_OID_USER_2} =       Put object                 ${USER_KEY}     ${FILE_S}   ${CID}
-    ${D_OID_USER} =         Put object                 ${USER_KEY}     ${FILE_S}   ${CID}  user_headers=${USER_HEADER_DEL}
-    @{S_OBJ_H} =	    Create List	               ${S_OID_USER}
+    ${S_OID_USER} =         Put object                 ${WALLET}     ${FILE_S}   ${CID}    user_headers=${USER_HEADER}
+    ${S_OID_USER_2} =       Put object                 ${WALLET}     ${FILE_S}   ${CID}
+    ${D_OID_USER} =         Put object                 ${WALLET}     ${FILE_S}   ${CID}    user_headers=${USER_HEADER_DEL}
+    @{S_OBJ_H} =            Create List	               ${S_OID_USER}
 
 
     ${filters}=             Create Dictionary    headerType=REQUEST    matchType=STRING_EQUAL    key=a    value=256
@@ -62,27 +62,27 @@ Check eACL Allow All Bearer Filter Requst Equal Deny
     ${rule7}=               Create Dictionary    Operation=GETRANGEHASH    Access=DENY    Role=USER    Filters=${filters}
     ${eACL_gen}=            Create List    ${rule1}    ${rule2}    ${rule3}    ${rule4}    ${rule5}    ${rule6}    ${rule7}
 
-    ${EACL_TOKEN} =     Form BearerToken File       ${USER_KEY}    ${CID}    ${eACL_gen}
+    ${EACL_TOKEN} =         Form BearerToken File       ${WALLET}    ${CID}    ${eACL_gen}
 
-                        Put object      ${USER_KEY}    ${FILE_S}     ${CID}           bearer=${EACL_TOKEN}    user_headers=${ANOTHER_HEADER}   options=--xhdr a=2
-                        Get object      ${USER_KEY}    ${CID}        ${S_OID_USER}    ${EACL_TOKEN}    local_file_eacl      ${EMPTY}      --xhdr a=2
-                        Search object   ${USER_KEY}    ${CID}        ${EMPTY}         ${EACL_TOKEN}    ${USER_HEADER}   ${S_OBJ_H}    --xhdr a=2
-                        Head object     ${USER_KEY}    ${CID}        ${S_OID_USER}    bearer_token=${EACL_TOKEN}    options=--xhdr a=2
-                        Get Range       ${USER_KEY}    ${CID}        ${S_OID_USER}    s_get_range      ${EACL_TOKEN}    0:256         --xhdr a=2
-                        Get Range Hash  ${USER_KEY}    ${CID}        ${S_OID_USER}    ${EACL_TOKEN}    0:256            --xhdr a=2
-                        Delete object   ${USER_KEY}    ${CID}        ${D_OID_USER}    bearer=${EACL_TOKEN}    options=--xhdr a=2
+                        Put object      ${WALLET}    ${FILE_S}     ${CID}           bearer=${EACL_TOKEN}    user_headers=${ANOTHER_HEADER}   options=--xhdr a=2
+                        Get object      ${WALLET}    ${CID}        ${S_OID_USER}    ${EACL_TOKEN}    local_file_eacl      ${EMPTY}      --xhdr a=2
+                        Search object   ${WALLET}    ${CID}        ${EMPTY}         ${EACL_TOKEN}    ${USER_HEADER}   ${S_OBJ_H}    --xhdr a=2
+                        Head object     ${WALLET}    ${CID}        ${S_OID_USER}    bearer_token=${EACL_TOKEN}    options=--xhdr a=2
+                        Get Range       ${WALLET}    ${CID}        ${S_OID_USER}    s_get_range      ${EACL_TOKEN}    0:256         --xhdr a=2
+                        Get Range Hash  ${WALLET}    ${CID}        ${S_OID_USER}    ${EACL_TOKEN}    0:256            --xhdr a=2
+                        Delete object   ${WALLET}    ${CID}        ${D_OID_USER}    bearer=${EACL_TOKEN}    options=--xhdr a=2
 
                         Run Keyword And Expect Error    *
-                        ...  Put object     ${USER_KEY}    ${FILE_S}    ${CID}       bearer=${EACL_TOKEN}    user_headers=${USER_HEADER}    options=--xhdr a=256
+                        ...  Put object     ${WALLET}    ${FILE_S}    ${CID}    bearer=${EACL_TOKEN}    user_headers=${USER_HEADER}    options=--xhdr a=256
                         Run Keyword And Expect Error    *
-                        ...  Get object     ${USER_KEY}    ${CID}       ${S_OID_USER}    ${EACL_TOKEN}    local_file_eacl      ${EMPTY}   --xhdr a=256
+                        ...  Get object     ${WALLET}    ${CID}       ${S_OID_USER}    ${EACL_TOKEN}    local_file_eacl      ${EMPTY}   --xhdr a=256
                         Run Keyword And Expect Error    *
-                        ...  Search object   ${USER_KEY}    ${CID}       ${EMPTY}     ${EACL_TOKEN}    ${USER_HEADER}   ${EMPTY}   --xhdr a=256
+                        ...  Search object   ${WALLET}    ${CID}       ${EMPTY}     ${EACL_TOKEN}    ${USER_HEADER}   ${EMPTY}   --xhdr a=256
                         Run Keyword And Expect Error    *
-                        ...  Head object     ${USER_KEY}    ${CID}       ${S_OID_USER}    bearer_token=${EACL_TOKEN}    options=--xhdr a=256
+                        ...  Head object     ${WALLET}    ${CID}       ${S_OID_USER}    bearer_token=${EACL_TOKEN}    options=--xhdr a=256
                         Run Keyword And Expect Error    *
-                        ...  Get Range       ${USER_KEY}    ${CID}       ${S_OID_USER}    s_get_range      ${EACL_TOKEN}    0:256      --xhdr a=256
+                        ...  Get Range       ${WALLET}    ${CID}       ${S_OID_USER}    s_get_range      ${EACL_TOKEN}    0:256      --xhdr a=256
                         Run Keyword And Expect Error    *
-                        ...  Get Range Hash  ${USER_KEY}    ${CID}       ${S_OID_USER}    ${EACL_TOKEN}    0:256    --xhdr a=256
+                        ...  Get Range Hash  ${WALLET}    ${CID}       ${S_OID_USER}    ${EACL_TOKEN}    0:256    --xhdr a=256
                         Run Keyword And Expect Error    *
-                        ...  Delete object   ${USER_KEY}    ${CID}       ${S_OID_USER}    bearer=${EACL_TOKEN}    options=--xhdr a=256
+                        ...  Delete object   ${WALLET}    ${CID}       ${S_OID_USER}    bearer=${EACL_TOKEN}    options=--xhdr a=256

--- a/robot/testsuites/integration/acl/acl_bearer_request_filter_xheader_equal.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_request_filter_xheader_equal.robot
@@ -25,15 +25,15 @@ BearerToken Operations with Filter Requst Equal
 
     [Setup]                 Setup
 
-    ${_}   ${_}     ${USER_KEY} =   Prepare Wallet And Deposit
+    ${WALLET}   ${_}     ${_} =   Prepare Wallet And Deposit
 
                             Log    Check Bearer token with simple object
     ${FILE_S} =             Generate file    ${SIMPLE_OBJ_SIZE}
-                            Check eACL Deny and Allow All Bearer Filter Requst Equal    ${USER_KEY}    ${FILE_S}
+                            Check eACL Deny and Allow All Bearer Filter Requst Equal    ${WALLET}    ${FILE_S}
 
                             Log    Check Bearer token with complex object
     ${FILE_S} =             Generate file    ${COMPLEX_OBJ_SIZE}
-                            Check eACL Deny and Allow All Bearer Filter Requst Equal    ${USER_KEY}    ${FILE_S}
+                            Check eACL Deny and Allow All Bearer Filter Requst Equal    ${WALLET}    ${FILE_S}
 
     [Teardown]              Teardown    acl_bearer_request_filter_xheader_equal
 
@@ -42,26 +42,26 @@ BearerToken Operations with Filter Requst Equal
 *** Keywords ***
 
 Check eACL Deny and Allow All Bearer Filter Requst Equal
-    [Arguments]    ${USER_KEY}    ${FILE_S}
+    [Arguments]    ${WALLET}    ${FILE_S}
 
-    ${CID} =                Create Container Public    ${USER_KEY}
+    ${CID} =                Create Container Public    ${WALLET}
                             Prepare eACL Role rules    ${CID}
-    ${S_OID_USER} =         Put object                 ${USER_KEY}     ${FILE_S}   ${CID}  user_headers=${USER_HEADER}
-    ${S_OID_USER_2} =       Put object                 ${USER_KEY}     ${FILE_S}   ${CID}
-    ${D_OID_USER} =         Put object                 ${USER_KEY}     ${FILE_S}   ${CID}  user_headers=${USER_HEADER_DEL}
+    ${S_OID_USER} =         Put object                 ${WALLET}     ${FILE_S}   ${CID}  user_headers=${USER_HEADER}
+    ${S_OID_USER_2} =       Put object                 ${WALLET}     ${FILE_S}   ${CID}
+    ${D_OID_USER} =         Put object                 ${WALLET}     ${FILE_S}   ${CID}  user_headers=${USER_HEADER_DEL}
     @{S_OBJ_H} =	    Create List	               ${S_OID_USER}
 
-                            Put object         ${USER_KEY}    ${FILE_S}     ${CID}
-                            Get object         ${USER_KEY}    ${CID}        ${S_OID_USER}        ${EMPTY}      local_file_eacl
-                            Search object      ${USER_KEY}    ${CID}        ${EMPTY}             ${EMPTY}      ${USER_HEADER}     ${S_OBJ_H}
-                            Head object        ${USER_KEY}    ${CID}        ${S_OID_USER}
-                            Get Range          ${USER_KEY}    ${CID}        ${S_OID_USER}        s_get_range    ${EMPTY}      0:256
-                            Delete object      ${USER_KEY}    ${CID}        ${D_OID_USER}
+                        Put object         ${WALLET}    ${FILE_S}     ${CID}
+                        Get object         ${WALLET}    ${CID}        ${S_OID_USER}        ${EMPTY}      local_file_eacl
+                        Search object      ${WALLET}    ${CID}        ${EMPTY}             ${EMPTY}      ${USER_HEADER}     ${S_OBJ_H}
+                        Head object        ${WALLET}    ${CID}        ${S_OID_USER}
+                        Get Range          ${WALLET}    ${CID}        ${S_OID_USER}        s_get_range    ${EMPTY}      0:256
+                        Delete object      ${WALLET}    ${CID}        ${D_OID_USER}
 
-                            Set eACL           ${USER_KEY}    ${CID}        ${EACL_DENY_ALL_USER}
+                        Set eACL           ${WALLET}    ${CID}        ${EACL_DENY_ALL_USER}
 
-                            # The current ACL cache lifetime is 30 sec
-                            Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}
+                        # The current ACL cache lifetime is 30 sec
+                        Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}
 
     ${filters}=         Create Dictionary    headerType=REQUEST    matchType=STRING_EQUAL    key=a    value=256
     ${rule1}=           Create Dictionary    Operation=GET             Access=ALLOW    Role=USER    Filters=${filters}
@@ -73,25 +73,25 @@ Check eACL Deny and Allow All Bearer Filter Requst Equal
     ${rule7}=           Create Dictionary    Operation=GETRANGEHASH    Access=ALLOW    Role=USER    Filters=${filters}
     ${eACL_gen}=        Create List    ${rule1}    ${rule2}    ${rule3}    ${rule4}    ${rule5}    ${rule6}    ${rule7}
 
-    ${EACL_TOKEN} =     Form BearerToken File      ${USER_KEY}    ${CID}   ${eACL_gen}
+    ${EACL_TOKEN} =     Form BearerToken File      ${WALLET}    ${CID}   ${eACL_gen}
 
                         Run Keyword And Expect Error    ${EACL_ERROR_MSG}
-                        ...  Put object     ${USER_KEY}    ${FILE_S}    ${CID}    user_headers=${USER_HEADER}
+                        ...  Put object     ${WALLET}    ${FILE_S}    ${CID}    user_headers=${USER_HEADER}
                         Run Keyword And Expect Error    ${EACL_ERROR_MSG}
-                        ...  Get object     ${USER_KEY}    ${CID}       ${S_OID_USER}    ${EMPTY}       local_file_eacl
+                        ...  Get object     ${WALLET}    ${CID}       ${S_OID_USER}    ${EMPTY}       local_file_eacl
                         Run Keyword And Expect Error    ${EACL_ERROR_MSG}
-                        ...  Search object  ${USER_KEY}    ${CID}       ${EMPTY}         ${EMPTY}       ${USER_HEADER}    ${S_OBJ_H}
+                        ...  Search object  ${WALLET}    ${CID}       ${EMPTY}         ${EMPTY}       ${USER_HEADER}    ${S_OBJ_H}
                         Run Keyword And Expect Error    ${EACL_ERROR_MSG}
-                        ...  Head object    ${USER_KEY}    ${CID}       ${S_OID_USER}
+                        ...  Head object    ${WALLET}    ${CID}       ${S_OID_USER}
                         Run Keyword And Expect Error    ${EACL_ERROR_MSG}
-                        ...  Get Range      ${USER_KEY}    ${CID}       ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+                        ...  Get Range      ${WALLET}    ${CID}       ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
                         Run Keyword And Expect Error    ${EACL_ERROR_MSG}
-                        ...  Delete object  ${USER_KEY}    ${CID}       ${S_OID_USER}
+                        ...  Delete object  ${WALLET}    ${CID}       ${S_OID_USER}
 
-                        Put object      ${USER_KEY}    ${FILE_S}    ${CID}           bearer=${EACL_TOKEN}    user_headers=${USER_HEADER}       options=--xhdr a=256
-                        Get object      ${USER_KEY}    ${CID}       ${S_OID_USER}    ${EACL_TOKEN}    local_file_eacl          ${EMPTY}       --xhdr a=256
-                        Search object   ${USER_KEY}    ${CID}       ${EMPTY}         ${EACL_TOKEN}    ${USER_HEADER}       ${EMPTY}       --xhdr a=256
-                        Head object     ${USER_KEY}    ${CID}       ${S_OID_USER}    bearer_token=${EACL_TOKEN}    options=--xhdr a=256
-                        Get Range       ${USER_KEY}    ${CID}       ${S_OID_USER}    s_get_range      ${EACL_TOKEN}    0:256          --xhdr a=256
-                        Get Range Hash  ${USER_KEY}    ${CID}       ${S_OID_USER}    ${EACL_TOKEN}    0:256            --xhdr a=256
-                        Delete object   ${USER_KEY}    ${CID}       ${S_OID_USER}    ${EACL_TOKEN}    --xhdr a=256
+                        Put object      ${WALLET}    ${FILE_S}    ${CID}           bearer=${EACL_TOKEN}    user_headers=${USER_HEADER}       options=--xhdr a=256
+                        Get object      ${WALLET}    ${CID}       ${S_OID_USER}    ${EACL_TOKEN}    local_file_eacl          ${EMPTY}       --xhdr a=256
+                        Search object   ${WALLET}    ${CID}       ${EMPTY}         ${EACL_TOKEN}    ${USER_HEADER}       ${EMPTY}       --xhdr a=256
+                        Head object     ${WALLET}    ${CID}       ${S_OID_USER}    bearer_token=${EACL_TOKEN}    options=--xhdr a=256
+                        Get Range       ${WALLET}    ${CID}       ${S_OID_USER}    s_get_range      ${EACL_TOKEN}    0:256          --xhdr a=256
+                        Get Range Hash  ${WALLET}    ${CID}       ${S_OID_USER}    ${EACL_TOKEN}    0:256            --xhdr a=256
+                        Delete object   ${WALLET}    ${CID}       ${S_OID_USER}    ${EACL_TOKEN}    --xhdr a=256

--- a/robot/testsuites/integration/acl/acl_bearer_request_filter_xheader_not_equal.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_request_filter_xheader_not_equal.robot
@@ -25,15 +25,15 @@ BearerToken Operations with Filter Requst NotEqual
 
     [Setup]                 Setup
 
-    ${_}    ${_}    ${USER_KEY} =   Prepare Wallet And Deposit
+    ${WALLET}    ${_}    ${_} =   Prepare Wallet And Deposit
 
                             Log    Check Bearer token with simple object
     ${FILE_S} =             Generate file    ${SIMPLE_OBJ_SIZE}
-                            Check eACL Deny and Allow All Bearer Filter Requst NotEqual    ${USER_KEY}    ${FILE_S}
+                            Check eACL Deny and Allow All Bearer Filter Requst NotEqual    ${WALLET}    ${FILE_S}
 
                             Log    Check Bearer token with complex object
     ${FILE_S} =             Generate file    ${COMPLEX_OBJ_SIZE}
-                            Check eACL Deny and Allow All Bearer Filter Requst NotEqual    ${USER_KEY}    ${FILE_S}
+                            Check eACL Deny and Allow All Bearer Filter Requst NotEqual    ${WALLET}    ${FILE_S}
 
     [Teardown]              Teardown    acl_bearer_request_filter_xheader_not_equal
 
@@ -41,22 +41,22 @@ BearerToken Operations with Filter Requst NotEqual
 *** Keywords ***
 
 Check eACL Deny and Allow All Bearer Filter Requst NotEqual
-    [Arguments]    ${USER_KEY}    ${FILE_S}
+    [Arguments]    ${WALLET}    ${FILE_S}
 
-    ${CID} =                Create Container Public    ${USER_KEY}
-    ${S_OID_USER} =         Put object                 ${USER_KEY}     ${FILE_S}   ${CID}  user_headers=${USER_HEADER}
-    ${S_OID_USER_2} =       Put object                 ${USER_KEY}     ${FILE_S}   ${CID}
-    ${D_OID_USER} =         Put object                 ${USER_KEY}     ${FILE_S}   ${CID}  user_headers=${USER_HEADER_DEL}
+    ${CID} =                Create Container Public    ${WALLET}
+    ${S_OID_USER} =         Put object                 ${WALLET}     ${FILE_S}   ${CID}  user_headers=${USER_HEADER}
+    ${S_OID_USER_2} =       Put object                 ${WALLET}     ${FILE_S}   ${CID}
+    ${D_OID_USER} =         Put object                 ${WALLET}     ${FILE_S}   ${CID}  user_headers=${USER_HEADER_DEL}
     @{S_OBJ_H} =	    Create List	               ${S_OID_USER}
 
-                            Put object         ${USER_KEY}    ${FILE_S}     ${CID}           user_headers=${ANOTHER_USER_HEADER}
-                            Get object         ${USER_KEY}    ${CID}        ${S_OID_USER}    ${EMPTY}      local_file_eacl
-                            Search object      ${USER_KEY}    ${CID}        ${EMPTY}         ${EMPTY}      ${USER_HEADER}     ${S_OBJ_H}
-                            Head object        ${USER_KEY}    ${CID}        ${S_OID_USER}
-                            Get Range          ${USER_KEY}    ${CID}        ${S_OID_USER}    s_get_range       ${EMPTY}      0:256
-                            Delete object      ${USER_KEY}    ${CID}        ${D_OID_USER}
+                            Put object         ${WALLET}    ${FILE_S}     ${CID}           user_headers=${ANOTHER_USER_HEADER}
+                            Get object         ${WALLET}    ${CID}        ${S_OID_USER}    ${EMPTY}      local_file_eacl
+                            Search object      ${WALLET}    ${CID}        ${EMPTY}         ${EMPTY}      ${USER_HEADER}     ${S_OBJ_H}
+                            Head object        ${WALLET}    ${CID}        ${S_OID_USER}
+                            Get Range          ${WALLET}    ${CID}        ${S_OID_USER}    s_get_range       ${EMPTY}      0:256
+                            Delete object      ${WALLET}    ${CID}        ${D_OID_USER}
 
-                            Set eACL           ${USER_KEY}    ${CID}        ${EACL_DENY_ALL_USER}
+                            Set eACL           ${WALLET}    ${CID}        ${EACL_DENY_ALL_USER}
 
                             # The current ACL cache lifetime is 30 sec
                             Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}
@@ -70,25 +70,25 @@ Check eACL Deny and Allow All Bearer Filter Requst NotEqual
     ${rule6}=           Create Dictionary    Operation=GETRANGE        Access=ALLOW    Role=USER    Filters=${filters}
     ${rule7}=           Create Dictionary    Operation=GETRANGEHASH    Access=ALLOW    Role=USER    Filters=${filters}
     ${eACL_gen}=        Create List    ${rule1}    ${rule2}    ${rule3}    ${rule4}    ${rule5}    ${rule6}    ${rule7}
-    ${EACL_TOKEN} =     Form BearerToken File      ${USER_KEY}    ${CID}    ${eACL_gen}
+    ${EACL_TOKEN} =     Form BearerToken File      ${WALLET}    ${CID}    ${eACL_gen}
 
                         Run Keyword And Expect Error    *
-                        ...  Put object      ${USER_KEY}    ${FILE_S}    ${CID}      user_headers=${USER_HEADER}
+                        ...  Put object      ${WALLET}    ${FILE_S}    ${CID}      user_headers=${USER_HEADER}
                         Run Keyword And Expect Error    *
-                        ...  Get object      ${USER_KEY}    ${CID}       ${S_OID_USER}    ${EMPTY}       local_file_eacl
+                        ...  Get object      ${WALLET}    ${CID}       ${S_OID_USER}    ${EMPTY}       local_file_eacl
                         #Run Keyword And Expect Error    *
-                        #...  Search object  ${USER_KEY}    ${CID}       ${EMPTY}         ${EMPTY}       ${USER_HEADER}    ${S_OBJ_H}
+                        #...  Search object  ${WALLET}    ${CID}       ${EMPTY}         ${EMPTY}       ${USER_HEADER}    ${S_OBJ_H}
                         Run Keyword And Expect Error    *
-                        ...  Head object     ${USER_KEY}    ${CID}       ${S_OID_USER}
+                        ...  Head object     ${WALLET}    ${CID}       ${S_OID_USER}
                         Run Keyword And Expect Error    *
-                        ...  Get Range       ${USER_KEY}    ${CID}       ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+                        ...  Get Range       ${WALLET}    ${CID}       ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
                         Run Keyword And Expect Error    *
-                        ...  Delete object   ${USER_KEY}    ${CID}       ${S_OID_USER}
+                        ...  Delete object   ${WALLET}    ${CID}       ${S_OID_USER}
 
-                        Put object       ${USER_KEY}    ${FILE_S}    ${CID}   bearer=${EACL_TOKEN}    user_headers=${USER_HEADER}   options=--xhdr a=2
-                        Get object       ${USER_KEY}    ${CID}       ${S_OID_USER}    ${EACL_TOKEN}    local_file_eacl      ${EMPTY}       --xhdr a=2
-                        Search object    ${USER_KEY}    ${CID}       ${EMPTY}         ${EACL_TOKEN}    ${USER_HEADER}   ${EMPTY}       --xhdr a=2
-                        Head object      ${USER_KEY}    ${CID}       ${S_OID_USER}    bearer_token=${EACL_TOKEN}    options=--xhdr a=2
-                        Get Range        ${USER_KEY}    ${CID}       ${S_OID_USER}    s_get_range      ${EACL_TOKEN}    0:256          --xhdr a=2
-                        Get Range Hash   ${USER_KEY}    ${CID}       ${S_OID_USER}    ${EACL_TOKEN}    0:256            --xhdr a=2
-                        Delete object    ${USER_KEY}    ${CID}       ${S_OID_USER}    bearer=${EACL_TOKEN}    options=--xhdr a=2
+                        Put object       ${WALLET}    ${FILE_S}    ${CID}   bearer=${EACL_TOKEN}    user_headers=${USER_HEADER}   options=--xhdr a=2
+                        Get object       ${WALLET}    ${CID}       ${S_OID_USER}    ${EACL_TOKEN}    local_file_eacl      ${EMPTY}       --xhdr a=2
+                        Search object    ${WALLET}    ${CID}       ${EMPTY}         ${EACL_TOKEN}    ${USER_HEADER}   ${EMPTY}       --xhdr a=2
+                        Head object      ${WALLET}    ${CID}       ${S_OID_USER}    bearer_token=${EACL_TOKEN}    options=--xhdr a=2
+                        Get Range        ${WALLET}    ${CID}       ${S_OID_USER}    s_get_range      ${EACL_TOKEN}    0:256          --xhdr a=2
+                        Get Range Hash   ${WALLET}    ${CID}       ${S_OID_USER}    ${EACL_TOKEN}    0:256            --xhdr a=2
+                        Delete object    ${WALLET}    ${CID}       ${S_OID_USER}    bearer=${EACL_TOKEN}    options=--xhdr a=2

--- a/robot/testsuites/integration/acl/acl_extended_actions_other.robot
+++ b/robot/testsuites/integration/acl/acl_extended_actions_other.robot
@@ -17,16 +17,16 @@ Extended ACL Operations
 
     [Setup]                 Setup
 
-    ${WALLET}   ${ADDR}     ${USER_KEY} =   Prepare Wallet And Deposit
-    ${WALLET_OTH}   ${ADDR_OTH}     ${OTHER_KEY} =   Prepare Wallet And Deposit
+    ${WALLET}   ${_}     ${_} =   Prepare Wallet And Deposit
+    ${WALLET_OTH}   ${_}     ${_} =   Prepare Wallet And Deposit
 
                             Log    Check extended ACL with simple object
-                            Generate files    ${SIMPLE_OBJ_SIZE}
-                            Check eACL Deny and Allow All Other    ${USER_KEY}    ${OTHER_KEY}
+    ${FILE_S} =             Generate file of bytes    ${SIMPLE_OBJ_SIZE}
+                            Check eACL Deny and Allow All Other    ${WALLET}    ${WALLET_OTH}
 
                             Log    Check extended ACL with complex object
-                            Generate files    ${COMPLEX_OBJ_SIZE}
-                            Check eACL Deny and Allow All Other    ${USER_KEY}    ${OTHER_KEY}
+    ${FILE_S} =             Generate file of bytes    ${COMPLEX_OBJ_SIZE}
+                            Check eACL Deny and Allow All Other    ${WALLET}    ${WALLET_OTH}
 
     [Teardown]              Teardown    acl_extended_actions_other
 
@@ -34,5 +34,5 @@ Extended ACL Operations
 *** Keywords ***
 
 Check eACL Deny and Allow All Other
-    [Arguments]    ${USER_KEY}    ${OTHER_KEY}
-                            Check eACL Deny and Allow All    ${OTHER_KEY}    ${EACL_DENY_ALL_OTHERS}    ${EACL_ALLOW_ALL_OTHERS}    ${USER_KEY}
+    [Arguments]    ${WALLET}    ${WALLET_OTH}
+                            Check eACL Deny and Allow All    ${WALLET_OTH}    ${EACL_DENY_ALL_OTHERS}    ${EACL_ALLOW_ALL_OTHERS}    ${WALLET}

--- a/robot/testsuites/integration/acl/acl_extended_actions_system.robot
+++ b/robot/testsuites/integration/acl/acl_extended_actions_system.robot
@@ -25,15 +25,15 @@ Extended ACL Operations
 
     [Setup]                 Setup
 
-    ${WALLET}   ${ADDR}     ${USER_KEY} =   Prepare Wallet And Deposit
+    ${WALLET}   ${_}     ${_} =   Prepare Wallet And Deposit
 
                             Log    Check extended ACL with simple object
-                            Generate files    ${SIMPLE_OBJ_SIZE}
-                            Check eACL Deny and Allow All System    ${USER_KEY}    ${FILE_S}
+    ${FILE_S} =             Generate file of bytes    ${SIMPLE_OBJ_SIZE}
+                            Check eACL Deny and Allow All System    ${WALLET}    ${FILE_S}
 
                             Log    Check extended ACL with complex object
-                            Generate files    ${COMPLEX_OBJ_SIZE}
-                            Check eACL Deny and Allow All System    ${USER_KEY}    ${FILE_S}
+    ${FILE_S} =             Generate file of bytes    ${COMPLEX_OBJ_SIZE}
+                            Check eACL Deny and Allow All System    ${WALLET}    ${FILE_S}
 
     [Teardown]              Teardown    acl_extended_actions_system
 
@@ -41,117 +41,120 @@ Extended ACL Operations
 *** Keywords ***
 
 Check eACL Deny and Allow All System
-    [Arguments]     ${USER_KEY}      ${FILE_S}
+    [Arguments]     ${WALLET}      ${FILE_S}
 
-    ${CID} =            Create Container Public     ${USER_KEY}
+    ${WALLET_SN}    ${_} =     Prepare Wallet with WIF And Deposit    ${NEOFS_SN_WIF}
+    ${WALLET_IR}    ${_} =     Prepare Wallet with WIF And Deposit    ${NEOFS_IR_WIF}
 
-    ${S_OID_USER} =     Put object      ${USER_KEY}    ${FILE_S}    ${CID}    user_headers=${USER_HEADER}
-    ${D_OID_USER_S} =   Put object      ${USER_KEY}    ${FILE_S}    ${CID}    user_headers=${USER_HEADER_DEL}
-    ${D_OID_USER_SN} =  Put object      ${USER_KEY}    ${FILE_S}    ${CID}    user_headers=${USER_HEADER_DEL}
+    ${CID} =            Create Container Public     ${WALLET}
+
+    ${S_OID_USER} =     Put object      ${WALLET}    ${FILE_S}    ${CID}    user_headers=${USER_HEADER}
+    ${D_OID_USER_S} =   Put object      ${WALLET}    ${FILE_S}    ${CID}    user_headers=${USER_HEADER_DEL}
+    ${D_OID_USER_SN} =  Put object      ${WALLET}    ${FILE_S}    ${CID}    user_headers=${USER_HEADER_DEL}
 
     @{S_OBJ_H} =	Create List	    ${S_OID_USER}
 
-                        Put object      ${NEOFS_IR_WIF}    ${FILE_S}    ${CID}    user_headers=${ANOTHER_USER_HEADER}
-                        Put object      ${NEOFS_SN_WIF}    ${FILE_S}    ${CID}    user_headers=${ANOTHER_USER_HEADER}
+                        Put object      ${WALLET_IR}    ${FILE_S}    ${CID}    user_headers=${ANOTHER_USER_HEADER}
+                        Put object      ${WALLET_SN}    ${FILE_S}    ${CID}    user_headers=${ANOTHER_USER_HEADER}
 
-                        Get object    ${NEOFS_IR_WIF}    ${CID}    ${S_OID_USER}    ${EMPTY}    local_file_eacl
-                        Get object    ${NEOFS_SN_WIF}    ${CID}    ${S_OID_USER}    ${EMPTY}    local_file_eacl
+                        Get object    ${WALLET_IR}    ${CID}    ${S_OID_USER}    ${EMPTY}    local_file_eacl
+                        Get object    ${WALLET_SN}    ${CID}    ${S_OID_USER}    ${EMPTY}    local_file_eacl
 
-                        Search object        ${NEOFS_IR_WIF}    ${CID}    ${EMPTY}    ${EMPTY}    ${USER_HEADER}    ${S_OBJ_H}
-                        Search object        ${NEOFS_SN_WIF}    ${CID}    ${EMPTY}    ${EMPTY}    ${USER_HEADER}    ${S_OBJ_H}
+                        Search object        ${WALLET_IR}    ${CID}    ${EMPTY}    ${EMPTY}    ${USER_HEADER}    ${S_OBJ_H}
+                        Search object        ${WALLET_SN}    ${CID}    ${EMPTY}    ${EMPTY}    ${USER_HEADER}    ${S_OBJ_H}
 
-                        Head object          ${NEOFS_IR_WIF}    ${CID}    ${S_OID_USER}
-                        Head object          ${NEOFS_SN_WIF}    ${CID}    ${S_OID_USER}
-
-                        Run Keyword And Expect Error    *
-                        ...    Get Range            ${NEOFS_IR_WIF}    ${CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
-                        Run Keyword And Expect Error    *
-                        ...    Get Range            ${NEOFS_SN_WIF}    ${CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
-
-                        Get Range Hash       ${NEOFS_IR_WIF}    ${CID}    ${S_OID_USER}    ${EMPTY}    0:256
-                        Get Range Hash       ${NEOFS_SN_WIF}    ${CID}    ${S_OID_USER}    ${EMPTY}    0:256
+                        Head object          ${WALLET_IR}    ${CID}    ${S_OID_USER}
+                        Head object          ${WALLET_SN}    ${CID}    ${S_OID_USER}
 
                         Run Keyword And Expect Error    *
-                        ...    Delete object        ${NEOFS_IR_WIF}    ${CID}    ${D_OID_USER_S}
+                        ...    Get Range            ${WALLET_IR}    ${CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
                         Run Keyword And Expect Error    *
-                        ...    Delete object        ${NEOFS_SN_WIF}    ${CID}    ${D_OID_USER_SN}
+                        ...    Get Range            ${WALLET_SN}    ${CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
 
-                        Set eACL             ${USER_KEY}     ${CID}       ${EACL_DENY_ALL_SYSTEM}
+                        Get Range Hash       ${WALLET_IR}    ${CID}    ${S_OID_USER}    ${EMPTY}    0:256
+                        Get Range Hash       ${WALLET_SN}    ${CID}    ${S_OID_USER}    ${EMPTY}    0:256
+
+                        Run Keyword And Expect Error    *
+                        ...    Delete object        ${WALLET_IR}    ${CID}    ${D_OID_USER_S}
+                        Run Keyword And Expect Error    *
+                        ...    Delete object        ${WALLET_SN}    ${CID}    ${D_OID_USER_SN}
+
+                        Set eACL             ${WALLET}     ${CID}       ${EACL_DENY_ALL_SYSTEM}
 
                         # The current ACL cache lifetime is 30 sec
                         Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}
 
                         Run Keyword And Expect Error    *
-                        ...  Put object        ${NEOFS_IR_WIF}    ${FILE_S}    ${CID}    user_headers=${ANOTHER_USER_HEADER}
+                        ...  Put object        ${WALLET_IR}    ${FILE_S}    ${CID}    user_headers=${ANOTHER_USER_HEADER}
                         Run Keyword And Expect Error    *
-                        ...  Put object        ${NEOFS_SN_WIF}    ${FILE_S}    ${CID}    user_headers=${ANOTHER_USER_HEADER}
-
-                        Run Keyword And Expect Error    *
-                        ...  Get object      ${NEOFS_IR_WIF}      ${CID}    ${S_OID_USER}    ${EMPTY}    local_file_eacl
-                        Run Keyword And Expect Error    *
-                        ...  Get object      ${NEOFS_SN_WIF}    ${CID}    ${S_OID_USER}    ${EMPTY}    local_file_eacl
+                        ...  Put object        ${WALLET_SN}    ${FILE_S}    ${CID}    user_headers=${ANOTHER_USER_HEADER}
 
                         Run Keyword And Expect Error    *
-                        ...  Search object              ${NEOFS_IR_WIF}    ${CID}    ${EMPTY}    ${EMPTY}    ${USER_HEADER}    ${S_OBJ_H}
+                        ...  Get object      ${WALLET_IR}      ${CID}    ${S_OID_USER}    ${EMPTY}    local_file_eacl
                         Run Keyword And Expect Error    *
-                        ...  Search object              ${NEOFS_SN_WIF}    ${CID}    ${EMPTY}    ${EMPTY}    ${USER_HEADER}    ${S_OBJ_H}
+                        ...  Get object      ${WALLET_SN}    ${CID}    ${S_OID_USER}    ${EMPTY}    local_file_eacl
+
+                        Run Keyword And Expect Error    *
+                        ...  Search object              ${WALLET_IR}    ${CID}    ${EMPTY}    ${EMPTY}    ${USER_HEADER}    ${S_OBJ_H}
+                        Run Keyword And Expect Error    *
+                        ...  Search object              ${WALLET_SN}    ${CID}    ${EMPTY}    ${EMPTY}    ${USER_HEADER}    ${S_OBJ_H}
 
 
                         Run Keyword And Expect Error        *
-                        ...  Head object                ${NEOFS_IR_WIF}    ${CID}    ${S_OID_USER}
+                        ...  Head object                ${WALLET_IR}    ${CID}    ${S_OID_USER}
                         Run Keyword And Expect Error        *
-                        ...  Head object                ${NEOFS_SN_WIF}    ${CID}    ${S_OID_USER}
+                        ...  Head object                ${WALLET_SN}    ${CID}    ${S_OID_USER}
 
                         Run Keyword And Expect Error        *
-                        ...  Get Range                  ${NEOFS_IR_WIF}    ${CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+                        ...  Get Range                  ${WALLET_IR}    ${CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
                         Run Keyword And Expect Error        *
-                        ...  Get Range                  ${NEOFS_SN_WIF}    ${CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
-
-
-                        Run Keyword And Expect Error        *
-                        ...  Get Range Hash             ${NEOFS_IR_WIF}    ${CID}    ${S_OID_USER}    ${EMPTY}    0:256
-                        Run Keyword And Expect Error        *
-                        ...  Get Range Hash             ${NEOFS_SN_WIF}    ${CID}    ${S_OID_USER}    ${EMPTY}    0:256
+                        ...  Get Range                  ${WALLET_SN}    ${CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
 
 
                         Run Keyword And Expect Error        *
-                        ...  Delete object              ${NEOFS_IR_WIF}    ${CID}        ${S_OID_USER}
+                        ...  Get Range Hash             ${WALLET_IR}    ${CID}    ${S_OID_USER}    ${EMPTY}    0:256
                         Run Keyword And Expect Error        *
-                        ...  Delete object              ${NEOFS_SN_WIF}    ${CID}        ${S_OID_USER}
+                        ...  Get Range Hash             ${WALLET_SN}    ${CID}    ${S_OID_USER}    ${EMPTY}    0:256
 
 
-                        Set eACL                        ${USER_KEY}     ${CID}        ${EACL_ALLOW_ALL_SYSTEM}
+                        Run Keyword And Expect Error        *
+                        ...  Delete object              ${WALLET_IR}    ${CID}        ${S_OID_USER}
+                        Run Keyword And Expect Error        *
+                        ...  Delete object              ${WALLET_SN}    ${CID}        ${S_OID_USER}
+
+
+                        Set eACL                        ${WALLET}     ${CID}        ${EACL_ALLOW_ALL_SYSTEM}
 
                         # The current ACL cache lifetime is 30 sec
                         Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}
 
-                        Delete object        ${USER_KEY}    ${CID}    ${D_OID_USER_S}
-                        Delete object        ${USER_KEY}    ${CID}    ${D_OID_USER_SN}
+                        Delete object        ${WALLET}    ${CID}    ${D_OID_USER_S}
+                        Delete object        ${WALLET}    ${CID}    ${D_OID_USER_SN}
 
-    ${D_OID_USER_S} =   Put object     ${USER_KEY}     ${FILE_S}    ${CID}    user_headers=${USER_HEADER_DEL}
-    ${D_OID_USER_SN} =  Put object     ${USER_KEY}     ${FILE_S}    ${CID}    user_headers=${USER_HEADER_DEL}
+    ${D_OID_USER_S} =   Put object     ${WALLET}     ${FILE_S}    ${CID}    user_headers=${USER_HEADER_DEL}
+    ${D_OID_USER_SN} =  Put object     ${WALLET}     ${FILE_S}    ${CID}    user_headers=${USER_HEADER_DEL}
 
-                        Put object     ${NEOFS_IR_WIF}    ${FILE_S}     ${CID}    user_headers=${ANOTHER_USER_HEADER}
-                        Put object     ${NEOFS_SN_WIF}    ${FILE_S}     ${CID}    user_headers=${ANOTHER_USER_HEADER}
+                        Put object     ${WALLET_IR}    ${FILE_S}     ${CID}    user_headers=${ANOTHER_USER_HEADER}
+                        Put object     ${WALLET_SN}    ${FILE_S}     ${CID}    user_headers=${ANOTHER_USER_HEADER}
 
-                        Get object       ${NEOFS_IR_WIF}    ${CID}        ${S_OID_USER}      ${EMPTY}    local_file_eacl
-                        Get object       ${NEOFS_SN_WIF}    ${CID}        ${S_OID_USER}      ${EMPTY}    local_file_eacl
+                        Get object       ${WALLET_IR}    ${CID}        ${S_OID_USER}      ${EMPTY}    local_file_eacl
+                        Get object       ${WALLET_SN}    ${CID}        ${S_OID_USER}      ${EMPTY}    local_file_eacl
 
-                        Search object        ${NEOFS_IR_WIF}    ${CID}    ${EMPTY}        ${EMPTY}     ${USER_HEADER}       ${S_OBJ_H}
-                        Search object        ${NEOFS_SN_WIF}    ${CID}    ${EMPTY}        ${EMPTY}     ${USER_HEADER}       ${S_OBJ_H}
+                        Search object        ${WALLET_IR}    ${CID}    ${EMPTY}        ${EMPTY}     ${USER_HEADER}       ${S_OBJ_H}
+                        Search object        ${WALLET_SN}    ${CID}    ${EMPTY}        ${EMPTY}     ${USER_HEADER}       ${S_OBJ_H}
 
-                        Head object          ${NEOFS_IR_WIF}    ${CID}    ${S_OID_USER}
-                        Head object          ${NEOFS_SN_WIF}    ${CID}    ${S_OID_USER}
-
-                        Run Keyword And Expect Error        *
-                        ...  Get Range            ${NEOFS_IR_WIF}    ${CID}    ${S_OID_USER}    s_get_range      ${EMPTY}    0:256
-                        Run Keyword And Expect Error        *
-                        ...  Get Range            ${NEOFS_SN_WIF}    ${CID}    ${S_OID_USER}    s_get_range      ${EMPTY}    0:256
-
-                        Get Range Hash       ${NEOFS_IR_WIF}    ${CID}    ${S_OID_USER}    ${EMPTY}    0:256
-                        Get Range Hash       ${NEOFS_SN_WIF}    ${CID}    ${S_OID_USER}    ${EMPTY}    0:256
+                        Head object          ${WALLET_IR}    ${CID}    ${S_OID_USER}
+                        Head object          ${WALLET_SN}    ${CID}    ${S_OID_USER}
 
                         Run Keyword And Expect Error        *
-                        ...  Delete object        ${NEOFS_IR_WIF}    ${CID}    ${D_OID_USER_S}
+                        ...  Get Range            ${WALLET_IR}    ${CID}    ${S_OID_USER}    s_get_range      ${EMPTY}    0:256
                         Run Keyword And Expect Error        *
-                        ...  Delete object        ${NEOFS_SN_WIF}    ${CID}    ${D_OID_USER_SN}
+                        ...  Get Range            ${WALLET_SN}    ${CID}    ${S_OID_USER}    s_get_range      ${EMPTY}    0:256
+
+                        Get Range Hash       ${WALLET_IR}    ${CID}    ${S_OID_USER}    ${EMPTY}    0:256
+                        Get Range Hash       ${WALLET_SN}    ${CID}    ${S_OID_USER}    ${EMPTY}    0:256
+
+                        Run Keyword And Expect Error        *
+                        ...  Delete object        ${WALLET_IR}    ${CID}    ${D_OID_USER_S}
+                        Run Keyword And Expect Error        *
+                        ...  Delete object        ${WALLET_SN}    ${CID}    ${D_OID_USER_SN}

--- a/robot/testsuites/integration/acl/acl_extended_actions_user.robot
+++ b/robot/testsuites/integration/acl/acl_extended_actions_user.robot
@@ -19,15 +19,15 @@ Extended ACL Operations
 
     [Setup]                 Setup
 
-    ${WALLET}   ${ADDR}     ${USER_KEY} =   Prepare Wallet And Deposit
+    ${WALLET}   ${_}     ${_} =   Prepare Wallet And Deposit
 
                             Log    Check extended ACL with simple object
-                            Generate files    ${SIMPLE_OBJ_SIZE}
-                            Check eACL Deny and Allow All User    ${USER_KEY}
+    ${FILE_S} =             Generate file of bytes    ${SIMPLE_OBJ_SIZE}
+                            Check eACL Deny and Allow All User    ${WALLET}
 
                             Log    Check extended ACL with complex object
-                            Generate files    ${COMPLEX_OBJ_SIZE}
-                            Check eACL Deny and Allow All User    ${USER_KEY}
+    ${FILE_S} =             Generate file of bytes    ${COMPLEX_OBJ_SIZE}
+                            Check eACL Deny and Allow All User    ${WALLET}
 
     [Teardown]              Teardown    acl_extended_action_user
 
@@ -35,5 +35,5 @@ Extended ACL Operations
 *** Keywords ***
 
 Check eACL Deny and Allow All User
-    [Arguments]             ${USER_KEY}
-                            Check eACL Deny and Allow All    ${USER_KEY}    ${EACL_DENY_ALL_USER}    ${EACL_ALLOW_ALL_USER}    ${USER_KEY}
+    [Arguments]             ${WALLET}
+                            Check eACL Deny and Allow All    ${WALLET}    ${EACL_DENY_ALL_USER}    ${EACL_ALLOW_ALL_USER}    ${WALLET}

--- a/robot/testsuites/integration/acl/acl_extended_deny_replication.robot
+++ b/robot/testsuites/integration/acl/acl_extended_deny_replication.robot
@@ -8,6 +8,7 @@ Library     acl.py
 Library     payment_neogo.py
 
 Library     contract_keywords.py
+Library     wallet_keywords.py
 
 Resource    eacl_tables.robot
 Resource    common_steps_acl_bearer.robot
@@ -18,6 +19,7 @@ Resource    storage.robot
 *** Variables ***
 ${FULL_PLACEMENT_RULE} =    REP 4 IN X CBF 1 SELECT 4 FROM * AS X
 ${EXPECTED_COPIES} =        ${4}
+${DEPOSIT} =                ${30}
 
 
 *** Test cases ***
@@ -28,36 +30,38 @@ eACL Deny Replication Operations
 
     [Setup]                 Setup
 
-    ${NODE_NUM}     ${NODE}    ${WIF_STORAGE} =     Get control endpoint with wif
-    ${WALLET}       ${ADDR}    ${WIF_USER} =        Prepare Wallet And Deposit
+    ${_}     ${NODE}    ${WIF_STORAGE} =     Get control endpoint with wif
+    ${WALLET_STORAGE}    ${_} =    Prepare Wallet with WIF And Deposit    ${WIF_STORAGE}
 
-                            Log    Check Replication with eACL deny - object should be replicated
-                            # https://github.com/nspcc-dev/neofs-node/issues/881
+    ${WALLET}    ${_}    ${_} =    Prepare Wallet And Deposit
 
-    ${FILE} =               Generate file of bytes    ${SIMPLE_OBJ_SIZE}
+                        Log    Check Replication with eACL deny - object should be replicated
+                        # https://github.com/nspcc-dev/neofs-node/issues/881
 
-    ${CID} =                Create container    ${WIF_USER}    ${PUBLIC_ACL}   ${FULL_PLACEMENT_RULE}
-                            Wait Until Keyword Succeeds    ${MORPH_BLOCK_TIME}    ${CONTAINER_WAIT_INTERVAL}
-                            ...     Container Existing    ${WIF_USER}    ${CID}
+    ${FILE} =           Generate file of bytes    ${SIMPLE_OBJ_SIZE}
 
-                            Prepare eACL Role rules    ${CID}
+    ${CID} =            Create container    ${WALLET}    ${PUBLIC_ACL}   ${FULL_PLACEMENT_RULE}
+                        Wait Until Keyword Succeeds    ${MORPH_BLOCK_TIME}    ${CONTAINER_WAIT_INTERVAL}
+                        ...     Container Existing    ${WALLET}    ${CID}
 
-    ${OID} =                Put object    ${WIF_USER}    ${FILE}    ${CID}
+                        Prepare eACL Role rules    ${CID}
 
-                            Validate storage policy for object    ${WIF_USER}    ${EXPECTED_COPIES}    ${CID}    ${OID}
+    ${OID} =            Put object    ${WALLET}    ${FILE}    ${CID}
 
-                            Set eACL    ${WIF_USER}    ${CID}    ${EACL_DENY_ALL_USER}
+                        Validate storage policy for object    ${WALLET}    ${EXPECTED_COPIES}    ${CID}    ${OID}
 
-                            Run Keyword And Expect Error    *
-                            ...  Put object    ${WIF_USER}    ${FILE}    ${CID}
+                        Set eACL    ${WALLET}    ${CID}    ${EACL_DENY_ALL_USER}
 
-                            # Drop object to check replication
-                            Drop object    ${NODE}    ${WIF_STORAGE}    ${CID}    ${OID}
+                        Run Keyword And Expect Error    *
+                        ...  Put object    ${WALLET}    ${FILE}    ${CID}
 
-                            Tick Epoch
+                        # Drop object to check replication
+                        Drop object    ${NODE}    ${WALLET_STORAGE}    ${CID}    ${OID}
 
-                            # We assume that during one epoch object should be replicated
-                            Wait Until Keyword Succeeds    ${NEOFS_EPOCH_TIMEOUT}    1m
-                            ...     Validate storage policy for object    ${WIF_STORAGE}    ${EXPECTED_COPIES}    ${CID}    ${OID}
+                        Tick Epoch
 
-    [Teardown]              Teardown    acl_deny_replication
+                        # We assume that during one epoch object should be replicated
+                        Wait Until Keyword Succeeds    ${NEOFS_EPOCH_TIMEOUT}    1m
+                        ...     Validate storage policy for object    ${WALLET_STORAGE}    ${EXPECTED_COPIES}    ${CID}    ${OID}
+
+    [Teardown]          Teardown    acl_deny_replication

--- a/robot/testsuites/integration/acl/acl_extended_filters.robot
+++ b/robot/testsuites/integration/acl/acl_extended_filters.robot
@@ -28,16 +28,16 @@ Extended ACL Operations
 
     [Setup]                 Setup
 
-    ${_}   ${_}     ${USER_KEY} =   Prepare Wallet And Deposit
-    ${_}   ${_}     ${OTHER_KEY} =   Prepare Wallet And Deposit
+    ${WALLET}   ${_}     ${_} =   Prepare Wallet And Deposit
+    ${WALLET_OTH}   ${_}     ${_} =   Prepare Wallet And Deposit
 
                             Log    Check extended ACL with simple object
-                            Generate files    ${SIMPLE_OBJ_SIZE}
-                            Check Filters    ${USER_KEY}    ${OTHER_KEY}
+    ${FILE_S}    ${FILE_S_2} =             Generate files    ${SIMPLE_OBJ_SIZE}
+                            Check Filters    ${WALLET}    ${WALLET_OTH}
 
                             Log    Check extended ACL with complex object
-                            Generate files    ${COMPLEX_OBJ_SIZE}
-                            Check Filters    ${USER_KEY}    ${OTHER_KEY}
+    ${FILE_S}    ${FILE_S_2} =             Generate files    ${COMPLEX_OBJ_SIZE}
+                            Check Filters    ${WALLET}    ${WALLET_OTH}
 
     [Teardown]              Teardown    acl_extended_filters
 
@@ -45,142 +45,141 @@ Extended ACL Operations
 *** Keywords ***
 
 Check Filters
-    [Arguments]    ${USER_KEY}    ${OTHER_KEY}
+    [Arguments]    ${WALLET}    ${WALLET_OTH}
 
-                            Check eACL MatchType String Equal Object    ${USER_KEY}    ${OTHER_KEY}
-                            Check eACL MatchType String Not Equal Object    ${USER_KEY}    ${OTHER_KEY}
-                            Check eACL MatchType String Equal Request Deny    ${USER_KEY}    ${OTHER_KEY}
-                            Check eACL MatchType String Equal Request Allow    ${USER_KEY}    ${OTHER_KEY}
+                            Check eACL MatchType String Equal Object    ${WALLET}    ${WALLET_OTH}
+                            Check eACL MatchType String Not Equal Object    ${WALLET}    ${WALLET_OTH}
+                            Check eACL MatchType String Equal Request Deny    ${WALLET}    ${WALLET_OTH}
+                            Check eACL MatchType String Equal Request Allow    ${WALLET}    ${WALLET_OTH}
 
 Check eACL MatchType String Equal Request Deny
-    [Arguments]    ${USER_KEY}    ${OTHER_KEY}
-    ${CID} =                Create Container Public    ${USER_KEY}
-    ${S_OID_USER} =         Put object             ${USER_KEY}     ${FILE_S}    ${CID}      user_headers=${USER_HEADER}
-                            Get object           ${OTHER_KEY}    ${CID}       ${S_OID_USER}    ${EMPTY}    ${PATH}
+    [Arguments]    ${USER_WALLET}    ${OTHER_WALLET}
+    ${CID} =                Create Container Public    ${USER_WALLET}
+    ${S_OID_USER} =         Put object             ${USER_WALLET}     ${FILE_S}    ${CID}      user_headers=${USER_HEADER}
+                            Get object           ${USER_WALLET}    ${CID}       ${S_OID_USER}    ${EMPTY}    ${PATH}
 
-                            Set eACL                ${USER_KEY}    ${CID}    ${EACL_XHEADER_DENY_ALL}
+                            Set eACL                ${USER_WALLET}    ${CID}    ${EACL_XHEADER_DENY_ALL}
 
                             # The current ACL cache lifetime is 30 sec
                             Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}
 
                             Run Keyword And Expect Error    *
-                            ...  Get object      ${OTHER_KEY}    ${CID}    ${S_OID_USER}    ${EMPTY}    ${PATH}    ${EMPTY}    --xhdr a=2
-                            Get object           ${OTHER_KEY}    ${CID}    ${S_OID_USER}    ${EMPTY}    ${PATH}    ${EMPTY}    --xhdr a=256
+                            ...  Get object      ${OTHER_WALLET}    ${CID}    ${S_OID_USER}    ${EMPTY}    ${PATH}    ${EMPTY}    --xhdr a=2
+                            Get object           ${OTHER_WALLET}    ${CID}    ${S_OID_USER}    ${EMPTY}    ${PATH}    ${EMPTY}    --xhdr a=256
 
                             Run Keyword And Expect Error    *
-                            ...  Put object        ${OTHER_KEY}    ${FILE_S}     ${CID}      user_headers=${ANOTHER_HEADER}    options=--xhdr a=2
+                            ...  Put object        ${OTHER_WALLET}    ${FILE_S}     ${CID}      user_headers=${ANOTHER_HEADER}    options=--xhdr a=2
                             Run Keyword And Expect Error    *
-                            ...  Get object      ${OTHER_KEY}    ${CID}        ${S_OID_USER}    ${EMPTY}       ${PATH}       ${EMPTY}      --xhdr a=2
+                            ...  Get object      ${OTHER_WALLET}    ${CID}        ${S_OID_USER}    ${EMPTY}       ${PATH}       ${EMPTY}      --xhdr a=2
                             Run Keyword And Expect Error    *
-                            ...   Search object             ${OTHER_KEY}    ${CID}        ${EMPTY}         ${EMPTY}       ${USER_HEADER}    ${EMPTY}      --xhdr a=2
+                            ...   Search object             ${OTHER_WALLET}    ${CID}        ${EMPTY}         ${EMPTY}       ${USER_HEADER}    ${EMPTY}      --xhdr a=2
                             Run Keyword And Expect Error    *
-                            ...  Head object                ${OTHER_KEY}    ${CID}        ${S_OID_USER}    options=--xhdr a=2
+                            ...  Head object                ${OTHER_WALLET}    ${CID}        ${S_OID_USER}    options=--xhdr a=2
                             Run Keyword And Expect Error    *
-                            ...  Get Range                  ${OTHER_KEY}    ${CID}        ${S_OID_USER}    s_get_range    ${EMPTY}              0:256         --xhdr a="2"
+                            ...  Get Range                  ${OTHER_WALLET}    ${CID}        ${S_OID_USER}    s_get_range    ${EMPTY}              0:256         --xhdr a="2"
                             Run Keyword And Expect Error    *
-                            ...  Get Range Hash             ${OTHER_KEY}    ${CID}        ${S_OID_USER}    ${EMPTY}       0:256                 --xhdr a=2
+                            ...  Get Range Hash             ${OTHER_WALLET}    ${CID}        ${S_OID_USER}    ${EMPTY}       0:256                 --xhdr a=2
                             Run Keyword And Expect Error    *
-                            ...  Delete object              ${OTHER_KEY}    ${CID}        ${S_OID_USER}    ${EMPTY}       --xhdr a=2
+                            ...  Delete object              ${OTHER_WALLET}    ${CID}        ${S_OID_USER}    ${EMPTY}       --xhdr a=2
 
-                            Put object                      ${OTHER_KEY}    ${FILE_S}     ${CID}           user_headers=${ANOTHER_HEADER}    options=--xhdr a=256
-                            Get object                      ${OTHER_KEY}    ${CID}        ${S_OID_USER}    ${EMPTY}       ${PATH}       ${EMPTY}        --xhdr a=*
-                            Search object                   ${OTHER_KEY}    ${CID}        ${EMPTY}         ${EMPTY}       ${USER_HEADER}    ${EMPTY}        --xhdr a=
-                            Head object                     ${OTHER_KEY}    ${CID}        ${S_OID_USER}    options=--xhdr a=.*
-                            Get Range                       ${OTHER_KEY}    ${CID}        ${S_OID_USER}    s_get_range    ${EMPTY}              0:256           --xhdr a="2 2"
-                            Get Range Hash                  ${OTHER_KEY}    ${CID}        ${S_OID_USER}    ${EMPTY}       0:256                 --xhdr a=256
-                            Delete object                   ${OTHER_KEY}    ${CID}        ${S_OID_USER}    options=--xhdr a=22
+                            Put object                      ${OTHER_WALLET}    ${FILE_S}     ${CID}           user_headers=${ANOTHER_HEADER}    options=--xhdr a=256
+                            Get object                      ${OTHER_WALLET}    ${CID}        ${S_OID_USER}    ${EMPTY}       ${PATH}       ${EMPTY}        --xhdr a=*
+                            Search object                   ${OTHER_WALLET}    ${CID}        ${EMPTY}         ${EMPTY}       ${USER_HEADER}    ${EMPTY}        --xhdr a=
+                            Head object                     ${OTHER_WALLET}    ${CID}        ${S_OID_USER}    options=--xhdr a=.*
+                            Get Range                       ${OTHER_WALLET}    ${CID}        ${S_OID_USER}    s_get_range    ${EMPTY}              0:256           --xhdr a="2 2"
+                            Get Range Hash                  ${OTHER_WALLET}    ${CID}        ${S_OID_USER}    ${EMPTY}       0:256                 --xhdr a=256
+                            Delete object                   ${OTHER_WALLET}    ${CID}        ${S_OID_USER}    options=--xhdr a=22
 
 
 Check eACL MatchType String Equal Request Allow
-    [Arguments]    ${USER_KEY}    ${OTHER_KEY}
+    [Arguments]    ${USER_WALLET}    ${OTHER_WALLET}
 
-    ${CID} =                Create Container Public    ${USER_KEY}
-    ${S_OID_USER} =         Put Object    ${USER_KEY}     ${FILE_S}    ${CID}
-                            Get Object    ${OTHER_KEY}    ${CID}    ${S_OID_USER}    ${EMPTY}    ${PATH}
+    ${CID} =                Create Container Public    ${USER_WALLET}
+    ${S_OID_USER} =         Put Object    ${USER_WALLET}     ${FILE_S}    ${CID}
+                            Get Object    ${OTHER_WALLET}    ${CID}    ${S_OID_USER}    ${EMPTY}    ${PATH}
 
-                            Set eACL    ${USER_KEY}    ${CID}    ${EACL_XHEADER_ALLOW_ALL}
+                            Set eACL    ${USER_WALLET}    ${CID}    ${EACL_XHEADER_ALLOW_ALL}
 
                             # The current ACL cache lifetime is 30 sec
                             Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}
 
-                            Get eACL                        ${USER_KEY}    ${CID}
+                            Get eACL                        ${USER_WALLET}    ${CID}
 
                             Run Keyword And Expect Error    *
-                            ...  Get object                 ${OTHER_KEY}    ${CID}    ${S_OID_USER}    ${EMPTY}    ${PATH}    ${EMPTY}
+                            ...  Get object                 ${OTHER_WALLET}    ${CID}    ${S_OID_USER}    ${EMPTY}    ${PATH}    ${EMPTY}
                             Run Keyword And Expect Error    *
-                            ...  Put object                 ${OTHER_KEY}    ${FILE_S}     ${CID}
+                            ...  Put object                 ${OTHER_WALLET}    ${FILE_S}     ${CID}
                             Run Keyword And Expect Error    *
-                            ...  Get object                 ${OTHER_KEY}    ${CID}        ${S_OID_USER}    ${EMPTY}       ${PATH}       ${EMPTY}
+                            ...  Get object                 ${OTHER_WALLET}    ${CID}        ${S_OID_USER}    ${EMPTY}       ${PATH}       ${EMPTY}
                             Run Keyword And Expect Error    *
-                            ...   Search object             ${OTHER_KEY}    ${CID}        ${EMPTY}         ${EMPTY}       ${USER_HEADER}    ${EMPTY}
+                            ...   Search object             ${OTHER_WALLET}    ${CID}        ${EMPTY}         ${EMPTY}       ${USER_HEADER}    ${EMPTY}
                             Run Keyword And Expect Error    *
-                            ...  Head object                ${OTHER_KEY}    ${CID}        ${S_OID_USER}
+                            ...  Head object                ${OTHER_WALLET}    ${CID}        ${S_OID_USER}
                             Run Keyword And Expect Error    *
-                            ...  Get Range                  ${OTHER_KEY}    ${CID}        ${S_OID_USER}    s_get_range    ${EMPTY}              0:256
+                            ...  Get Range                  ${OTHER_WALLET}    ${CID}        ${S_OID_USER}    s_get_range    ${EMPTY}              0:256
                             Run Keyword And Expect Error    *
-                            ...  Get Range Hash             ${OTHER_KEY}    ${CID}        ${S_OID_USER}    ${EMPTY}       0:256
+                            ...  Get Range Hash             ${OTHER_WALLET}    ${CID}        ${S_OID_USER}    ${EMPTY}       0:256
                             Run Keyword And Expect Error    *
-                            ...  Delete object              ${OTHER_KEY}    ${CID}        ${S_OID_USER}
+                            ...  Delete object              ${OTHER_WALLET}    ${CID}        ${S_OID_USER}
 
-                            Put object                      ${OTHER_KEY}    ${FILE_S}     ${CID}           options=--xhdr a=2
-                            Get object                      ${OTHER_KEY}    ${CID}        ${S_OID_USER}    ${EMPTY}       ${PATH}       ${EMPTY}        --xhdr a=2
-                            Search object                   ${OTHER_KEY}    ${CID}        ${EMPTY}         ${EMPTY}       ${USER_HEADER}    ${EMPTY}        --xhdr a=2
-                            Head object                     ${OTHER_KEY}    ${CID}        ${S_OID_USER}    options=--xhdr a=2
-                            Get Range                       ${OTHER_KEY}    ${CID}        ${S_OID_USER}    s_get_range    ${EMPTY}              0:256           --xhdr a=2
-                            Get Range Hash                  ${OTHER_KEY}    ${CID}        ${S_OID_USER}    ${EMPTY}       0:256                 --xhdr a=2
-                            Delete object                   ${OTHER_KEY}    ${CID}        ${S_OID_USER}    options=--xhdr a=2
+                            Put object                      ${OTHER_WALLET}    ${FILE_S}     ${CID}           options=--xhdr a=2
+                            Get object                      ${OTHER_WALLET}    ${CID}        ${S_OID_USER}    ${EMPTY}       ${PATH}       ${EMPTY}        --xhdr a=2
+                            Search object                   ${OTHER_WALLET}    ${CID}        ${EMPTY}         ${EMPTY}       ${USER_HEADER}    ${EMPTY}        --xhdr a=2
+                            Head object                     ${OTHER_WALLET}    ${CID}        ${S_OID_USER}    options=--xhdr a=2
+                            Get Range                       ${OTHER_WALLET}    ${CID}        ${S_OID_USER}    s_get_range    ${EMPTY}              0:256           --xhdr a=2
+                            Get Range Hash                  ${OTHER_WALLET}    ${CID}        ${S_OID_USER}    ${EMPTY}       0:256                 --xhdr a=2
+                            Delete object                   ${OTHER_WALLET}    ${CID}        ${S_OID_USER}    options=--xhdr a=2
 
 
 Check eACL MatchType String Equal Object
-    [Arguments]    ${USER_KEY}    ${OTHER_KEY}
+    [Arguments]    ${USER_WALLET}    ${OTHER_WALLET}
 
-    ${CID} =                Create Container Public    ${USER_KEY}
-    ${S_OID_USER} =         Put Object    ${USER_KEY}     ${FILE_S}    ${CID}    user_headers=${USER_HEADER}
-                            Get Object    ${OTHER_KEY}    ${CID}       ${S_OID_USER}    ${EMPTY}    ${PATH}
+    ${CID} =                Create Container Public    ${USER_WALLET}
+    ${S_OID_USER} =         Put Object    ${USER_WALLET}     ${FILE_S}    ${CID}    user_headers=${USER_HEADER}
+                            Get Object    ${OTHER_WALLET}    ${CID}       ${S_OID_USER}    ${EMPTY}    ${PATH}
 
                             Log    Set eACL for Deny GET operation with StringEqual Object ID
 
-    &{HEADER_DICT} =        Head Object    ${USER_KEY}     ${CID}       ${S_OID_USER}
+    &{HEADER_DICT} =        Head Object    ${USER_WALLET}     ${CID}       ${S_OID_USER}
     ${ID_value} =           Get From dictionary    ${HEADER_DICT}    ${EACL_OBJ_FILTERS}[${ID_FILTER}]
 
     ${filters} =            Set Variable    obj:${ID_FILTER}=${ID_value}
     ${rule1} =              Set Variable    deny get ${filters} others
     ${eACL_gen} =           Create List     ${rule1}
     ${EACL_CUSTOM} =        Create eACL     ${CID}    ${eACL_gen}
-                            Set eACL           ${USER_KEY}       ${CID}    ${EACL_CUSTOM}
+                            Set eACL           ${USER_WALLET}       ${CID}    ${EACL_CUSTOM}
                             Run Keyword And Expect Error    *
-                            ...  Get object    ${OTHER_KEY}      ${CID}    ${S_OID_USER}     ${EMPTY}    ${PATH}
+                            ...  Get object    ${OTHER_WALLET}      ${CID}    ${S_OID_USER}     ${EMPTY}    ${PATH}
 
 
                             Log	                 Set eACL for Deny GET operation with StringEqual Object Extended User Header
 
-    ${S_OID_USER_OTH} =     Put object           ${USER_KEY}     ${FILE_S}    ${CID}    user_headers=${ANOTHER_HEADER}
+    ${S_OID_USER_OTH} =     Put object           ${USER_WALLET}     ${FILE_S}    ${CID}    user_headers=${ANOTHER_HEADER}
 
     ${filters} =            Set Variable    obj:${CUSTOM_FILTER}=1
     ${rule1} =              Set Variable    deny get ${filters} others
     ${eACL_gen} =           Create List     ${rule1}
     ${EACL_CUSTOM} =        Create eACL     ${CID}    ${eACL_gen}
 
-                            Set eACL             ${USER_KEY}     ${CID}       ${EACL_CUSTOM}
+                            Set eACL             ${USER_WALLET}     ${CID}       ${EACL_CUSTOM}
                             Run Keyword And Expect Error    *
-                            ...  Get object      ${OTHER_KEY}    ${CID}    ${S_OID_USER}    ${EMPTY}    ${PATH}
-                            Get object           ${OTHER_KEY}    ${CID}    ${S_OID_USER_OTH}    ${EMPTY}    ${PATH}
-
+                            ...  Get object      ${OTHER_WALLET}    ${CID}    ${S_OID_USER}    ${EMPTY}    ${PATH}
+                            Get object           ${OTHER_WALLET}    ${CID}    ${S_OID_USER_OTH}    ${EMPTY}    ${PATH}
 
 
 Check eACL MatchType String Not Equal Object
-    [Arguments]    ${USER_KEY}    ${OTHER_KEY}
+    [Arguments]    ${USER_WALLET}    ${OTHER_WALLET}
 
-    ${CID} =                Create Container Public    ${USER_KEY}
+    ${CID} =                Create Container Public    ${USER_WALLET}
 
-    ${S_OID_USER} =         Put object         ${USER_KEY}     ${FILE_S}      ${CID}    user_headers=${USER_HEADER}
-    ${S_OID_OTHER} =        Put object         ${OTHER_KEY}    ${FILE_S_2}    ${CID}    user_headers=${ANOTHER_HEADER}
-                            Get object          ${OTHER_KEY}    ${CID}    ${S_OID_USER}     ${EMPTY}    ${PATH}
-                            Get object          ${OTHER_KEY}    ${CID}    ${S_OID_OTHER}    ${EMPTY}    ${PATH}
+    ${S_OID_USER} =         Put object         ${USER_WALLET}     ${FILE_S}      ${CID}    user_headers=${USER_HEADER}
+    ${S_OID_OTHER} =        Put object         ${OTHER_WALLET}    ${FILE_S_2}    ${CID}    user_headers=${ANOTHER_HEADER}
+                            Get object          ${OTHER_WALLET}    ${CID}    ${S_OID_USER}     ${EMPTY}    ${PATH}
+                            Get object          ${OTHER_WALLET}    ${CID}    ${S_OID_OTHER}    ${EMPTY}    ${PATH}
 
                             Log	                    Set eACL for Deny GET operation with StringNotEqual Object ID
 
-    &{HEADER_DICT} =        Head object        ${USER_KEY}    ${CID}    ${S_OID_USER}
+    &{HEADER_DICT} =        Head object        ${USER_WALLET}    ${CID}    ${S_OID_USER}
     ${ID_value} =           Get From Dictionary	    ${HEADER_DICT}    ${EACL_OBJ_FILTERS}[${ID_FILTER}]
 
     ${filters} =            Set Variable    obj:${ID_FILTER}!=${ID_value}
@@ -188,21 +187,20 @@ Check eACL MatchType String Not Equal Object
     ${eACL_gen} =           Create List     ${rule1}
     ${EACL_CUSTOM} =        Create eACL     ${CID}    ${eACL_gen}
 
-                            Set eACL             ${USER_KEY}       ${CID}    ${EACL_CUSTOM}
+                            Set eACL        ${USER_WALLET}       ${CID}    ${EACL_CUSTOM}
                             Run Keyword And Expect Error    *
-                            ...  Get object      ${OTHER_KEY}      ${CID}    ${S_OID_OTHER}    ${EMPTY}            ${PATH}
-                            Get object           ${OTHER_KEY}      ${CID}    ${S_OID_USER}     ${EMPTY}            ${PATH}
-
+                            ...  Get object      ${OTHER_WALLET}      ${CID}    ${S_OID_OTHER}    ${EMPTY}            ${PATH}
+                            Get object           ${OTHER_WALLET}      ${CID}    ${S_OID_USER}     ${EMPTY}            ${PATH}
 
                             Log	               Set eACL for Deny GET operation with StringEqual Object Extended User Header
 
-    ${S_OID_USER_OTH} =     Put object         ${USER_KEY}    ${FILE_S}    ${CID}    user_headers=${ANOTHER_HEADER}
+    ${S_OID_USER_OTH} =     Put object         ${USER_WALLET}    ${FILE_S}    ${CID}    user_headers=${ANOTHER_HEADER}
     ${filters} =            Set Variable    obj:${CUSTOM_FILTER}!=1
     ${rule1} =              Set Variable    deny get ${filters} others
     ${eACL_gen} =           Create List     ${rule1}
     ${EACL_CUSTOM} =        Create eACL     ${CID}    ${eACL_gen}
 
-                            Set eACL             ${USER_KEY}    ${CID}       ${EACL_CUSTOM}
+                            Set eACL             ${USER_WALLET}    ${CID}       ${EACL_CUSTOM}
                             Run Keyword And Expect Error    *
-                            ...  Get object      ${OTHER_KEY}    ${CID}      ${S_OID_USER_OTH}    ${EMPTY}            ${PATH}
-                            Get object           ${OTHER_KEY}    ${CID}      ${S_OID_USER}        ${EMPTY}            ${PATH}
+                            ...  Get object      ${OTHER_WALLET}    ${CID}      ${S_OID_USER_OTH}    ${EMPTY}            ${PATH}
+                            Get object           ${OTHER_WALLET}    ${CID}      ${S_OID_USER}        ${EMPTY}            ${PATH}

--- a/robot/testsuites/integration/acl/object_attributes/creation_epoch_filter.robot
+++ b/robot/testsuites/integration/acl/object_attributes/creation_epoch_filter.robot
@@ -29,32 +29,32 @@ Creation Epoch Object Filter for Extended ACL
     Log    Check eACL creationEpoch Filter with MatchType String Not Equal
     Check $Object:creationEpoch Filter with MatchType String Not Equal    $Object:creationEpoch
 
+    [Teardown]          Teardown    creation_epoch_filter
+
 *** Keywords ***
 
 Check $Object:creationEpoch Filter with MatchType String Not Equal
     [Arguments]    ${FILTER}
 
-    ${_}   ${_}    ${USER_KEY} =    Prepare Wallet And Deposit
-    ${_}   ${_}    ${OTHER_KEY} =    Prepare Wallet And Deposit
+    ${WALLET}   ${_}    ${_} =    Prepare Wallet And Deposit
+    ${WALLET_OTH}   ${_}    ${_} =    Prepare Wallet And Deposit
 
-    ${CID} =            Create Container Public    ${USER_KEY}
+    ${CID} =            Create Container Public    ${WALLET}
     ${FILE_S}    ${_} =    Generate file    ${SIMPLE_OBJ_SIZE}
 
-    ${S_OID} =          Put Object    ${USER_KEY}    ${FILE_S}    ${CID}
+    ${S_OID} =          Put Object    ${WALLET}    ${FILE_S}    ${CID}
                         Tick Epoch
-    ${S_OID_NEW} =      Put Object    ${USER_KEY}    ${FILE_S}    ${CID}
+    ${S_OID_NEW} =      Put Object    ${WALLET}    ${FILE_S}    ${CID}
 
-                        Get Object    ${USER_KEY}    ${CID}    ${S_OID_NEW}    ${EMPTY}    local_file_eacl
+                        Get Object    ${WALLET}    ${CID}    ${S_OID_NEW}    ${EMPTY}    local_file_eacl
 
-    &{HEADER_DICT} =    Head Object    ${USER_KEY}    ${CID}    ${S_OID_NEW}
+    &{HEADER_DICT} =    Head Object    ${WALLET}    ${CID}    ${S_OID_NEW}
     ${EACL_CUSTOM} =    Compose eACL Custom    ${CID}    ${HEADER_DICT}    !=    ${FILTER}    DENY    OTHERS
-                        Set eACL    ${USER_KEY}    ${CID}    ${EACL_CUSTOM}
+                        Set eACL    ${WALLET}    ${CID}    ${EACL_CUSTOM}
 
     Run Keyword And Expect Error   ${EACL_ERR_MSG}
-    ...  Get object    ${OTHER_KEY}    ${CID}    ${S_OID}    ${EMPTY}    ${OBJECT_PATH}
-    Get object    ${OTHER_KEY}    ${CID}    ${S_OID_NEW}     ${EMPTY}    ${OBJECT_PATH}
+    ...  Get object    ${WALLET_OTH}    ${CID}    ${S_OID}    ${EMPTY}    ${OBJECT_PATH}
+    Get object    ${WALLET_OTH}    ${CID}    ${S_OID_NEW}     ${EMPTY}    ${OBJECT_PATH}
     Run Keyword And Expect error    ${EACL_ERR_MSG}
-    ...  Head object    ${OTHER_KEY}    ${CID}    ${S_OID}
-    Head object    ${OTHER_KEY}    ${CID}    ${S_OID_NEW}
-
-    [Teardown]          Teardown    creation_epoch_filter
+    ...  Head object    ${WALLET_OTH}    ${CID}    ${S_OID}
+    Head object    ${WALLET_OTH}    ${CID}    ${S_OID_NEW}

--- a/robot/testsuites/integration/acl/object_attributes/object_id_filter.robot
+++ b/robot/testsuites/integration/acl/object_attributes/object_id_filter.robot
@@ -48,16 +48,16 @@ Object ID Object Filter for Extended ACL
 Check eACL Filters with MatchType String Equal with two contradicting filters
     [Arguments]    ${FILTER}
 
-    ${_}   ${_}     ${USER_KEY} =    Prepare Wallet And Deposit  
-    ${_}   ${_}     ${OTHER_KEY} =    Prepare Wallet And Deposit
+    ${WALLET}   ${_}     ${_} =    Prepare Wallet And Deposit  
+    ${WALLET_OTH}   ${_}     ${_} =    Prepare Wallet And Deposit
 
-    ${CID} =            Create Container Public    ${USER_KEY} 
+    ${CID} =            Create Container Public    ${WALLET} 
     ${FILE_S_USER}    ${_} =    Generate file    ${SIMPLE_OBJ_SIZE}
 
-    ${S_OID_USER} =     Put Object    ${USER_KEY}     ${FILE_S_USER}    ${CID}    ${EMPTY}
-    &{HEADER_DICT_USER} =    Object Header Decoded    ${USER_KEY}    ${CID}    ${S_OID_USER}
+    ${S_OID_USER} =     Put Object    ${WALLET}     ${FILE_S_USER}    ${CID}    ${EMPTY}
+    &{HEADER_DICT_USER} =    Object Header Decoded    ${WALLET}    ${CID}    ${S_OID_USER}
    
-                        Get Object    ${OTHER_KEY}    ${CID}       ${S_OID_USER}    ${EMPTY}    ${OBJECT_PATH}
+                        Get Object    ${WALLET_OTH}    ${CID}       ${S_OID_USER}    ${EMPTY}    ${OBJECT_PATH}
 
     ${filter_value} =    Get From Dictionary    ${HEADER_DICT_USER}    ${EACL_OBJ_FILTERS}[${FILTER}]
     ${filters} =        Set Variable    obj:${FILTER}=${filter_value}
@@ -67,24 +67,24 @@ Check eACL Filters with MatchType String Equal with two contradicting filters
     ${eACL_gen} =       Create List    ${rule}    ${contradicting_rule}
     ${EACL_CUSTOM} =    Create eACL    ${CID}      ${eACL_gen}
 
-                        Set eACL    ${USER_KEY}    ${CID}    ${EACL_CUSTOM}
-                        Get object    ${OTHER_KEY}    ${CID}    ${S_OID_USER}    ${EMPTY}    ${OBJECT_PATH}
+                        Set eACL    ${WALLET}    ${CID}    ${EACL_CUSTOM}
+                        Get object    ${WALLET_OTH}    ${CID}    ${S_OID_USER}    ${EMPTY}    ${OBJECT_PATH}
 
 Check eACL Filters, two matchTypes
     [Arguments]    ${FILTER}
 
-    ${_}   ${_}    ${USER_KEY} =    Prepare Wallet And Deposit  
-    ${_}   ${_}    ${OTHER_KEY} =    Prepare Wallet And Deposit
+    ${WALLET}   ${_}    ${_} =    Prepare Wallet And Deposit  
+    ${WALLET_OTH}   ${_}    ${_} =    Prepare Wallet And Deposit
 
-    ${CID} =            Create Container Public    ${USER_KEY}
+    ${CID} =            Create Container Public    ${WALLET}
     ${FILE_S}    ${_} =    Generate file    ${SIMPLE_OBJ_SIZE}
 
-    ${S_OID_USER} =     Put Object    ${USER_KEY}    ${FILE_S}    ${CID}    ${EMPTY}
-    ${S_OID_OTHER} =    Put Object    ${OTHER_KEY}    ${FILE_S}    ${CID}    ${EMPTY}
-    &{HEADER_DICT_USER} =    Object Header Decoded    ${USER_KEY}    ${CID}    ${S_OID_USER}
+    ${S_OID_USER} =     Put Object    ${WALLET}    ${FILE_S}    ${CID}    ${EMPTY}
+    ${S_OID_OTHER} =    Put Object    ${WALLET_OTH}    ${FILE_S}    ${CID}    ${EMPTY}
+    &{HEADER_DICT_USER} =    Object Header Decoded    ${WALLET}    ${CID}    ${S_OID_USER}
 
-                        Get Object    ${OTHER_KEY}    ${CID}    ${S_OID_USER}     ${EMPTY}    ${OBJECT_PATH}
-                        Get Object    ${OTHER_KEY}    ${CID}    ${S_OID_OTHER}    ${EMPTY}    ${OBJECT_PATH}
+                        Get Object    ${WALLET_OTH}    ${CID}    ${S_OID_USER}     ${EMPTY}    ${OBJECT_PATH}
+                        Get Object    ${WALLET_OTH}    ${CID}    ${S_OID_OTHER}    ${EMPTY}    ${OBJECT_PATH}
 
     ${filter_value} =    Get From Dictionary    ${HEADER_DICT_USER}    ${EACL_OBJ_FILTERS}[${FILTER}]
     ${noneq_filters} =    Set Variable    obj:${FILTER}!=${filter_value}
@@ -94,8 +94,8 @@ Check eACL Filters, two matchTypes
     ${eACL_gen} =       Create List    ${rule_noneq_filter}    ${rule_eq_filter}
     ${EACL_CUSTOM} =    Create eACL    ${CID}      ${eACL_gen}
 
-                        Set eACL    ${USER_KEY}    ${CID}    ${EACL_CUSTOM}
+                        Set eACL    ${WALLET}    ${CID}    ${EACL_CUSTOM}
                         Run Keyword And Expect Error    *
-                        ...  Get object      ${OTHER_KEY}    ${CID}    ${S_OID_OTHER}    ${EMPTY}    ${OBJECT_PATH}
+                        ...  Get object      ${WALLET_OTH}    ${CID}    ${S_OID_OTHER}    ${EMPTY}    ${OBJECT_PATH}
                         Run Keyword And Expect Error    *
-                        ...  Get Object    ${OTHER_KEY}    ${CID}    ${S_OID_USER}    ${EMPTY}    ${OBJECT_PATH}
+                        ...  Get Object    ${WALLET_OTH}    ${CID}    ${S_OID_USER}    ${EMPTY}    ${OBJECT_PATH}

--- a/robot/testsuites/integration/acl/object_attributes/payload_length_filter.robot
+++ b/robot/testsuites/integration/acl/object_attributes/payload_length_filter.robot
@@ -28,34 +28,33 @@ Payload Length Object Filter for Extended ACL
     Log    Check eACL payloadLength Filter with MatchType String Not Equal
     Check $Object:payloadLength Filter with MatchType String Not Equal    $Object:payloadLength
 
+    [Teardown]          Teardown    payload_length_filter
+
 *** Keywords ***
 
 Check $Object:payloadLength Filter with MatchType String Not Equal
     [Arguments]    ${FILTER}
 
-    ${_}   ${_}    ${USER_KEY} =    Prepare Wallet And Deposit
-    ${_}   ${_}    ${OTHER_KEY} =    Prepare Wallet And Deposit
+    ${WALLET}   ${_}    ${_} =    Prepare Wallet And Deposit
+    ${WALLET_OTH}   ${_}    ${_} =    Prepare Wallet And Deposit
 
-    ${CID} =            Create Container Public    ${USER_KEY}
+    ${CID} =            Create Container Public    ${WALLET}
     ${FILE_S}    ${_} =    Generate file    ${SIMPLE_OBJ_SIZE}
     ${FILE_0}    ${_} =    Generate file    ${0}
 
-    ${S_OID_0} =        Put Object    ${USER_KEY}    ${FILE_0}    ${CID}
-    ${S_OID} =          Put Object    ${USER_KEY}    ${FILE_S}    ${CID}
+    ${S_OID_0} =        Put Object    ${WALLET}    ${FILE_0}    ${CID}
+    ${S_OID} =          Put Object    ${WALLET}    ${FILE_S}    ${CID}
 
-                        Get Object    ${USER_KEY}    ${CID}    ${S_OID}    ${EMPTY}    local_file_eacl
-                        Head Object    ${USER_KEY}    ${CID}    ${S_OID}
+                        Get Object    ${WALLET}    ${CID}    ${S_OID}    ${EMPTY}    local_file_eacl
+                        Head Object    ${WALLET}    ${CID}    ${S_OID}
 
-    &{HEADER_DICT} =    Object Header Decoded    ${USER_KEY}    ${CID}    ${S_OID}
+    &{HEADER_DICT} =    Object Header Decoded    ${WALLET}    ${CID}    ${S_OID}
     ${EACL_CUSTOM} =    Compose eACL Custom    ${CID}    ${HEADER_DICT}    !=    ${FILTER}    DENY    OTHERS
-                        Set eACL    ${USER_KEY}    ${CID}    ${EACL_CUSTOM}
+                        Set eACL    ${WALLET}    ${CID}    ${EACL_CUSTOM}
 
     Run Keyword And Expect Error   ${EACL_ERR_MSG}
-    ...  Get object    ${OTHER_KEY}    ${CID}    ${S_OID_0}    ${EMPTY}    ${OBJECT_PATH}
-    Get object    ${OTHER_KEY}    ${CID}    ${S_OID}     ${EMPTY}    ${OBJECT_PATH}
+    ...  Get object    ${WALLET_OTH}    ${CID}    ${S_OID_0}    ${EMPTY}    ${OBJECT_PATH}
+    Get object    ${WALLET_OTH}    ${CID}    ${S_OID}     ${EMPTY}    ${OBJECT_PATH}
     Run Keyword And Expect error    ${EACL_ERR_MSG}
-    ...  Head object    ${OTHER_KEY}    ${CID}    ${S_OID_0}
-    Head object    ${OTHER_KEY}    ${CID}    ${S_OID}
-
-
-    [Teardown]          Teardown    payload_length_filter
+    ...  Head object    ${WALLET_OTH}    ${CID}    ${S_OID_0}
+    Head object    ${WALLET_OTH}    ${CID}    ${S_OID}

--- a/robot/testsuites/integration/cli/accounting/balance.robot
+++ b/robot/testsuites/integration/cli/accounting/balance.robot
@@ -22,34 +22,29 @@ CLI Accounting Balance Test
 
     [Setup]                   Setup
 
-    ${WALLET}   ${ADDR}     ${WIF} =   Prepare Wallet And Deposit   ${DEPOSIT_AMOUNT}
-
-    # Getting balance with WIF
-    ${OUTPUT} =    Run Process    ${NEOFS_CLI_EXEC} accounting balance -r ${NEOFS_ENDPOINT} --wallet ${WIF}
-                   ...            shell=True
-    Should Be Equal As Numbers   ${OUTPUT.stdout}   ${DEPOSIT_AMOUNT}
+    ${WALLET}   ${ADDR}     ${_} =   Prepare Wallet And Deposit   ${DEPOSIT_AMOUNT}
 
     # Getting balance with wallet and address
-    ${OUTPUT} =    Run Process And Enter Empty Password
-                    ...    ${NEOFS_CLI_EXEC} accounting balance -r ${NEOFS_ENDPOINT} --address ${ADDR} --wallet ${WALLET}
-    Should Be Equal As Numbers   ${OUTPUT}   ${DEPOSIT_AMOUNT}
+    ${OUTPUT} =     Run Process    ${NEOFS_CLI_EXEC} accounting balance -r ${NEOFS_ENDPOINT} --address ${ADDR} --wallet ${WALLET} --config ${WALLET_PASS}
+                    ...    shell=True
+    Should Be Equal As Numbers   ${OUTPUT.stdout}   ${DEPOSIT_AMOUNT}
 
     # Getting balance with wallet only
-    ${OUTPUT} =    Run Process And Enter Empty Password
-                    ...    ${NEOFS_CLI_EXEC} accounting balance -r ${NEOFS_ENDPOINT} --wallet ${WALLET}
-    Should Be Equal As Numbers   ${OUTPUT}   ${DEPOSIT_AMOUNT}
+    ${OUTPUT} =     Run Process    ${NEOFS_CLI_EXEC} accounting balance -r ${NEOFS_ENDPOINT} --wallet ${WALLET} --config ${WALLET_PASS}
+                    ...    shell=True
+    Should Be Equal As Numbers   ${OUTPUT.stdout}   ${DEPOSIT_AMOUNT}
 
     # Getting balance with wallet and wrong address
     ${ANOTHER_WALLET}   ${ANOTHER_ADDR}     ${ANOTHER_WIF} =   Init Wallet With Address     ${ASSETS_DIR}
-    ${OUTPUT} =     Run Process    ${NEOFS_CLI_EXEC} accounting balance -r ${NEOFS_ENDPOINT} --address ${ANOTHER_ADDR} --wallet ${WALLET}
-                    ...            shell=True
+    ${OUTPUT} =     Run Process    ${NEOFS_CLI_EXEC} accounting balance -r ${NEOFS_ENDPOINT} --address ${ANOTHER_ADDR} --wallet ${WALLET} --config ${WALLET_PASS}
+                    ...    shell=True
     Should Be Equal As Strings     ${OUTPUT.stderr}    --address option must be specified and valid
     Should Be Equal As Numbers     ${OUTPUT.rc}        1
 
     # Getting balance with control API
-    ${CONFIG_PATH} =    Write API Config    ${NEOFS_ENDPOINT}   ${WIF}
+    ${CONFIG_PATH} =    Write API Config    ${NEOFS_ENDPOINT}   ${WALLET}
     ${OUTPUT} =         Run Process     ${NEOFS_CLI_EXEC} accounting balance --config ${CONFIG_PATH}
-                        ...             shell=True
+                        ...    shell=True
     Should Be Equal As Numbers          ${OUTPUT.stdout}   ${DEPOSIT_AMOUNT}
 
     [Teardown]      Teardown    cli_accounting_balance
@@ -58,9 +53,9 @@ CLI Accounting Balance Test
 
 Write API Config
     [Documentation]     Write YAML config for requesting NeoFS API via CLI
-    [Arguments]         ${ENDPOINT}     ${WIF}
+    [Arguments]         ${ENDPOINT}     ${WALLET}
 
     Set Local Variable  ${PATH}     ${ASSETS_DIR}/config.yaml
-    Create File         ${PATH}     rpc-endpoint: ${ENDPOINT}\nwif: ${WIF}
+    Create File         ${PATH}     rpc-endpoint: ${ENDPOINT}\nwallet: ${WALLET}\npassword: ''
 
     [Return]            ${PATH}

--- a/robot/testsuites/integration/cli/netmap/networkinfo_rpc_method.robot
+++ b/robot/testsuites/integration/cli/netmap/networkinfo_rpc_method.robot
@@ -6,6 +6,7 @@ Library    Process
 Library    String
 Library    contract_keywords.py
 
+Resource    payment_operations.robot
 Resource    setup_teardown.robot
 
 *** Variables ***
@@ -23,10 +24,12 @@ NetworkInfo RPC Method
     ######################################################################
     # Checking if the command returns equal results for two storage nodes
     ######################################################################
+#TODO: Remove line for it's unnecessary (#194)
+    ${WALLET_MAINNET}    ${ADDR_MAINNET} =     Prepare Wallet with WIF And Deposit    ${MAINNET_WALLET_WIF}
 
-    ${RESULT1_S01}            Run Process    ${NEOFS_CLI_EXEC} netmap netinfo -r ${SN_01_ADDR} --wallet ${MAINNET_WALLET_WIF}    shell=True
+    ${RESULT1_S01}            Run Process    ${NEOFS_CLI_EXEC} netmap netinfo -r ${SN_01_ADDR} --wallet ${WALLET_MAINNET} --config ${WALLET_PASS}    shell=True
     Should Be Equal As Integers    ${RESULT1_S01.rc} 	0
-    ${RESULT1_S02}            Run Process    ${NEOFS_CLI_EXEC} netmap netinfo -r ${SN_02_ADDR} --wallet ${MAINNET_WALLET_WIF}    shell=True
+    ${RESULT1_S02}            Run Process    ${NEOFS_CLI_EXEC} netmap netinfo -r ${SN_02_ADDR} --wallet ${WALLET_MAINNET} --config ${WALLET_PASS}    shell=True
     Should Be Equal As Integers    ${RESULT1_S02.rc} 	0
 
     #############################################
@@ -53,9 +56,9 @@ NetworkInfo RPC Method
 
     Tick Epoch
 
-    ${RESULT2_S01}           Run Process    ${NEOFS_CLI_EXEC} netmap netinfo -r ${SN_01_ADDR} --wallet ${MAINNET_WALLET_WIF}    shell=True
+    ${RESULT2_S01}           Run Process    ${NEOFS_CLI_EXEC} netmap netinfo -r ${SN_01_ADDR} --wallet ${WALLET_MAINNET} --config ${WALLET_PASS}    shell=True
     Should Be Equal As Integers    ${RESULT2_S01.rc} 	0
-    ${RESULT2_S02}           Run Process    ${NEOFS_CLI_EXEC} netmap netinfo -r ${SN_02_ADDR} --wallet ${MAINNET_WALLET_WIF}    shell=True
+    ${RESULT2_S02}           Run Process    ${NEOFS_CLI_EXEC} netmap netinfo -r ${SN_02_ADDR} --wallet ${WALLET_MAINNET} --config ${WALLET_PASS}    shell=True
     Should Be Equal As Integers    ${RESULT2_S02.rc} 	0
 
     Should Be Equal As Strings    ${RESULT2_S01.stdout}    ${RESULT2_S02.stdout}

--- a/robot/testsuites/integration/container/container_attributes.robot
+++ b/robot/testsuites/integration/container/container_attributes.robot
@@ -26,33 +26,32 @@ Duplicated Container Attributes
 
     [Setup]                     Setup
 
-    ${_}   ${ADDR}     ${USER_KEY} =   Init Wallet with Address    ${ASSETS_DIR}
-    Payment Operations      ${ADDR}         ${USER_KEY}
+    ${WALLET}   ${_}     ${_} =   Prepare Wallet And Deposit
 
     ######################################################
     # Checking that container attributes cannot duplicate
     ######################################################
 
     Run Keyword And Expect Error    *
-    ...    Create container        ${USER_KEY}    ${EMPTY}    ${POLICY}   ${ATTR_TIME}
+    ...    Create container        ${WALLET}    ${EMPTY}    ${POLICY}   ${ATTR_TIME}
     Run Keyword And Expect Error    *
-    ...    Create container        ${USER_KEY}    ${EMPTY}    ${POLICY}    ${ATTR_DUPLICATE}
+    ...    Create container        ${WALLET}    ${EMPTY}    ${POLICY}    ${ATTR_DUPLICATE}
 
     ######################################################
     # Checking that container cannot have empty attribute
     ######################################################
 
     Run Keyword And Expect Error    *
-    ...    Create container        ${USER_KEY}    ${EMPTY}    ${POLICY}    ${ATTR_NONE}
+    ...    Create container        ${WALLET}    ${EMPTY}    ${POLICY}    ${ATTR_NONE}
 
     #####################################################
     # Checking a successful step with a single attribute
     #####################################################
 
-    ${CID} =                Create container    ${USER_KEY}    ${EMPTY}    ${POLICY}    ${ATTR_SINGLE}
+    ${CID} =                Create container    ${WALLET}    ${EMPTY}    ${POLICY}    ${ATTR_SINGLE}
                             Wait Until Keyword Succeeds    ${MORPH_BLOCK_TIME}       ${CONTAINER_WAIT_INTERVAL}
-                            ...     Container Existing     ${USER_KEY}     ${CID}
-    ${ATTRIBUTES} =         Get container attributes    ${USER_KEY}    ${CID}    ${EMPTY}    json_output=True
+                            ...     Container Existing     ${WALLET}     ${CID}
+    ${ATTRIBUTES} =         Get container attributes    ${WALLET}    ${CID}    ${EMPTY}    json_output=True
     &{ATTRIBUTES_DICT} =    Decode Container Attributes Json    ${ATTRIBUTES}
                             List Should Contain Value
                                 ...     ${ATTRIBUTES_DICT}[Attributes]

--- a/robot/testsuites/integration/container/container_session_token.robot
+++ b/robot/testsuites/integration/container/container_session_token.robot
@@ -22,8 +22,8 @@ Session Token for Container
 
     [Setup]            Setup
 
-    ${WALLET}    ${OWNER}    ${OWNER_KEY} =   Prepare Wallet And Deposit
-    ${GEN_WALLET}    ${GEN}    ${GEN_KEY} =    Init Wallet with Address    ${ASSETS_DIR}
+    ${WALLET}    ${OWNER}    ${_} =   Prepare Wallet And Deposit
+    ${GEN_WALLET}    ${GEN}    ${_} =    Prepare Wallet And Deposit
 
     ${UTIL} =    Run Process    ${NEOGO_EXECUTABLE} wallet dump-keys -w ${GEN_WALLET}     shell=True
     ${PUB_PART} =    Get Line    ${UTIL.stdout}    1
@@ -32,17 +32,17 @@ Session Token for Container
 
     Sign Session token    ${SESSION_TOKEN}    ${WALLET}    ${SIGNED_FILE}
     
-    ${CID} =            Create Container    ${GEN_KEY}    ${PRIVATE_ACL_F}    ${COMMON_PLACEMENT_RULE}    ${EMPTY}    ${SIGNED_FILE}
+    ${CID} =            Create Container    ${GEN_WALLET}    ${PRIVATE_ACL_F}    ${COMMON_PLACEMENT_RULE}    ${EMPTY}    ${SIGNED_FILE}
                         Wait Until Keyword Succeeds    ${MORPH_BLOCK_TIME}    ${CONTAINER_WAIT_INTERVAL}
-                        ...  Container Existing    ${OWNER_KEY}    ${CID}
+                        ...  Container Existing    ${WALLET}    ${CID}
                         Run Keyword And Expect Error    *
-                        ...  Container Existing    ${GEN_KEY}    ${CID}  
+                        ...  Container Existing    ${GEN_WALLET}    ${CID}  
 
 ########################
 # Check container owner 
 ########################
 
-    ${CONTAINER_INFO} =    Run Process    ${NEOFS_CLI_EXEC} container get --cid ${CID} --wallet ${GEN_KEY} --rpc-endpoint ${NEOFS_ENDPOINT}    shell=True
+    ${CONTAINER_INFO} =    Run Process    ${NEOFS_CLI_EXEC} container get --cid ${CID} --wallet ${GEN_WALLET} --config ${WALLET_PASS} --rpc-endpoint ${NEOFS_ENDPOINT}    shell=True
     ${CID_OWNER_ID_LINE} =    Get Line    ${CONTAINER_INFO.stdout}    2
     @{CID_OWNER_ID} =    Split String    ${CID_OWNER_ID_LINE}
     Should Be Equal As Strings    ${OWNER}    ${CID_OWNER_ID}[2]

--- a/robot/testsuites/integration/network/netmap_control.robot
+++ b/robot/testsuites/integration/network/netmap_control.robot
@@ -18,37 +18,37 @@ Control Operations with storage nodes
 
     [Setup]                 Setup
 
-    ${NODE_NUM}    ${NODE}    ${WIF} =     Get control endpoint with wif    
+    ${NODE_NUM}    ${NODE}    ${WIF} =     Get control endpoint with wif
+    ${WALLET_STORAGE}    ${ADDR_STORAGE} =    Prepare Wallet with WIF And Deposit    ${WIF}     
     ${empty_list} =         Create List
 
-    ${SNAPSHOT} =           Run Process    ${NEOFS_CLI_EXEC} control netmap-snapshot --endpoint ${NODE} --wallet ${WIF}    shell=True
-    ${HEALTHCHECK} =        Run Process    ${NEOFS_CLI_EXEC} control healthcheck --endpoint ${NODE} --wallet ${WIF}    shell=True
+    ${SNAPSHOT} =           Run Process    ${NEOFS_CLI_EXEC} control netmap-snapshot --endpoint ${NODE} --wallet ${WALLET_STORAGE} --config ${WALLET_PASS}    shell=True
+    ${HEALTHCHECK} =        Run Process    ${NEOFS_CLI_EXEC} control healthcheck --endpoint ${NODE} --wallet ${WALLET_STORAGE} --config ${WALLET_PASS}    shell=True
                             Should Be Equal As Integers    ${HEALTHCHECK.rc}    0
 
-                            Run Process    ${NEOFS_CLI_EXEC} control set-status --endpoint ${NODE} --wallet ${WIF} --status 'offline'    shell=True
+                            Run Process    ${NEOFS_CLI_EXEC} control set-status --endpoint ${NODE} --wallet ${WALLET_STORAGE} --config ${WALLET_PASS} --status 'offline'    shell=True
                             
                             Sleep    ${MAINNET_BLOCK_TIME}
                             Tick Epoch
 
-
-    ${SNAPSHOT_OFFLINE}=    Run Process    ${NEOFS_CLI_EXEC} control netmap-snapshot --endpoint ${NODE} --wallet ${WIF}    shell=True
+    ${SNAPSHOT_OFFLINE}=    Run Process    ${NEOFS_CLI_EXEC} control netmap-snapshot --endpoint ${NODE} --wallet ${WALLET_STORAGE} --config ${WALLET_PASS}    shell=True
     ${NODE_NUM_OFFLINE}=    Get Regexp Matches        ${SNAPSHOT_OFFLINE.stdout}    ${NODE_NUM}
                             Should Be Equal    ${NODE_NUM_OFFLINE}    ${empty_list}
 
-    ${HEALTHCHECK_OFFLINE} =    Run Process    ${NEOFS_CLI_EXEC} control healthcheck --endpoint ${NODE} --wallet ${WIF}    shell=True
+    ${HEALTHCHECK_OFFLINE} =    Run Process    ${NEOFS_CLI_EXEC} control healthcheck --endpoint ${NODE} --wallet ${WALLET_STORAGE} --config ${WALLET_PASS}    shell=True
                             Should Be Equal As Integers    ${HEALTHCHECK_OFFLINE.rc}    0
                             Should Not Be Equal    ${HEALTHCHECK.stdout}    ${HEALTHCHECK_OFFLINE.stdout} 
     
-                            Run Process    ${NEOFS_CLI_EXEC} control set-status --endpoint ${NODE} --wallet ${WIF} --status 'online'    shell=True
+                            Run Process    ${NEOFS_CLI_EXEC} control set-status --endpoint ${NODE} --wallet ${WALLET_STORAGE} --config ${WALLET_PASS} --status 'online'    shell=True
 
                             Sleep    ${MAINNET_BLOCK_TIME}
                             Tick Epoch
 
-    ${SNAPSHOT_ONLINE} =    Run Process    ${NEOFS_CLI_EXEC} control netmap-snapshot --endpoint ${NODE} --wallet ${WIF}    shell=True
+    ${SNAPSHOT_ONLINE} =    Run Process    ${NEOFS_CLI_EXEC} control netmap-snapshot --endpoint ${NODE} --wallet ${WALLET_STORAGE} --config ${WALLET_PASS}    shell=True
     ${NODE_NUM_ONLINE} =    Get Regexp Matches        ${SNAPSHOT_ONLINE.stdout}    ${NODE_NUM}    
                             Should Be Equal    ${NODE_NUM_ONLINE}[0]    ${NODE_NUM}
 
-    ${HEALTHCHECK_ONLINE} =    Run Process    ${NEOFS_CLI_EXEC} control healthcheck --endpoint ${NODE} --wallet ${WIF}    shell=True
+    ${HEALTHCHECK_ONLINE} =    Run Process    ${NEOFS_CLI_EXEC} control healthcheck --endpoint ${NODE} --wallet ${WALLET_STORAGE} --config ${WALLET_PASS}    shell=True
                             Should Be Equal As Integers    ${HEALTHCHECK_ONLINE.rc}    0
                             Should Be Equal    ${HEALTHCHECK.stdout}    ${HEALTHCHECK_ONLINE.stdout}    
 

--- a/robot/testsuites/integration/network/netmap_control_drop.robot
+++ b/robot/testsuites/integration/network/netmap_control_drop.robot
@@ -26,62 +26,63 @@ Drop command in control group
 
     [Setup]                 Setup
 
-    ${_}    ${NODE}    ${WIF} =     Get control endpoint with wif
+    ${_}    ${NODE}    ${WIF_STORAGE} =     Get control endpoint with wif
+    ${WALLET_STORAGE}    ${_} =          Prepare Wallet with WIF And Deposit    ${WIF_STORAGE}
     ${LOCODE} =         Get Locode
 
     ${FILE_SIMPLE} =    Generate file of bytes    ${SIMPLE_OBJ_SIZE}
     ${FILE_COMPLEX} =   Generate file of bytes    ${COMPLEX_OBJ_SIZE}
 
-    ${_}    ${_}    ${USER_KEY} =    Prepare Wallet And Deposit
+    ${WALLET}    ${_}    ${_} =    Prepare Wallet And Deposit
 
-    ${PRIV_CID} =       Create container             ${USER_KEY}    ${PRIVATE_ACL_F}   REP 1 CBF 1 SELECT 1 FROM * FILTER 'UN-LOCODE' EQ '${LOCODE}' AS LOC
+    ${PRIV_CID} =       Create container             ${WALLET}    ${PRIVATE_ACL_F}   REP 1 CBF 1 SELECT 1 FROM * FILTER 'UN-LOCODE' EQ '${LOCODE}' AS LOC
                         Wait Until Keyword Succeeds      ${MORPH_BLOCK_TIME}    ${CONTAINER_WAIT_INTERVAL}
-                        ...  Container Existing       ${USER_KEY}    ${PRIV_CID}
+                        ...  Container Existing       ${WALLET}    ${PRIV_CID}
 
     #########################
     # Dropping simple object
     #########################
 
-    ${S_OID} =          Put object    ${USER_KEY}    ${FILE_SIMPLE}    ${PRIV_CID}
-                        Get object    ${USER_KEY}    ${PRIV_CID}    ${S_OID}    ${EMPTY}    s_file_read
-                        Head object    ${USER_KEY}    ${PRIV_CID}    ${S_OID}
+    ${S_OID} =          Put object    ${WALLET}    ${FILE_SIMPLE}    ${PRIV_CID}
+                        Get object    ${WALLET}    ${PRIV_CID}    ${S_OID}    ${EMPTY}    s_file_read
+                        Head object    ${WALLET}    ${PRIV_CID}    ${S_OID}
 
-                        Drop object    ${NODE}    ${WIF}    ${PRIV_CID}    ${S_OID}
+                        Drop object    ${NODE}    ${WALLET_STORAGE}    ${PRIV_CID}    ${S_OID}
 
                         Wait Until Keyword Succeeds    3x    ${SHARD_0_GC_SLEEP}
                         ...  Run Keyword And Expect Error    Error:*
-                        ...  Get object    ${USER_KEY}    ${PRIV_CID}    ${S_OID}    ${EMPTY}    s_file_read    options=--ttl 1
+                        ...  Get object    ${WALLET}    ${PRIV_CID}    ${S_OID}    ${EMPTY}    s_file_read    options=--ttl 1
                         Wait Until Keyword Succeeds    3x    ${SHARD_0_GC_SLEEP}
                         ...  Run Keyword And Expect Error    Error:*
-                        ...  Head object    ${USER_KEY}    ${PRIV_CID}    ${S_OID}    options=--ttl 1
+                        ...  Head object    ${WALLET}    ${PRIV_CID}    ${S_OID}    options=--ttl 1
 
-                        Drop object    ${NODE}    ${WIF}    ${PRIV_CID}    ${S_OID}
+                        Drop object    ${NODE}    ${WALLET_STORAGE}    ${PRIV_CID}    ${S_OID}
 
     ##########################
     # Dropping complex object
     ##########################
 
-    ${C_OID} =          Put object    ${USER_KEY}    ${FILE_COMPLEX}    ${PRIV_CID}
-                        Get object    ${USER_KEY}    ${PRIV_CID}    ${C_OID}    ${EMPTY}    s_file_read
-                        Head object    ${USER_KEY}    ${PRIV_CID}    ${C_OID}
+    ${C_OID} =          Put object    ${WALLET}    ${FILE_COMPLEX}    ${PRIV_CID}
+                        Get object    ${WALLET}    ${PRIV_CID}    ${C_OID}    ${EMPTY}    s_file_read
+                        Head object    ${WALLET}    ${PRIV_CID}    ${C_OID}
 
-                        Drop object    ${NODE}    ${WIF}    ${PRIV_CID}    ${C_OID}
+                        Drop object    ${NODE}    ${WALLET_STORAGE}    ${PRIV_CID}    ${C_OID}
 
-                        Get object    ${USER_KEY}    ${PRIV_CID}    ${C_OID}    ${EMPTY}    s_file_read
-                        Head object    ${USER_KEY}    ${PRIV_CID}    ${C_OID}
+                        Get object    ${WALLET}    ${PRIV_CID}    ${C_OID}    ${EMPTY}    s_file_read
+                        Head object    ${WALLET}    ${PRIV_CID}    ${C_OID}
 
-    @{SPLIT_OIDS} =     Get Object Parts By Link Object    ${USER_KEY}    ${PRIV_CID}   ${C_OID}
+    @{SPLIT_OIDS} =     Get Object Parts By Link Object    ${WALLET}    ${PRIV_CID}   ${C_OID}
     FOR    ${CHILD_OID}    IN    @{SPLIT_OIDS}
-        Drop object    ${NODE}    ${WIF}    ${PRIV_CID}    ${CHILD_OID}
+        Drop object    ${NODE}    ${WALLET_STORAGE}    ${PRIV_CID}    ${CHILD_OID}
 
     END
 
                         Wait Until Keyword Succeeds    3x    ${SHARD_0_GC_SLEEP}
                         ...  Run Keyword And Expect Error    Error:*
-                        ...  Get object    ${USER_KEY}    ${PRIV_CID}    ${C_OID}    ${EMPTY}    s_file_read    options=--ttl 1
+                        ...  Get object    ${WALLET}    ${PRIV_CID}    ${C_OID}    ${EMPTY}    s_file_read    options=--ttl 1
                         Wait Until Keyword Succeeds    3x    ${SHARD_0_GC_SLEEP}
                         ...  Run Keyword And Expect Error    Error:*
-                        ...  Head object    ${USER_KEY}    ${PRIV_CID}    ${C_OID}    options=--ttl 1
+                        ...  Head object    ${WALLET}    ${PRIV_CID}    ${C_OID}    options=--ttl 1
 
 
     [Teardown]    Teardown    netmap_control_drop

--- a/robot/testsuites/integration/network/netmap_simple.robot
+++ b/robot/testsuites/integration/network/netmap_simple.robot
@@ -21,78 +21,69 @@ NeoFS Simple Netmap
 
     [Setup]             Setup
 
-    Generate Key and Pre-payment
+    ${WALLET}   ${_}    ${_} =    Prepare Wallet And Deposit
+    ${FILE} =          Generate file of bytes    ${SIMPLE_OBJ_SIZE}
 
-    Generate file
+    Validate Policy    ${USER_WALLET}    ${FILE_S}    REP 2 IN X CBF 2 SELECT 2 FROM * AS X    2    @{EMPTY}
 
-    Validate Policy    REP 2 IN X CBF 2 SELECT 2 FROM * AS X    2    @{EMPTY}
+    Validate Policy    ${USER_WALLET}    ${FILE_S}    REP 2 IN X CBF 1 SELECT 2 FROM * AS X    2    @{EMPTY}
 
-    Validate Policy    REP 2 IN X CBF 1 SELECT 2 FROM * AS X    2    @{EMPTY}
+    Validate Policy    ${USER_WALLET}    ${FILE_S}    REP 3 IN X CBF 1 SELECT 3 FROM * AS X    3    @{EMPTY}
 
-    Validate Policy    REP 3 IN X CBF 1 SELECT 3 FROM * AS X    3    @{EMPTY}
+    Validate Policy    ${USER_WALLET}    ${FILE_S}    REP 1 IN X CBF 1 SELECT 1 FROM * AS X    1    @{EMPTY}
 
-    Validate Policy    REP 1 IN X CBF 1 SELECT 1 FROM * AS X    1    @{EMPTY}
+    Validate Policy    ${USER_WALLET}    ${FILE_S}    REP 1 IN X CBF 2 SELECT 1 FROM * AS X    1    @{EMPTY}
 
-    Validate Policy    REP 1 IN X CBF 2 SELECT 1 FROM * AS X    1    @{EMPTY}
+    Validate Policy    ${USER_WALLET}    ${FILE_S}    REP 4 IN X CBF 1 SELECT 4 FROM * AS X    4    @{EMPTY}
 
-    Validate Policy    REP 4 IN X CBF 1 SELECT 4 FROM * AS X    4    @{EMPTY}
-
-    Validate Policy    REP 2 IN X CBF 1 SELECT 4 FROM * AS X    2    @{EMPTY}
+    Validate Policy    ${USER_WALLET}    ${FILE_S}    REP 2 IN X CBF 1 SELECT 4 FROM * AS X    2    @{EMPTY}
 
     @{EXPECTED} =	   Create List    s01.neofs.devenv:8080    s02.neofs.devenv:8080    s03.neofs.devenv:8080    s04.neofs.devenv:8080
-    Validate Policy    REP 4 IN X CBF 1 SELECT 4 FROM * AS X    4    @{EXPECTED}
+    Validate Policy    ${USER_WALLET}    ${FILE_S}    REP 4 IN X CBF 1 SELECT 4 FROM * AS X    4    @{EXPECTED}
 
     @{EXPECTED} =	   Create List    s03.neofs.devenv:8080
-    Validate Policy    REP 1 IN LOC_PLACE CBF 1 SELECT 1 FROM LOC_SW AS LOC_PLACE FILTER Country EQ Sweden AS LOC_SW    1    @{EXPECTED}
+    Validate Policy    ${USER_WALLET}    ${FILE_S}    REP 1 IN LOC_PLACE CBF 1 SELECT 1 FROM LOC_SW AS LOC_PLACE FILTER Country EQ Sweden AS LOC_SW
+    ...    1    @{EXPECTED}
 
     @{EXPECTED} =	   Create List    s02.neofs.devenv:8080
-    Validate Policy    REP 1 CBF 1 SELECT 1 FROM LOC_SPB FILTER 'UN-LOCODE' EQ 'RU LED' AS LOC_SPB    1    @{EXPECTED}
+    Validate Policy    ${USER_WALLET}    ${FILE_S}    REP 1 CBF 1 SELECT 1 FROM LOC_SPB FILTER 'UN-LOCODE' EQ 'RU LED' AS LOC_SPB    1    @{EXPECTED}
 
     @{EXPECTED} =	   Create List    s01.neofs.devenv:8080    s02.neofs.devenv:8080
-    Validate Policy    REP 1 IN LOC_SPB_PLACE REP 1 IN LOC_MSK_PLACE CBF 1 SELECT 1 FROM LOC_SPB AS LOC_SPB_PLACE SELECT 1 FROM LOC_MSK AS LOC_MSK_PLACE FILTER 'UN-LOCODE' EQ 'RU LED' AS LOC_SPB FILTER 'UN-LOCODE' EQ 'RU MOW' AS LOC_MSK          2       @{EXPECTED}
+    Validate Policy    ${USER_WALLET}    ${FILE_S}    REP 1 IN LOC_SPB_PLACE REP 1 IN LOC_MSK_PLACE CBF 1 SELECT 1 FROM LOC_SPB AS LOC_SPB_PLACE SELECT 1 FROM LOC_MSK AS LOC_MSK_PLACE FILTER 'UN-LOCODE' EQ 'RU LED' AS LOC_SPB FILTER 'UN-LOCODE' EQ 'RU MOW' AS LOC_MSK
+    ...          2       @{EXPECTED}
 
     @{EXPECTED} =	   Create List    s01.neofs.devenv:8080    s02.neofs.devenv:8080    s03.neofs.devenv:8080    s04.neofs.devenv:8080
-    Validate Policy    REP 4 CBF 1 SELECT 4 FROM LOC_EU FILTER Continent EQ Europe AS LOC_EU    4    @{EXPECTED}
+    Validate Policy    ${USER_WALLET}    ${FILE_S}    REP 4 CBF 1 SELECT 4 FROM LOC_EU FILTER Continent EQ Europe AS LOC_EU    4    @{EXPECTED}
 
     @{EXPECTED} =	   Create List    s02.neofs.devenv:8080
-    Validate Policy    REP 1 CBF 1 SELECT 1 FROM LOC_SPB FILTER 'UN-LOCODE' NE 'RU MOW' AND 'UN-LOCODE' NE 'SE STO' AND 'UN-LOCODE' NE 'FI HEL' AS LOC_SPB           1       @{EXPECTED}
+    Validate Policy    ${USER_WALLET}    ${FILE_S}    REP 1 CBF 1 SELECT 1 FROM LOC_SPB FILTER 'UN-LOCODE' NE 'RU MOW' AND 'UN-LOCODE' NE 'SE STO' AND 'UN-LOCODE' NE 'FI HEL' AS LOC_SPB
+    ...           1       @{EXPECTED}
 
     @{EXPECTED} =	   Create List    s01.neofs.devenv:8080    s02.neofs.devenv:8080
-    Validate Policy    REP 2 CBF 1 SELECT 2 FROM LOC_RU FILTER SubDivCode NE 'AB' AND SubDivCode NE '18' AS LOC_RU    2    @{EXPECTED}
+    Validate Policy    ${USER_WALLET}    ${FILE_S}    REP 2 CBF 1 SELECT 2 FROM LOC_RU FILTER SubDivCode NE 'AB' AND SubDivCode NE '18' AS LOC_RU    2    @{EXPECTED}
 
     @{EXPECTED} =	   Create List    s01.neofs.devenv:8080    s02.neofs.devenv:8080
-    Validate Policy    REP 2 CBF 1 SELECT 2 FROM LOC_RU FILTER Country EQ 'Russia' AS LOC_RU    2    @{EXPECTED}
+    Validate Policy    ${USER_WALLET}    ${FILE_S}    REP 2 CBF 1 SELECT 2 FROM LOC_RU FILTER Country EQ 'Russia' AS LOC_RU    2    @{EXPECTED}
 
     @{EXPECTED} =      Create List    s03.neofs.devenv:8080    s04.neofs.devenv:8080
-    Validate Policy    REP 2 CBF 1 SELECT 2 FROM LOC_EU FILTER Country NE 'Russia' AS LOC_EU    2    @{EXPECTED}
+    Validate Policy    ${USER_WALLET}    ${FILE_S}    REP 2 CBF 1 SELECT 2 FROM LOC_EU FILTER Country NE 'Russia' AS LOC_EU    2    @{EXPECTED}
 
     Log	               Put operation should be failed with error "not enough nodes to SELECT from: 'X'"
                        Run Keyword And Expect Error    *
-                       ...  Validate Policy    REP 2 IN X CBF 2 SELECT 6 FROM * AS X    2    @{EMPTY}
+                       ...  Validate Policy    ${USER_WALLET}    ${FILE_S}    REP 2 IN X CBF 2 SELECT 6 FROM * AS X    2    @{EMPTY}
 
     [Teardown]         Teardown     netmap_simple
 
 *** Keywords ***
 
-
-Generate file
-    ${FILE} =           Generate file of bytes    ${SIMPLE_OBJ_SIZE}
-                        Set Global Variable       ${FILE}    ${FILE}
-
-Generate Key and Pre-payment
-    ${WALLET}   ${ADDR}     ${USER_KEY_GEN} =   Init Wallet with Address    ${ASSETS_DIR}
-                        Set Global Variable     ${PRIV_KEY}     ${USER_KEY_GEN}
-                        Payment Operations      ${ADDR}      ${PRIV_KEY}
-
-
 Validate Policy
-    [Arguments]    ${POLICY}    ${EXPECTED_VAL}     @{EXPECTED_LIST}
+    [Arguments]    ${WALLET}    ${FILE}    ${POLICY}    ${EXPECTED_VAL}     @{EXPECTED_LIST}
 
                         Log	                   Container with rule ${POLICY}
 
-    ${CID} =            Create container               ${PRIV_KEY}    ${EMPTY}      ${POLICY}
+    ${CID} =            Create container               ${WALLET}    ${EMPTY}      ${POLICY}
                         Wait Until Keyword Succeeds    ${MORPH_BLOCK_TIME}      ${CONTAINER_WAIT_INTERVAL}
-                        ...     Container Existing         ${PRIV_KEY}    ${CID}
-    ${S_OID} =          Put object               ${PRIV_KEY}    ${FILE}       ${CID}
-                        Validate storage policy for object      ${PRIV_KEY}    ${EXPECTED_VAL}           ${CID}       ${S_OID}   ${EXPECTED_LIST}
-                        Get object               ${PRIV_KEY}    ${CID}    ${S_OID}    ${EMPTY}    s_file_read
+                        ...     Container Existing         ${WALLET}    ${CID}
+    ${S_OID} =          Put object               ${WALLET}    ${FILE}       ${CID}
+                        Validate storage policy for object      ${WALLET}    ${EXPECTED_VAL}           ${CID}       ${S_OID}   ${EXPECTED_LIST}
+                        Get object               ${WALLET}    ${CID}    ${S_OID}    ${EMPTY}    s_file_read

--- a/robot/testsuites/integration/network/replication.robot
+++ b/robot/testsuites/integration/network/replication.robot
@@ -38,18 +38,18 @@ NeoFS Object Replication
 Check Replication
     [Arguments]    ${ACL}
 
-    ${_}   ${_}     ${WIF} =    Prepare Wallet And Deposit
-    ${CID} =                Create Container    ${WIF}    ${ACL}   ${PLACEMENT_RULE}
+    ${WALLET}   ${_}     ${_} =    Prepare Wallet And Deposit
+    ${CID} =                Create Container    ${WALLET}    ${ACL}   ${PLACEMENT_RULE}
                             Wait Until Keyword Succeeds    ${MORPH_BLOCK_TIME}    ${CONTAINER_WAIT_INTERVAL}
-                            ...     Container Existing    ${WIF}    ${CID}
+                            ...     Container Existing    ${WALLET}    ${CID}
 
     ${FILE} =               Generate file of bytes    ${SIMPLE_OBJ_SIZE}
     ${FILE_HASH} =          Get file hash    ${FILE}
 
-    ${S_OID} =              Put Object    ${WIF}    ${FILE}    ${CID}
-                            Validate storage policy for object    ${WIF}    ${EXPECTED_COPIES}    ${CID}    ${S_OID}
+    ${S_OID} =              Put Object    ${WALLET}    ${FILE}    ${CID}
+                            Validate storage policy for object    ${WALLET}    ${EXPECTED_COPIES}    ${CID}    ${S_OID}
 
-    @{NODES_OBJ} =          Get nodes with Object    ${WIF}    ${CID}    ${S_OID}
+    @{NODES_OBJ} =          Get nodes with Object    ${WALLET}    ${CID}    ${S_OID}
     ${NODES_LOG_TIME} =     Get Nodes Log Latest Timestamp
 
     @{NODES_OBJ_STOPPED} =  Stop nodes          1              @{NODES_OBJ}
@@ -59,7 +59,7 @@ Check Replication
     # We expect that during two epochs the missed copy will be replicated.
     FOR    ${i}    IN RANGE   2
         ${PASSED} =     Run Keyword And Return Status
-                        ...     Validate storage policy for object    ${WIF}    ${EXPECTED_COPIES}
+                        ...     Validate storage policy for object    ${WALLET}    ${EXPECTED_COPIES}
                         ...     ${CID}    ${S_OID}    ${EMPTY}    ${NETMAP}
         Exit For Loop If    ${PASSED}
         Tick Epoch
@@ -74,7 +74,7 @@ Check Replication
     # We have 2 or 3 copies. Expected behaviour: during two epochs potential 3rd copy should be removed.
     FOR    ${i}    IN RANGE   2
         ${PASSED} =     Run Keyword And Return Status
-                        ...     Validate storage policy for object    ${WIF}    ${EXPECTED_COPIES}    ${CID}    ${S_OID}
+                        ...     Validate storage policy for object    ${WALLET}    ${EXPECTED_COPIES}    ${CID}    ${S_OID}
         Exit For Loop If    ${PASSED}
         Tick Epoch
         Sleep               ${CHECK_INTERVAL}

--- a/robot/testsuites/integration/object/object_attributes.robot
+++ b/robot/testsuites/integration/object/object_attributes.robot
@@ -27,10 +27,9 @@ Duplicated Object Attributes
 
     [Setup]                     Setup
 
-    ${WALLET}   ${ADDR}     ${USER_KEY} =   Init Wallet with Address    ${ASSETS_DIR}
-    Payment Operations      ${ADDR}         ${USER_KEY}
+    ${WALLET}   ${_}     ${_} =    Prepare Wallet And Deposit
 
-    ${PUBLIC_CID} =             Create container       ${USER_KEY}    ${PUBLIC_ACL_F}    ${POLICY}    ${EMPTY}
+    ${PUBLIC_CID} =             Create container       ${WALLET}    ${PUBLIC_ACL_F}    ${POLICY}    ${EMPTY}
     ${FILE_S} =                 Generate file of bytes            ${SIMPLE_OBJ_SIZE}
 
 
@@ -39,24 +38,24 @@ Duplicated Object Attributes
     ###################################################
 
     Run Keyword And Expect Error    *
-    ...    Put object        ${USER_KEY}         ${FILE_S}    ${PUBLIC_CID}    user_headers=${ATTR_FILENAME}
+    ...    Put object        ${WALLET}         ${FILE_S}    ${PUBLIC_CID}    user_headers=${ATTR_FILENAME}
     # Robot doesn't allow to create a dictionary with the same keys, so using plain text option here
     Run Keyword And Expect Error    *
-    ...    Put object        ${USER_KEY}         ${FILE_S}    ${PUBLIC_CID}    options=--attributes ${ATTR_DUPLICATE}
+    ...    Put object        ${WALLET}         ${FILE_S}    ${PUBLIC_CID}    options=--attributes ${ATTR_DUPLICATE}
 
     ##################################################
     # Checking that object cannot have empty attibute
     ##################################################
 
     Run Keyword And Expect Error    *
-    ...    Put object        ${USER_KEY}         ${FILE_S}    ${PUBLIC_CID}    user_headers=${ATTR_NONE}
+    ...    Put object        ${WALLET}         ${FILE_S}    ${PUBLIC_CID}    user_headers=${ATTR_NONE}
 
     #####################################################
     # Checking a successful step with a single attribute
     #####################################################
 
-    ${OID} =            Put object    ${USER_KEY}         ${FILE_S}    ${PUBLIC_CID}    user_headers=${ATTR_SINGLE}
-    ${HEADER} =         Head object              ${USER_KEY}         ${PUBLIC_CID}    ${OID}
+    ${OID} =            Put object    ${WALLET}         ${FILE_S}    ${PUBLIC_CID}    user_headers=${ATTR_SINGLE}
+    ${HEADER} =         Head object              ${WALLET}         ${PUBLIC_CID}    ${OID}
                         Dictionary Should Contain Sub Dictionary
                             ...     ${HEADER}[header][attributes]
                             ...     ${ATTR_SINGLE}

--- a/robot/testsuites/integration/object/object_complex.robot
+++ b/robot/testsuites/integration/object/object_complex.robot
@@ -28,29 +28,29 @@ NeoFS Complex Object Operations
     [Setup]             Setup
 
     ${WALLET}   ${ADDR}     ${WIF} =   Prepare Wallet And Deposit
-    ${CID} =            Prepare container       ${WIF}
+    ${CID} =            Prepare container       ${WIF}    ${WALLET}
 
     ${FILE} =           Generate file of bytes              ${COMPLEX_OBJ_SIZE}
     ${FILE_HASH} =      Get file hash                       ${FILE}
 
-    ${S_OID} =          Put object                 ${WIF}    ${FILE}       ${CID}
-    ${H_OID} =          Put object                 ${WIF}    ${FILE}       ${CID}        user_headers=${FILE_USR_HEADER}
-    ${H_OID_OTH} =      Put object                 ${WIF}    ${FILE}       ${CID}        user_headers=${FILE_USR_HEADER_OTH}
+    ${S_OID} =          Put object                 ${WALLET}    ${FILE}       ${CID}
+    ${H_OID} =          Put object                 ${WALLET}    ${FILE}       ${CID}        user_headers=${FILE_USR_HEADER}
+    ${H_OID_OTH} =      Put object                 ${WALLET}    ${FILE}       ${CID}        user_headers=${FILE_USR_HEADER_OTH}
 
     Should Be True     '${S_OID}'!='${H_OID}' and '${H_OID}'!='${H_OID_OTH}'
 
-                        Validate storage policy for object  ${WIF}    2             ${CID}         ${S_OID}
-                        Validate storage policy for object  ${WIF}    2             ${CID}         ${H_OID}
-                        Validate storage policy for object  ${WIF}    2             ${CID}         ${H_OID_OTH}
+                        Validate storage policy for object  ${WALLET}    2             ${CID}         ${S_OID}
+                        Validate storage policy for object  ${WALLET}    2             ${CID}         ${H_OID}
+                        Validate storage policy for object  ${WALLET}    2             ${CID}         ${H_OID_OTH}
 
     @{S_OBJ_ALL} =      Create List    ${S_OID}       ${H_OID}     ${H_OID_OTH}
     @{S_OBJ_H} =        Create List    ${H_OID}
     @{S_OBJ_H_OTH} =    Create List    ${H_OID_OTH}
 
-                        Search Object    ${WIF}    ${CID}        --root       expected_objects_list=${S_OBJ_ALL}
+                        Search Object    ${WALLET}    ${CID}        --root       expected_objects_list=${S_OBJ_ALL}
 
-    ${GET_OBJ_S} =      Get object               ${WIF}    ${CID}        ${S_OID}
-    ${GET_OBJ_H} =      Get object               ${WIF}    ${CID}        ${H_OID}
+    ${GET_OBJ_S} =      Get object               ${WALLET}    ${CID}        ${S_OID}
+    ${GET_OBJ_H} =      Get object               ${WALLET}    ${CID}        ${H_OID}
 
     ${FILE_HASH_S} =    Get file hash            ${GET_OBJ_S}
     ${FILE_HASH_H} =    Get file hash            ${GET_OBJ_H}
@@ -58,49 +58,49 @@ NeoFS Complex Object Operations
                         Should Be Equal          ${FILE_HASH_S}   ${FILE_HASH}
                         Should Be Equal          ${FILE_HASH_H}   ${FILE_HASH}
 
-                        Get Range Hash           ${WIF}    ${CID}        ${S_OID}          ${EMPTY}       0:10
-                        Get Range Hash           ${WIF}    ${CID}        ${H_OID}          ${EMPTY}       0:10
+                        Get Range Hash           ${WALLET}    ${CID}        ${S_OID}          ${EMPTY}       0:10
+                        Get Range Hash           ${WALLET}    ${CID}        ${H_OID}          ${EMPTY}       0:10
 
-                        Get Range                ${WIF}    ${CID}        ${S_OID}          s_get_range    ${EMPTY}       0:10
-                        Get Range                ${WIF}    ${CID}        ${H_OID}          h_get_range    ${EMPTY}       0:10
+                        Get Range                ${WALLET}    ${CID}        ${S_OID}          s_get_range    ${EMPTY}       0:10
+                        Get Range                ${WALLET}    ${CID}        ${H_OID}          h_get_range    ${EMPTY}       0:10
 
-                        Search object            ${WIF}    ${CID}        --root        expected_objects_list=${S_OBJ_ALL}
-                        Search object            ${WIF}    ${CID}        --root        filters=${FILE_USR_HEADER}      expected_objects_list=${S_OBJ_H}
-                        Search object            ${WIF}    ${CID}        --root        filters=${FILE_USR_HEADER_OTH}  expected_objects_list=${S_OBJ_H_OTH}
+                        Search object            ${WALLET}    ${CID}        --root        expected_objects_list=${S_OBJ_ALL}
+                        Search object            ${WALLET}    ${CID}        --root        filters=${FILE_USR_HEADER}      expected_objects_list=${S_OBJ_H}
+                        Search object            ${WALLET}    ${CID}        --root        filters=${FILE_USR_HEADER_OTH}  expected_objects_list=${S_OBJ_H_OTH}
 
-    &{S_RESPONSE} =     Head object              ${WIF}    ${CID}        ${S_OID}
-    &{H_RESPONSE} =     Head object              ${WIF}    ${CID}        ${H_OID}
+    &{S_RESPONSE} =     Head object              ${WALLET}    ${CID}        ${S_OID}
+    &{H_RESPONSE} =     Head object              ${WALLET}    ${CID}        ${H_OID}
                         Dictionary Should Contain Sub Dictionary
                             ...     ${H_RESPONSE}[header][attributes]
                             ...     ${FILE_USR_HEADER}
                             ...     msg="There are no User Headers in HEAD response"
 
     ${PAYLOAD_LENGTH}    ${SPLIT_ID}     ${SPLIT_OBJECTS} =      Restore Large Object By Last
-                                                ...     ${WIF}    ${CID}        ${S_OID}
+                                                ...     ${WALLET}    ${CID}        ${S_OID}
     ${H_PAYLOAD_LENGTH}    ${H_SPLIT_ID}       ${H_SPLIT_OBJECTS} =  Restore Large Object By Last
-                                                ...     ${WIF}    ${CID}        ${H_OID}
+                                                ...     ${WALLET}    ${CID}        ${H_OID}
 
-                        Compare With Link Object    ${WIF}  ${CID}  ${S_OID}    ${SPLIT_ID}     ${SPLIT_OBJECTS}
-                        Compare With Link Object    ${WIF}  ${CID}  ${H_OID}    ${H_SPLIT_ID}     ${H_SPLIT_OBJECTS}
+                        Compare With Link Object    ${WALLET}  ${CID}  ${S_OID}    ${SPLIT_ID}     ${SPLIT_OBJECTS}
+                        Compare With Link Object    ${WALLET}  ${CID}  ${H_OID}    ${H_SPLIT_ID}     ${H_SPLIT_OBJECTS}
 
                         Should Be Equal As Numbers     ${S_RESPONSE.header.payloadLength}  ${PAYLOAD_LENGTH}
                         Should Be Equal As Numbers     ${H_RESPONSE.header.payloadLength}  ${H_PAYLOAD_LENGTH}
 
-    ${TOMBSTONE_S} =    Delete object            ${WIF}    ${CID}        ${S_OID}
-    ${TOMBSTONE_H} =    Delete object            ${WIF}    ${CID}        ${H_OID}
+    ${TOMBSTONE_S} =    Delete object            ${WALLET}    ${CID}        ${S_OID}
+    ${TOMBSTONE_H} =    Delete object            ${WALLET}    ${CID}        ${H_OID}
 
-                        Verify Head tombstone    ${WIF}    ${CID}        ${TOMBSTONE_S}     ${S_OID}    ${ADDR}
-                        Verify Head tombstone    ${WIF}    ${CID}        ${TOMBSTONE_H}     ${H_OID}    ${ADDR}
+                        Verify Head tombstone    ${WALLET}    ${CID}        ${TOMBSTONE_S}     ${S_OID}    ${ADDR}
+                        Verify Head tombstone    ${WALLET}    ${CID}        ${TOMBSTONE_H}     ${H_OID}    ${ADDR}
 
                         Tick Epoch
                         # we assume that during this time objects must be deleted
                         Sleep   ${CLEANUP_TIMEOUT}
 
      ${ERR_MSG} =       Run Keyword And Expect Error        *
-                        ...  Get object          ${WIF}    ${CID}        ${S_OID}
+                        ...  Get object          ${WALLET}    ${CID}        ${S_OID}
                         Should Contain      ${ERR_MSG}      ${ALREADY_REMOVED_ERROR}
      ${ERR_MSG} =       Run Keyword And Expect Error        *
-                        ...  Get object          ${WIF}    ${CID}        ${H_OID}
+                        ...  Get object          ${WALLET}    ${CID}        ${H_OID}
                         Should Contain      ${ERR_MSG}      ${ALREADY_REMOVED_ERROR}
 
     [Teardown]          Teardown    object_complex
@@ -117,10 +117,10 @@ Restore Large Object By Last
              ...        The keyword returns total payload length, SplitID and list of Part Objects for
              ...        these data might be verified by other keywords.
 
-    [Arguments]     ${WIF}  ${CID}  ${LARGE_OID}
+    [Arguments]     ${WALLET}  ${CID}  ${LARGE_OID}
 
-    ${LAST_OID} =           Get Last Object     ${WIF}  ${CID}  ${LARGE_OID}
-    &{LAST_OBJ_HEADER} =    Head Object         ${WIF}  ${CID}  ${LAST_OID}   is_raw=True
+    ${LAST_OID} =           Get Last Object     ${WALLET}  ${CID}  ${LARGE_OID}
+    &{LAST_OBJ_HEADER} =    Head Object         ${WALLET}  ${CID}  ${LAST_OID}   is_raw=True
                             Should Be Equal     ${LARGE_OID}    ${LAST_OBJ_HEADER.header.split.parent}
 
     ${SPLIT_ID} =           Set Variable    ${LAST_OBJ_HEADER.header.split.splitID}
@@ -129,7 +129,7 @@ Restore Large Object By Last
     @{PART_OBJECTS} =       Create List
 
     FOR     ${i}    IN RANGE    1000
-        &{SPLIT_HEADER} =       Head object     ${WIF}  ${CID}  ${PART_OID}  is_raw=True
+        &{SPLIT_HEADER} =       Head object     ${WALLET}  ${CID}  ${PART_OID}  is_raw=True
 
         ${PAYLOAD_LENGTH} =     Evaluate    ${PAYLOAD_LENGTH} + ${SPLIT_HEADER.header.payloadLength}
 
@@ -160,10 +160,10 @@ Compare With Link Object
                 ...     Object and the Split Chain from Link Object are equal and the
                 ...     system is able to restore the Large Object using any of these ways.
 
-    [Arguments]         ${WIF}  ${CID}  ${LARGE_OID}    ${SPLIT_ID}      ${SPLIT_OBJECTS}
+    [Arguments]         ${WALLET}  ${CID}  ${LARGE_OID}    ${SPLIT_ID}      ${SPLIT_OBJECTS}
 
-    ${LINK_OID} =       Get Link Object     ${WIF}  ${CID}  ${LARGE_OID}
-    &{LINK_HEADER} =    Head Object         ${WIF}  ${CID}  ${LINK_OID}    is_raw=True
+    ${LINK_OID} =       Get Link Object     ${WALLET}  ${CID}  ${LARGE_OID}
+    &{LINK_HEADER} =    Head Object         ${WALLET}  ${CID}  ${LINK_OID}    is_raw=True
 
                         Reverse List    ${SPLIT_OBJECTS}
                         Lists Should Be Equal

--- a/robot/testsuites/integration/object/object_expiration.robot
+++ b/robot/testsuites/integration/object/object_expiration.robot
@@ -21,9 +21,8 @@ NeoFS Simple Object Operations
 
     [Setup]             Setup
 
-    ${WALLET}   ${ADDR}     ${WIF} =   Init Wallet with Address    ${ASSETS_DIR}
-    Payment Operations      ${ADDR}     ${WIF}
-    ${CID} =    Prepare container       ${WIF}
+    ${WALLET}   ${_}     ${WIF} =   Prepare Wallet And Deposit
+    ${CID} =    Prepare container      ${WIF}    ${WALLET}
 
     ${FILE} =           Generate file of bytes    ${SIMPLE_OBJ_SIZE}
     ${FILE_HASH} =      Get file hash    ${FILE}
@@ -36,37 +35,37 @@ NeoFS Simple Object Operations
 
                         # Failed on attempt to create epoch from the past
                         Run Keyword And Expect Error        *
-                        ...  Put object    ${WIF}    ${FILE}    ${CID}    options= --attributes __NEOFS__EXPIRATION_EPOCH=${EPOCH_PRE}
+                        ...  Put object    ${WALLET}    ${FILE}    ${CID}    options= --attributes __NEOFS__EXPIRATION_EPOCH=${EPOCH_PRE}
 
                         # Put object with different expiration epoch numbers (current, next, and from the distant future)
-    ${OID_CUR} =        Put object    ${WIF}    ${FILE}    ${CID}    options= --attributes __NEOFS__EXPIRATION_EPOCH=${EPOCH}
-    ${OID_NXT} =        Put object    ${WIF}    ${FILE}    ${CID}    options= --attributes __NEOFS__EXPIRATION_EPOCH=${EPOCH_NEXT}
-    ${OID_PST} =        Put object    ${WIF}    ${FILE}    ${CID}    options= --attributes __NEOFS__EXPIRATION_EPOCH=${EPOCH_POST}
+    ${OID_CUR} =        Put object    ${WALLET}    ${FILE}    ${CID}    options= --attributes __NEOFS__EXPIRATION_EPOCH=${EPOCH}
+    ${OID_NXT} =        Put object    ${WALLET}    ${FILE}    ${CID}    options= --attributes __NEOFS__EXPIRATION_EPOCH=${EPOCH_NEXT}
+    ${OID_PST} =        Put object    ${WALLET}    ${FILE}    ${CID}    options= --attributes __NEOFS__EXPIRATION_EPOCH=${EPOCH_POST}
 
                         # Check objects for existence
-                        Get object    ${WIF}    ${CID}    ${OID_CUR}    ${EMPTY}    file_read_cur
-                        Get object    ${WIF}    ${CID}    ${OID_NXT}    ${EMPTY}    file_read_nxt
-                        Get object    ${WIF}    ${CID}    ${OID_PST}    ${EMPTY}    file_read_pst
+                        Get object    ${WALLET}    ${CID}    ${OID_CUR}    ${EMPTY}    file_read_cur
+                        Get object    ${WALLET}    ${CID}    ${OID_NXT}    ${EMPTY}    file_read_nxt
+                        Get object    ${WALLET}    ${CID}    ${OID_PST}    ${EMPTY}    file_read_pst
 
                         # Increment epoch to check that expired objects (OID_CUR) will be removed
                         Tick Epoch
                         # we assume that during this time objects must be deleted
                         Sleep   ${CLEANUP_TIMEOUT}
                         Run Keyword And Expect Error        *
-                        ...  Get object    ${WIF}    ${CID}    ${OID_CUR}    ${EMPTY}    file_read
+                        ...  Get object    ${WALLET}    ${CID}    ${OID_CUR}    ${EMPTY}    file_read
 
                         # Check that correct object with expiration in the future is existed
-                        Get object    ${WIF}    ${CID}    ${OID_NXT}    ${EMPTY}    file_read
-                        Get object    ${WIF}    ${CID}    ${OID_PST}    ${EMPTY}    file_read_pst
+                        Get object    ${WALLET}    ${CID}    ${OID_NXT}    ${EMPTY}    file_read
+                        Get object    ${WALLET}    ${CID}    ${OID_PST}    ${EMPTY}    file_read_pst
 
                         # Increment one more epoch to check that expired object (OID_NXT) will be removed
                         Tick Epoch
                         # we assume that during this time objects must be deleted
                         Sleep   ${CLEANUP_TIMEOUT}
                         Run Keyword And Expect Error        *
-                        ...  Get object    ${WIF}    ${CID}    ${OID_NXT}    ${EMPTY}    file_read
+                        ...  Get object    ${WALLET}    ${CID}    ${OID_NXT}    ${EMPTY}    file_read
 
                         # Check that correct object with expiration in the distant future is existed
-                        Get object    ${WIF}    ${CID}    ${OID_PST}    ${EMPTY}    file_read_pst
+                        Get object    ${WALLET}    ${CID}    ${OID_PST}    ${EMPTY}    file_read_pst
 
     [Teardown]          Teardown    object_expiration

--- a/robot/testsuites/integration/object/object_simple.robot
+++ b/robot/testsuites/integration/object/object_simple.robot
@@ -25,28 +25,27 @@ NeoFS Simple Object Operations
 
     [Setup]             Setup
 
-    ${WALLET}   ${ADDR}     ${WIF} =   Init Wallet with Address    ${ASSETS_DIR}
-                Payment Operations      ${ADDR}     ${WIF}
-    ${CID} =    Prepare container       ${WIF}
+    ${WALLET}   ${ADDR}     ${WIF} =   Prepare Wallet And Deposit
+    ${CID} =    Prepare container      ${WIF}    ${WALLET}
 
     ${FILE} =           Generate file of bytes              ${SIMPLE_OBJ_SIZE}
     ${FILE_HASH} =      Get file hash                       ${FILE}
 
 
-    ${S_OID} =          Put object          ${WIF}    ${FILE}       ${CID}
-    ${H_OID} =          Put object          ${WIF}    ${FILE}       ${CID}      user_headers=${FILE_USR_HEADER}
-    ${H_OID_OTH} =      Put object          ${WIF}    ${FILE}       ${CID}      user_headers=${FILE_USR_HEADER_OTH}
+    ${S_OID} =          Put object          ${WALLET}    ${FILE}       ${CID}
+    ${H_OID} =          Put object          ${WALLET}    ${FILE}       ${CID}      user_headers=${FILE_USR_HEADER}
+    ${H_OID_OTH} =      Put object          ${WALLET}    ${FILE}       ${CID}      user_headers=${FILE_USR_HEADER_OTH}
 
-                        Validate storage policy for object  ${WIF}    2         ${CID}            ${S_OID}
-                        Validate storage policy for object  ${WIF}    2         ${CID}            ${H_OID}
-                        Validate storage policy for object  ${WIF}    2         ${CID}            ${H_OID_OTH}
+                        Validate storage policy for object  ${WALLET}    2         ${CID}            ${S_OID}
+                        Validate storage policy for object  ${WALLET}    2         ${CID}            ${H_OID}
+                        Validate storage policy for object  ${WALLET}    2         ${CID}            ${H_OID_OTH}
 
     @{S_OBJ_ALL} =	Create List         ${S_OID}       ${H_OID}      ${H_OID_OTH}
     @{S_OBJ_H} =	Create List         ${H_OID}
     @{S_OBJ_H_OTH} =    Create List         ${H_OID_OTH}
 
-    ${GET_OBJ_S} =      Get object          ${WIF}    ${CID}        ${S_OID}
-    ${GET_OBJ_H} =      Get object          ${WIF}    ${CID}        ${H_OID}
+    ${GET_OBJ_S} =      Get object          ${WALLET}    ${CID}        ${S_OID}
+    ${GET_OBJ_H} =      Get object          ${WALLET}    ${CID}        ${H_OID}
 
     ${FILE_HASH_S} =    Get file hash            ${GET_OBJ_S}
     ${FILE_HASH_H} =    Get file hash            ${GET_OBJ_H}
@@ -54,37 +53,37 @@ NeoFS Simple Object Operations
                         Should Be Equal        ${FILE_HASH_S}   ${FILE_HASH}
                         Should Be Equal        ${FILE_HASH_H}   ${FILE_HASH}
 
-                        Get Range Hash          ${WIF}    ${CID}        ${S_OID}            ${EMPTY}       0:10
-                        Get Range Hash          ${WIF}    ${CID}        ${H_OID}            ${EMPTY}       0:10
+                        Get Range Hash          ${WALLET}    ${CID}        ${S_OID}            ${EMPTY}       0:10
+                        Get Range Hash          ${WALLET}    ${CID}        ${H_OID}            ${EMPTY}       0:10
 
-                        Get Range               ${WIF}    ${CID}        ${S_OID}            s_get_range    ${EMPTY}       0:10
-                        Get Range               ${WIF}    ${CID}        ${H_OID}            h_get_range    ${EMPTY}       0:10
+                        Get Range               ${WALLET}    ${CID}        ${S_OID}            s_get_range    ${EMPTY}       0:10
+                        Get Range               ${WALLET}    ${CID}        ${H_OID}            h_get_range    ${EMPTY}       0:10
 
-                        Search object           ${WIF}    ${CID}        expected_objects_list=${S_OBJ_ALL}
-                        Search object           ${WIF}    ${CID}        filters=${FILE_USR_HEADER}        expected_objects_list=${S_OBJ_H}
-                        Search object           ${WIF}    ${CID}        filters=${FILE_USR_HEADER_OTH}    expected_objects_list=${S_OBJ_H_OTH}
+                        Search object           ${WALLET}    ${CID}        expected_objects_list=${S_OBJ_ALL}
+                        Search object           ${WALLET}    ${CID}        filters=${FILE_USR_HEADER}        expected_objects_list=${S_OBJ_H}
+                        Search object           ${WALLET}    ${CID}        filters=${FILE_USR_HEADER_OTH}    expected_objects_list=${S_OBJ_H_OTH}
 
-                        Head object             ${WIF}    ${CID}        ${S_OID}
-    &{RESPONSE} =       Head object             ${WIF}    ${CID}        ${H_OID}
+                        Head object             ${WALLET}    ${CID}        ${S_OID}
+    &{RESPONSE} =       Head object             ${WALLET}    ${CID}        ${H_OID}
                         Dictionary Should Contain Sub Dictionary
                             ...     ${RESPONSE}[header][attributes]
                             ...     ${FILE_USR_HEADER}
                             ...     msg="There are no User Headers in HEAD response"
 
-    ${TOMBSTONE_S} =    Delete object                       ${WIF}    ${CID}        ${S_OID}
-    ${TOMBSTONE_H} =    Delete object                       ${WIF}    ${CID}        ${H_OID}
+    ${TOMBSTONE_S} =    Delete object                       ${WALLET}    ${CID}        ${S_OID}
+    ${TOMBSTONE_H} =    Delete object                       ${WALLET}    ${CID}        ${H_OID}
 
-                        Verify Head tombstone               ${WIF}    ${CID}        ${TOMBSTONE_S}     ${S_OID}    ${ADDR}
-                        Verify Head tombstone               ${WIF}    ${CID}        ${TOMBSTONE_H}     ${H_OID}    ${ADDR}
+                        Verify Head tombstone               ${WALLET}    ${CID}        ${TOMBSTONE_S}     ${S_OID}    ${ADDR}
+                        Verify Head tombstone               ${WALLET}    ${CID}        ${TOMBSTONE_H}     ${H_OID}    ${ADDR}
 
                         Tick Epoch
                         # we assume that during this time objects must be deleted
                         Sleep   ${CLEANUP_TIMEOUT}
 
                         Run Keyword And Expect Error        *
-                        ...  Get object          ${WIF}    ${CID}        ${S_OID}           ${EMPTY}       ${GET_OBJ_S}
+                        ...  Get object          ${WALLET}    ${CID}        ${S_OID}           ${EMPTY}       ${GET_OBJ_S}
 
                         Run Keyword And Expect Error        *
-                        ...  Get object          ${WIF}    ${CID}        ${H_OID}           ${EMPTY}       ${GET_OBJ_H}
+                        ...  Get object          ${WALLET}    ${CID}        ${H_OID}           ${EMPTY}       ${GET_OBJ_H}
 
     [Teardown]          Teardown    object_simple

--- a/robot/testsuites/integration/object/object_storagegroup_complex.robot
+++ b/robot/testsuites/integration/object/object_storagegroup_complex.robot
@@ -23,48 +23,47 @@ NeoFS Complex Storagegroup
 
     [Setup]             Setup
 
-    ${WALLET}   ${ADDR}     ${WIF} =   Init Wallet with Address    ${ASSETS_DIR}
-    Payment Operations      ${ADDR}     ${WIF}
-    ${CID} =    Prepare container       ${WIF}
+    ${WALLET}   ${ADDR}     ${WIF} =   Prepare Wallet And Deposit
+    ${CID} =    Prepare container    ${WIF}    ${WALLET}
 
     ${FILE_S} =         Generate file of bytes            ${COMPLEX_OBJ_SIZE}
     ${FILE_HASH_S} =    Get file hash                     ${FILE_S}
 
     # Put two Simple Object
-    ${S_OID_1} =        Put object    ${WIF}    ${FILE_S}    ${CID}
-    ${S_OID_2} =        Put object    ${WIF}    ${FILE_S}    ${CID}    user_headers=&{USER_HEADER}
+    ${S_OID_1} =        Put object    ${WALLET}    ${FILE_S}    ${CID}
+    ${S_OID_2} =        Put object    ${WALLET}    ${FILE_S}    ${CID}    user_headers=&{USER_HEADER}
 
     @{S_OBJ_ALL} =	Create List    ${S_OID_1}    ${S_OID_2}
 
                         Log    Storage group with 1 object
-    ${SG_OID_1} =       Put Storagegroup    ${WIF}    ${CID}   ${EMPTY}    ${S_OID_1}
-                        List Storagegroup    ${WIF}    ${CID}   ${EMPTY}    ${SG_OID_1}
-    @{SPLIT_OBJ_1} =    Get Object Parts By Link Object    ${WIF}    ${CID}   ${S_OID_1}
-                        Get Storagegroup    ${WIF}    ${CID}    ${SG_OID_1}   ${EMPTY}    ${COMPLEX_OBJ_SIZE}    @{SPLIT_OBJ_1}
-    ${Tombstone} =      Delete Storagegroup    ${WIF}    ${CID}    ${SG_OID_1}    ${EMPTY}
-                        Verify Head tombstone    ${WIF}    ${CID}    ${Tombstone}    ${SG_OID_1}    ${ADDR}
+    ${SG_OID_1} =       Put Storagegroup    ${WALLET}    ${CID}   ${EMPTY}    ${S_OID_1}
+                        List Storagegroup    ${WALLET}    ${CID}   ${EMPTY}    ${SG_OID_1}
+    @{SPLIT_OBJ_1} =    Get Object Parts By Link Object    ${WALLET}    ${CID}   ${S_OID_1}
+                        Get Storagegroup    ${WALLET}    ${CID}    ${SG_OID_1}   ${EMPTY}    ${COMPLEX_OBJ_SIZE}    @{SPLIT_OBJ_1}
+    ${Tombstone} =      Delete Storagegroup    ${WALLET}    ${CID}    ${SG_OID_1}    ${EMPTY}
+                        Verify Head tombstone    ${WALLET}    ${CID}    ${Tombstone}    ${SG_OID_1}    ${ADDR}
                         Run Keyword And Expect Error    *
-                        ...  Get Storagegroup    ${WIF}    ${CID}    ${SG_OID_1}   ${EMPTY}    ${COMPLEX_OBJ_SIZE}    @{SPLIT_OBJ_1}
-                        List Storagegroup    ${WIF}    ${CID}   ${EMPTY}    @{EMPTY}
+                        ...  Get Storagegroup    ${WALLET}    ${CID}    ${SG_OID_1}   ${EMPTY}    ${COMPLEX_OBJ_SIZE}    @{SPLIT_OBJ_1}
+                        List Storagegroup    ${WALLET}    ${CID}   ${EMPTY}    @{EMPTY}
 
                         Log    Storage group with 2 objects
-    ${SG_OID_2} =       Put Storagegroup    ${WIF}    ${CID}    ${EMPTY}    @{S_OBJ_ALL}
-                        List Storagegroup    ${WIF}    ${CID}   ${EMPTY}    ${SG_OID_2}
-    @{SPLIT_OBJ_2} =    Get Object Parts By Link Object    ${WIF}    ${CID}   ${S_OID_2}
+    ${SG_OID_2} =       Put Storagegroup    ${WALLET}    ${CID}    ${EMPTY}    @{S_OBJ_ALL}
+                        List Storagegroup    ${WALLET}    ${CID}   ${EMPTY}    ${SG_OID_2}
+    @{SPLIT_OBJ_2} =    Get Object Parts By Link Object    ${WALLET}    ${CID}   ${S_OID_2}
     @{SPLIT_OBJ_ALL} =  Combine Lists    ${SPLIT_OBJ_1}    ${SPLIT_OBJ_2}
     ${EXPECTED_SIZE} =  Evaluate    2*${COMPLEX_OBJ_SIZE}
-                        Get Storagegroup    ${WIF}    ${CID}    ${SG_OID_2}   ${EMPTY}    ${EXPECTED_SIZE}    @{SPLIT_OBJ_ALL}
-    ${Tombstone} =      Delete Storagegroup    ${WIF}    ${CID}    ${SG_OID_2}    ${EMPTY}
-                        Verify Head tombstone    ${WIF}    ${CID}    ${Tombstone}    ${SG_OID_2}    ${ADDR}
+                        Get Storagegroup    ${WALLET}    ${CID}    ${SG_OID_2}   ${EMPTY}    ${EXPECTED_SIZE}    @{SPLIT_OBJ_ALL}
+    ${Tombstone} =      Delete Storagegroup    ${WALLET}    ${CID}    ${SG_OID_2}    ${EMPTY}
+                        Verify Head tombstone    ${WALLET}    ${CID}    ${Tombstone}    ${SG_OID_2}    ${ADDR}
                         Run Keyword And Expect Error    *
-                        ...  Get Storagegroup    ${WIF}    ${CID}    ${SG_OID_2}   ${EMPTY}    ${EXPECTED_SIZE}    @{SPLIT_OBJ_ALL}
-                        List Storagegroup    ${WIF}    ${CID}   ${EMPTY}    @{EMPTY}
+                        ...  Get Storagegroup    ${WALLET}    ${CID}    ${SG_OID_2}   ${EMPTY}    ${EXPECTED_SIZE}    @{SPLIT_OBJ_ALL}
+                        List Storagegroup    ${WALLET}    ${CID}   ${EMPTY}    @{EMPTY}
 
                         Log    Incorrect input
 
                         Run Keyword And Expect Error    *
-                        ...  Put Storagegroup    ${WIF}    ${CID}    ${EMPTY}    ${UNEXIST_OID}
+                        ...  Put Storagegroup    ${WALLET}    ${CID}    ${EMPTY}    ${UNEXIST_OID}
                         Run Keyword And Expect Error    *
-                        ...  Delete Storagegroup    ${WIF}    ${CID}    ${UNEXIST_OID}    ${EMPTY}
+                        ...  Delete Storagegroup    ${WALLET}    ${CID}    ${UNEXIST_OID}    ${EMPTY}
 
     [Teardown]          Teardown    object_storage_group_complex

--- a/robot/testsuites/integration/object/object_storagegroup_simple.robot
+++ b/robot/testsuites/integration/object/object_storagegroup_simple.robot
@@ -21,47 +21,46 @@ NeoFS Simple Storagegroup
 
     [Setup]             Setup
 
-    ${WALLET}   ${ADDR}     ${WIF} =   Init Wallet with Address    ${ASSETS_DIR}
-    Payment Operations      ${ADDR}     ${WIF}
-    ${CID} =    Prepare container       ${WIF}
+    ${WALLET}   ${ADDR}     ${WIF} =   Prepare Wallet And Deposit
+    ${CID} =    Prepare container      ${WIF}    ${WALLET}
 
     ${FILE_S} =         Generate file of bytes            ${SIMPLE_OBJ_SIZE}
     ${FILE_HASH_S} =    Get file hash                     ${FILE_S}
 
 
     # Put two Simple Object
-    ${S_OID_1} =        Put object    ${WIF}    ${FILE_S}    ${CID}
-    ${S_OID_2} =        Put object    ${WIF}    ${FILE_S}    ${CID}    user_headers=&{USER_HEADER}
+    ${S_OID_1} =        Put object    ${WALLET}    ${FILE_S}    ${CID}
+    ${S_OID_2} =        Put object    ${WALLET}    ${FILE_S}    ${CID}    user_headers=&{USER_HEADER}
 
     @{S_OBJ_ALL} =	    Create List    ${S_OID_1}    ${S_OID_2}
 
                         Log    Storage group with 1 object
-    ${SG_OID_1} =       Put Storagegroup    ${WIF}    ${CID}   ${EMPTY}    ${S_OID_1}
-                        List Storagegroup    ${WIF}    ${CID}   ${EMPTY}    ${SG_OID_1}
-                        Get Storagegroup    ${WIF}    ${CID}    ${SG_OID_1}   ${EMPTY}    ${SIMPLE_OBJ_SIZE}    ${S_OID_1}
-    ${Tombstone} =      Delete Storagegroup    ${WIF}    ${CID}    ${SG_OID_1}    ${EMPTY}
-                        Verify Head tombstone    ${WIF}    ${CID}    ${Tombstone}    ${SG_OID_1}    ${ADDR}
+    ${SG_OID_1} =       Put Storagegroup    ${WALLET}    ${CID}   ${EMPTY}    ${S_OID_1}
+                        List Storagegroup    ${WALLET}    ${CID}   ${EMPTY}    ${SG_OID_1}
+                        Get Storagegroup    ${WALLET}    ${CID}    ${SG_OID_1}   ${EMPTY}    ${SIMPLE_OBJ_SIZE}    ${S_OID_1}
+    ${Tombstone} =      Delete Storagegroup    ${WALLET}    ${CID}    ${SG_OID_1}    ${EMPTY}
+                        Verify Head tombstone    ${WALLET}    ${CID}    ${Tombstone}    ${SG_OID_1}    ${ADDR}
                         Run Keyword And Expect Error    *
-                        ...  Get Storagegroup    ${WIF}    ${CID}    ${SG_OID_1}   ${EMPTY}    ${SIMPLE_OBJ_SIZE}    ${S_OID_1}
-                        List Storagegroup    ${WIF}    ${CID}   ${EMPTY}    @{EMPTY}
+                        ...  Get Storagegroup    ${WALLET}    ${CID}    ${SG_OID_1}   ${EMPTY}    ${SIMPLE_OBJ_SIZE}    ${S_OID_1}
+                        List Storagegroup    ${WALLET}    ${CID}   ${EMPTY}    @{EMPTY}
 
 
                         Log    Storage group with 2 objects
-    ${SG_OID_2} =       Put Storagegroup    ${WIF}    ${CID}    ${EMPTY}    @{S_OBJ_ALL}
-                        List Storagegroup    ${WIF}    ${CID}   ${EMPTY}    ${SG_OID_2}
+    ${SG_OID_2} =       Put Storagegroup    ${WALLET}    ${CID}    ${EMPTY}    @{S_OBJ_ALL}
+                        List Storagegroup    ${WALLET}    ${CID}   ${EMPTY}    ${SG_OID_2}
     ${EXPECTED_SIZE} =  Evaluate    2*${SIMPLE_OBJ_SIZE}
-                        Get Storagegroup    ${WIF}    ${CID}    ${SG_OID_2}   ${EMPTY}    ${EXPECTED_SIZE}    @{S_OBJ_ALL}
-    ${Tombstone} =      Delete Storagegroup    ${WIF}    ${CID}    ${SG_OID_2}    ${EMPTY}
-                        Verify Head tombstone    ${WIF}    ${CID}    ${Tombstone}    ${SG_OID_2}    ${ADDR}
+                        Get Storagegroup    ${WALLET}    ${CID}    ${SG_OID_2}   ${EMPTY}    ${EXPECTED_SIZE}    @{S_OBJ_ALL}
+    ${Tombstone} =      Delete Storagegroup    ${WALLET}    ${CID}    ${SG_OID_2}    ${EMPTY}
+                        Verify Head tombstone    ${WALLET}    ${CID}    ${Tombstone}    ${SG_OID_2}    ${ADDR}
                         Run Keyword And Expect Error    *
-                        ...  Get Storagegroup    ${WIF}    ${CID}    ${SG_OID_2}   ${EMPTY}    ${EXPECTED_SIZE}    @{S_OBJ_ALL}
-                        List Storagegroup    ${WIF}    ${CID}   ${EMPTY}    @{EMPTY}
+                        ...  Get Storagegroup    ${WALLET}    ${CID}    ${SG_OID_2}   ${EMPTY}    ${EXPECTED_SIZE}    @{S_OBJ_ALL}
+                        List Storagegroup    ${WALLET}    ${CID}   ${EMPTY}    @{EMPTY}
 
                         Log    Incorrect input
 
                         Run Keyword And Expect Error    *
-                        ...  Put Storagegroup    ${WIF}    ${CID}    ${EMPTY}    ${UNEXIST_OID}
+                        ...  Put Storagegroup    ${WALLET}    ${CID}    ${EMPTY}    ${UNEXIST_OID}
                         Run Keyword And Expect Error    *
-                        ...  Delete Storagegroup    ${WIF}    ${CID}    ${UNEXIST_OID}    ${EMPTY}
+                        ...  Delete Storagegroup    ${WALLET}    ${CID}    ${UNEXIST_OID}    ${EMPTY}
 
     [Teardown]          Teardown    object_storage_group_simple

--- a/robot/testsuites/integration/payment/withdraw.robot
+++ b/robot/testsuites/integration/payment/withdraw.robot
@@ -21,7 +21,7 @@ NeoFS Deposit and Withdraw
 
     [Setup]                 Setup
 
-    ${WALLET}   ${ADDR}     ${WIF} =   Init Wallet with Address    ${ASSETS_DIR}
+    ${WALLET}   ${ADDR}    ${WIF} =   Init Wallet with Address    ${ASSETS_DIR}
     ${SCRIPT_HASH} =        Get ScriptHash                        ${WIF}
 
     ##########################################################
@@ -62,7 +62,7 @@ NeoFS Deposit and Withdraw
 
     ${NEOFS_BALANCE} =      Get NeoFS Balance                     ${WIF}
     ${EXPECTED_BALANCE} =   Evaluate                              ${DEPOSIT_AMOUNT} - ${WITHDRAW_AMOUNT}
-    Should Be Equal As Numbers                ${NEOFS_BALANCE}    ${EXPECTED_BALANCE}
+    Should Be Equal As numbers    ${NEOFS_BALANCE}    ${EXPECTED_BALANCE}
 
     ${MAINNET_BALANCE_AFTER} =      Get Mainnet Balance                   ${ADDR}
     ${MAINNET_BALANCE_DIFF} =       Evaluate    ${MAINNET_BALANCE_AFTER} - ${MAINNET_BALANCE}

--- a/robot/testsuites/integration/services/http_gate.robot
+++ b/robot/testsuites/integration/services/http_gate.robot
@@ -23,26 +23,26 @@ NeoFS HTTP Gateway
     [Setup]             Setup
                         Make Up    ${INCLUDE_SVC}
 
-    ${WALLET}   ${ADDR}     ${WIF} =   Prepare Wallet And Deposit
+    ${WALLET}   ${_}     ${_} =   Prepare Wallet And Deposit
 
-    ${CID} =            Create container                    ${WIF}    ${PUBLIC_ACL}    ${PLACEMENT_RULE}
+    ${CID} =            Create container                    ${WALLET}    ${PUBLIC_ACL}    ${PLACEMENT_RULE}
                         Wait Until Keyword Succeeds         ${MORPH_BLOCK_TIME}     ${CONTAINER_WAIT_INTERVAL}
-                        ...  Container Existing             ${WIF}    ${CID}
+                        ...  Container Existing             ${WALLET}    ${CID}
 
     ${FILE} =           Generate file of bytes              ${SIMPLE_OBJ_SIZE}
     ${FILE_L} =         Generate file of bytes              ${COMPLEX_OBJ_SIZE}
     ${FILE_HASH} =      Get file hash                       ${FILE}
     ${FILE_L_HASH} =    Get file hash                       ${FILE_L}
 
-    ${S_OID} =          Put object                 ${WIF}    ${FILE}      ${CID}
-    ${L_OID} =          Put object                 ${WIF}    ${FILE_L}    ${CID}
+    ${S_OID} =          Put object                 ${WALLET}    ${FILE}      ${CID}
+    ${L_OID} =          Put object                 ${WALLET}    ${FILE_L}    ${CID}
 
     # By request from Service team - try to GET object from the node without object
 
-    @{GET_NODE_LIST} =  Get nodes without object            ${WIF}    ${CID}    ${S_OID}
+    @{GET_NODE_LIST} =  Get nodes without object            ${WALLET}    ${CID}    ${S_OID}
     ${NODE} =           Evaluate                            random.choice($GET_NODE_LIST)    random
 
-    ${GET_OBJ_S} =      Get object               ${WIF}     ${CID}    ${S_OID}    ${EMPTY}    s_file_read    ${NODE}
+    ${GET_OBJ_S} =      Get object               ${WALLET}     ${CID}    ${S_OID}    ${EMPTY}    s_file_read    ${NODE}
     ${FILEPATH} =       Get via HTTP Gate                   ${CID}    ${S_OID}
 
     ${PLAIN_FILE_HASH} =    Get file hash       ${GET_OBJ_S}
@@ -50,10 +50,10 @@ NeoFS HTTP Gateway
                             Should Be Equal     ${FILE_HASH}      ${PLAIN_FILE_HASH}
                             Should Be Equal     ${FILE_HASH}      ${GATE_FILE_HASH}
 
-    @{GET_NODE_LIST} =  Get nodes without object            ${WIF}    ${CID}    ${L_OID}
+    @{GET_NODE_LIST} =  Get nodes without object            ${WALLET}    ${CID}    ${L_OID}
     ${NODE} =           Evaluate                            random.choice($GET_NODE_LIST)    random
 
-    ${GET_OBJ_L} =      Get object               ${WIF}     ${CID}    ${L_OID}    ${EMPTY}    l_file_read    ${NODE}
+    ${GET_OBJ_L} =      Get object               ${WALLET}     ${CID}    ${L_OID}    ${EMPTY}    l_file_read    ${NODE}
     ${FILEPATH} =       Get via HTTP Gate                   ${CID}    ${L_OID}
 
     ${PLAIN_FILE_HASH} =    Get file hash       ${GET_OBJ_L}

--- a/robot/testsuites/integration/services/s3_gate_object.robot
+++ b/robot/testsuites/integration/services/s3_gate_object.robot
@@ -8,8 +8,8 @@ Library     neofs.py
 Library     s3_gate.py
 Library     contract_keywords.py
 
-Resource    setup_teardown.robot
 Resource    payment_operations.robot
+Resource    setup_teardown.robot
 
 *** Variables ***
 @{INCLUDE_SVC} =        s3_gate     coredns
@@ -23,7 +23,7 @@ Objects in NeoFS S3 Gateway
     [Setup]                     Setup
                                 Make Up    ${INCLUDE_SVC}
 
-    ${WALLET}   ${_}    ${WIF} =    Prepare Wallet And Deposit
+    ${WALLET}   ${_}    ${_} =    Prepare Wallet And Deposit
 
     ${FILE_S3} =                Generate file of bytes    ${COMPLEX_OBJ_SIZE}
     ${FILE_S3_HASH} =           Get file hash             ${FILE_S3}
@@ -35,7 +35,7 @@ Objects in NeoFS S3 Gateway
     ...  ${SEC_ACCESS_KEY}
     ...  ${OWNER_PRIV_KEY} =    Init S3 Credentials    ${WALLET}
 
-    ${CONTEINERS_LIST} =        Container List               ${WIF}
+    ${CONTEINERS_LIST} =        Container List               ${WALLET}
                                 List Should Contain Value    ${CONTEINERS_LIST}    ${CID}
 
     ${S3_CLIENT} =              Config S3 client    ${ACCESS_KEY_ID}    ${SEC_ACCESS_KEY}

--- a/robot/variables/common.py
+++ b/robot/variables/common.py
@@ -66,3 +66,5 @@ NEOFS_NETMAP_DICT = {'s01': {'rpc': 's01.neofs.devenv:8080',
 NEOFS_NETMAP = [i['rpc'] for i in NEOFS_NETMAP_DICT.values()]
 NEOGO_EXECUTABLE = os.getenv('NEOGO_EXECUTABLE', 'neo-go')
 NEOFS_CLI_EXEC = os.getenv('NEOFS_CLI_EXEC', 'neofs-cli')
+
+WALLET_PASS = f"{os.getcwd()}/wallet_pass.yml"

--- a/wallet_pass.yml
+++ b/wallet_pass.yml
@@ -1,0 +1,1 @@
+password: ""


### PR DESCRIPTION
- All WIF's in `neofs-cli` commands have been replaced with wallets.
- To pass empty password for `neofs-cli` commands, `wallet_pass.yml` file is introduced with `--config` flag.
- `Payment Operations` keyword removed from `robot/resources/lib/robot/payment_operations.robot` for no more need. In tests where they had been used, replaced with `Prepare Wallet And Deposit`.
- `Binary to WIF` keyword removed from `robot/resources/lib/python/utility_keywords.py` for no more needed.
- Values that are not used in tests replaced with `${_}`.
- For some tests we used to use system keys. To avoid keys, wallets were created with such keys. New keyword `Prepare Wallet with WIF And Deposit` introduced for this.
- Fix: `--no-progress` added to `Put Object` in `robot/resources/lib/python/neofs.py`.

#424
Signed-off-by: Elizaveta Chichindaeva <elizaveta@nspcc.ru>