### PR TITLE
get rid of duplicated "create container" keywords for basic acl suites

### DIFF
--- a/robot/resources/lib/robot/common_steps_acl_basic.robot
+++ b/robot/resources/lib/robot/common_steps_acl_basic.robot
@@ -1,26 +1,4 @@
-*** Settings ***
-Variables   common.py
-Variables   wellknown_acl.py
-
-Library     container.py
-
 *** Keywords ***
-
-Create Private Container
-    [Arguments]    ${USER_KEY}
-    ${PRIV_CID_GEN} =       Create container       ${USER_KEY}        basic_acl=${PRIVATE_ACL_F}
-    [Return]    ${PRIV_CID_GEN}
-
-Create Public Container
-    [Arguments]    ${USER_KEY}
-    ${PUBLIC_CID_GEN} =     Create container       ${USER_KEY}        basic_acl=${PUBLIC_ACL_F}
-    [Return]    ${PUBLIC_CID_GEN}
-
-Create Read-Only Container
-    [Arguments]    ${USER_KEY}
-    ${READONLY_CID_GEN} =   Create container       ${USER_KEY}        basic_acl=${READONLY_ACL_F}
-    [Return]    ${READONLY_CID_GEN}
-
 
 Generate file
     [Arguments]             ${SIZE}

--- a/robot/testsuites/integration/acl/acl_basic_private_container.robot
+++ b/robot/testsuites/integration/acl/acl_basic_private_container.robot
@@ -1,6 +1,7 @@
 *** Settings ***
 Variables       common.py
 
+Library         container.py
 Library         neofs.py
 Library         neofs_verbs.py
 Library         payment_neogo.py
@@ -21,12 +22,12 @@ Basic ACL Operations for Private Container
     ${WALLET}   ${_}     ${_} =   Prepare Wallet And Deposit
     ${WALLET_OTH}   ${_}     ${_} =   Prepare Wallet And Deposit
 
-    ${PRIV_CID} =           Create Private Container    ${WALLET}
-    ${FILE_S}    ${_} =    Generate file    ${SIMPLE_OBJ_SIZE}
+    ${PRIV_CID} =           Create Container    ${WALLET}
+    ${FILE_S}    ${_} =     Generate file    ${SIMPLE_OBJ_SIZE}
                             Check Private Container    ${WALLET}    ${FILE_S}    ${PRIV_CID}    ${WALLET_OTH}
 
-    ${PRIV_CID} =           Create Private Container    ${WALLET}
-    ${FILE_S}    ${_} =    Generate file    ${COMPLEX_OBJ_SIZE}
+    ${PRIV_CID} =           Create Container    ${WALLET}
+    ${FILE_S}    ${_} =     Generate file    ${COMPLEX_OBJ_SIZE}
                             Check Private Container    ${WALLET}    ${FILE_S}    ${PRIV_CID}    ${WALLET_OTH}
 
     [Teardown]              Teardown    acl_basic_private_container

--- a/robot/testsuites/integration/acl/acl_basic_public_container.robot
+++ b/robot/testsuites/integration/acl/acl_basic_public_container.robot
@@ -1,6 +1,7 @@
 *** Settings ***
 Variables    common.py
 
+Library      container.py
 Library      neofs.py
 Library      neofs_verbs.py
 Library      payment_neogo.py
@@ -21,11 +22,11 @@ Basic ACL Operations for Public Container
     ${WALLET}   ${_}     ${_} =   Prepare Wallet And Deposit
     ${WALLET_OTH}   ${_}     ${_} =   Prepare Wallet And Deposit
 
-    ${PUBLIC_CID} =         Create Public Container    ${WALLET}
+    ${PUBLIC_CID} =         Create Container    ${WALLET}       basic_acl=public-read-write
     ${FILE_S}    ${_} =     Generate file    ${SIMPLE_OBJ_SIZE}
                             Check Public Container    ${WALLET}    ${FILE_S}    ${PUBLIC_CID}    ${WALLET_OTH}
 
-    ${PUBLIC_CID} =         Create Public Container    ${WALLET}
+    ${PUBLIC_CID} =         Create Container    ${WALLET}       basic_acl=public-read-write
     ${FILE_S}    ${_} =     Generate file    ${COMPLEX_OBJ_SIZE}
                             Check Public Container    ${WALLET}    ${FILE_S}    ${PUBLIC_CID}    ${WALLET_OTH}
 

--- a/robot/testsuites/integration/acl/acl_basic_public_container_storagegroup.robot
+++ b/robot/testsuites/integration/acl/acl_basic_public_container_storagegroup.robot
@@ -1,6 +1,7 @@
 *** Settings ***
 Variables    common.py
 
+Library     container.py
 Library     neofs.py
 Library     neofs_verbs.py
 Library     payment_neogo.py
@@ -24,11 +25,11 @@ Basic ACL Operations for Public Container
     ${WALLET}   ${_}     ${_} =   Prepare Wallet And Deposit
     ${WALLET_OTH}   ${_}     ${_} =   Prepare Wallet And Deposit
 
-    ${PUBLIC_CID} =         Create Public Container    ${WALLET}
+    ${PUBLIC_CID} =         Create Container    ${WALLET}   basic_acl=public-read-write
     ${FILE_S}    ${_} =     Generate file    ${SIMPLE_OBJ_SIZE}
                             Check Public Container    Simple    ${WALLET}    ${FILE_S}    ${PUBLIC_CID}    ${WALLET_OTH}
 
-    ${PUBLIC_CID} =         Create Public Container    ${WALLET}
+    ${PUBLIC_CID} =         Create Container    ${WALLET}   basic_acl=public-read-write
     ${FILE_S}    ${_} =     Generate file    ${COMPLEX_OBJ_SIZE}
                             Check Public Container    Complex    ${WALLET}    ${FILE_S}    ${PUBLIC_CID}    ${WALLET_OTH}
 

--- a/robot/testsuites/integration/acl/acl_basic_readonly_container_storagegroup.robot
+++ b/robot/testsuites/integration/acl/acl_basic_readonly_container_storagegroup.robot
@@ -1,6 +1,7 @@
 *** Settings ***
 Variables    common.py
 
+Library     container.py
 Library     neofs.py
 Library     neofs_verbs.py
 Library     payment_neogo.py
@@ -23,11 +24,11 @@ Basic ACL Operations for Read-Only Container
     ${WALLET}   ${_}     ${_} =         Prepare Wallet And Deposit
     ${WALLET_OTH}   ${_}     ${_} =     Prepare Wallet And Deposit
 
-    ${READONLY_CID} =       Create Read-Only Container    ${WALLET}
+    ${READONLY_CID} =       Create Container    ${WALLET}   basic_acl=public-read
     ${FILE_S}    ${_} =     Generate file    ${SIMPLE_OBJ_SIZE}
                             Check Read-Only Container    Simple    ${WALLET}    ${FILE_S}    ${READONLY_CID}    ${WALLET_OTH}
 
-    ${READONLY_CID} =       Create Read-Only Container    ${WALLET}
+    ${READONLY_CID} =       Create Container    ${WALLET}   basic_acl=public-read
     ${FILE_S}    ${_} =     Generate file    ${COMPLEX_OBJ_SIZE}
                             Check Read-Only Container    Complex    ${WALLET}    ${FILE_S}    ${READONLY_CID}    ${WALLET_OTH}
 


### PR DESCRIPTION
Signed-off-by: anastasia prasolova <anastasia@nspcc.ru>