### PR TITLE
get rid of duplicated "create container" keywords for extended acl suites

### DIFF
--- a/robot/testsuites/integration/acl/acl_extended_actions_pubkey.robot
+++ b/robot/testsuites/integration/acl/acl_extended_actions_pubkey.robot
@@ -3,6 +3,7 @@ Variables    common.py
 
 Library      Collections
 Library      acl.py
+Library      container.py
 Library      neofs.py
 Library      neofs_verbs.py
 Library      payment_neogo.py
@@ -47,7 +48,7 @@ Extended ACL Operations
 Check eACL Deny All Other and Allow All Pubkey
     [Arguments]    ${USER_WALLET}    ${FILE_S}    ${WALLET_OTH}
 
-    ${CID} =                Create Container Public    ${USER_WALLET}
+    ${CID} =                Create Container           ${USER_WALLET}     basic_acl=eacl-public-read-write
     ${S_OID_USER} =         Put object                 ${USER_WALLET}     ${FILE_S}        ${CID}    user_headers=${USER_HEADER}
     ${D_OID_USER} =         Put object                 ${USER_WALLET}     ${FILE_S}        ${CID}    user_headers=${USER_HEADER_DEL}
     @{S_OBJ_H} =	    Create List	               ${S_OID_USER}

--- a/robot/testsuites/integration/acl/acl_extended_actions_system.robot
+++ b/robot/testsuites/integration/acl/acl_extended_actions_system.robot
@@ -2,10 +2,11 @@
 Variables    common.py
 
 Library     Collections
+Library     acl.py
+Library     container.py
 Library     neofs.py
 Library     neofs_verbs.py
 Library     payment_neogo.py
-Library     acl.py
 
 Resource    common_steps_acl_extended.robot
 Resource    payment_operations.robot
@@ -46,13 +47,13 @@ Check eACL Deny and Allow All System
     ${WALLET_SN}    ${_} =     Prepare Wallet with WIF And Deposit    ${NEOFS_SN_WIF}
     ${WALLET_IR}    ${_} =     Prepare Wallet with WIF And Deposit    ${NEOFS_IR_WIF}
 
-    ${CID} =            Create Container Public     ${WALLET}
+    ${CID} =            Create Container    ${WALLET}   basic_acl=eacl-public-read-write
 
     ${S_OID_USER} =     Put object      ${WALLET}    ${FILE_S}    ${CID}    user_headers=${USER_HEADER}
     ${D_OID_USER_S} =   Put object      ${WALLET}    ${FILE_S}    ${CID}    user_headers=${USER_HEADER_DEL}
     ${D_OID_USER_SN} =  Put object      ${WALLET}    ${FILE_S}    ${CID}    user_headers=${USER_HEADER_DEL}
 
-    @{S_OBJ_H} =	Create List	    ${S_OID_USER}
+    @{S_OBJ_H} =	Create List     ${S_OID_USER}
 
                         Put object      ${WALLET_IR}    ${FILE_S}    ${CID}    user_headers=${ANOTHER_USER_HEADER}
                         Put object      ${WALLET_SN}    ${FILE_S}    ${CID}    user_headers=${ANOTHER_USER_HEADER}

--- a/robot/testsuites/integration/acl/acl_extended_compound.robot
+++ b/robot/testsuites/integration/acl/acl_extended_compound.robot
@@ -2,10 +2,11 @@
 Variables    common.py
 
 Library     Collections
+Library     acl.py
+Library     container.py
 Library     neofs.py
 Library     neofs_verbs.py
 Library     payment_neogo.py
-Library     acl.py
 
 Resource     common_steps_acl_extended.robot
 Resource     payment_operations.robot
@@ -31,7 +32,7 @@ Extended ACL Operations
 
                             Log    Check extended ACL with simple object
     ${FILE_S} =             Generate file of bytes    ${SIMPLE_OBJ_SIZE}
-                            Check Сompound Operations    ${WALLET}    ${WALLET_OTH}    ${FILE_S}   
+                            Check Сompound Operations    ${WALLET}    ${WALLET_OTH}    ${FILE_S}
 
                             Log    Check extended ACL with complex object
     ${FILE_S} =             Generate file of bytes    ${COMPLEX_OBJ_SIZE}
@@ -48,22 +49,22 @@ Check Сompound Operations
 
     ${WALLET_SYS}    ${ADDR_SYS} =     Prepare Wallet with WIF And Deposit    ${SYSTEM_KEY}
 
-                            Check eACL Сompound Get    ${WALLET_OTH}     ${EACL_COMPOUND_GET_OTHERS}    ${FILE_S}    ${WALLET}    ${WALLET_SYS}
-                            Check eACL Сompound Get    ${WALLET}      ${EACL_COMPOUND_GET_USER}      ${FILE_S}    ${WALLET}    ${WALLET_SYS}
-                            Check eACL Сompound Get    ${WALLET_SYS}       ${EACL_COMPOUND_GET_SYSTEM}    ${FILE_S}    ${WALLET}    ${WALLET_SYS}
+    Check eACL Сompound Get    ${WALLET_OTH}    ${EACL_COMPOUND_GET_OTHERS}    ${FILE_S}    ${WALLET}    ${WALLET_SYS}
+    Check eACL Сompound Get    ${WALLET}        ${EACL_COMPOUND_GET_USER}      ${FILE_S}    ${WALLET}    ${WALLET_SYS}
+    Check eACL Сompound Get    ${WALLET_SYS}    ${EACL_COMPOUND_GET_SYSTEM}    ${FILE_S}    ${WALLET}    ${WALLET_SYS}
 
-                            Check eACL Сompound Delete    ${WALLET_OTH}     ${EACL_COMPOUND_DELETE_OTHERS}    ${FILE_S}    ${WALLET}    ${WALLET_SYS}
-                            Check eACL Сompound Delete    ${WALLET}      ${EACL_COMPOUND_DELETE_USER}      ${FILE_S}    ${WALLET}    ${WALLET_SYS}
-                            Check eACL Сompound Delete    ${WALLET_SYS}       ${EACL_COMPOUND_DELETE_SYSTEM}    ${FILE_S}    ${WALLET}    ${WALLET_SYS}
+    Check eACL Сompound Delete    ${WALLET_OTH}     ${EACL_COMPOUND_DELETE_OTHERS}    ${FILE_S}    ${WALLET}    ${WALLET_SYS}
+    Check eACL Сompound Delete    ${WALLET}         ${EACL_COMPOUND_DELETE_USER}      ${FILE_S}    ${WALLET}    ${WALLET_SYS}
+    Check eACL Сompound Delete    ${WALLET_SYS}     ${EACL_COMPOUND_DELETE_SYSTEM}    ${FILE_S}    ${WALLET}    ${WALLET_SYS}
 
-                            Check eACL Сompound Get Range Hash    ${WALLET_OTH}     ${EACL_COMPOUND_GET_HASH_OTHERS}    ${FILE_S}    ${WALLET}    ${WALLET_SYS}
-                            Check eACL Сompound Get Range Hash    ${WALLET}      ${EACL_COMPOUND_GET_HASH_USER}      ${FILE_S}    ${WALLET}    ${WALLET_SYS}
-                            Check eACL Сompound Get Range Hash    ${WALLET_SYS}       ${EACL_COMPOUND_GET_HASH_SYSTEM}    ${FILE_S}    ${WALLET}    ${WALLET_SYS}
+    Check eACL Сompound Get Range Hash    ${WALLET_OTH}     ${EACL_COMPOUND_GET_HASH_OTHERS}    ${FILE_S}    ${WALLET}    ${WALLET_SYS}
+    Check eACL Сompound Get Range Hash    ${WALLET}         ${EACL_COMPOUND_GET_HASH_USER}      ${FILE_S}    ${WALLET}    ${WALLET_SYS}
+    Check eACL Сompound Get Range Hash    ${WALLET_SYS}     ${EACL_COMPOUND_GET_HASH_SYSTEM}    ${FILE_S}    ${WALLET}    ${WALLET_SYS}
 
 Check eACL Сompound Get
     [Arguments]             ${WALLET}    ${DENY_EACL}    ${FILE_S}    ${USER_WALLET}    ${WALLET_SYS}
 
-    ${CID} =                Create Container Public    ${USER_WALLET}
+    ${CID} =                Create Container    ${USER_WALLET}  basic_acl=eacl-public-read-write
 
     ${S_OID_USER} =         Put object    ${USER_WALLET}    ${FILE_S}    ${CID}           user_headers=${USER_HEADER}
                             Put object    ${WALLET}         ${FILE_S}    ${CID}           user_headers=${ANOTHER_HEADER}
@@ -89,7 +90,7 @@ Check eACL Сompound Get
 Check eACL Сompound Delete
     [Arguments]             ${WALLET}    ${DENY_EACL}    ${FILE_S}    ${USER_WALLET}    ${WALLET_SYS}
 
-    ${CID} =                Create Container Public    ${USER_WALLET}
+    ${CID} =                Create Container       ${USER_WALLET}   basic_acl=eacl-public-read-write
 
     ${S_OID_USER} =         Put object             ${USER_WALLET}    ${FILE_S}    ${CID}    user_headers=${USER_HEADER}
     ${D_OID_USER} =         Put object             ${USER_WALLET}    ${FILE_S}    ${CID}
@@ -118,11 +119,10 @@ Check eACL Сompound Delete
                             END
 
 
-
 Check eACL Сompound Get Range Hash
     [Arguments]             ${WALLET}    ${DENY_EACL}    ${FILE_S}    ${USER_WALLET}    ${WALLET_SYS}
 
-    ${CID} =                Create Container Public    ${USER_WALLET}
+    ${CID} =                Create Container       ${USER_WALLET}   basic_acl=eacl-public-read-write
 
     ${S_OID_USER} =         Put object             ${USER_WALLET}          ${FILE_S}    ${CID}    user_headers=${USER_HEADER}
                             Put object             ${WALLET}               ${FILE_S}    ${CID}    user_headers=${ANOTHER_HEADER}

--- a/robot/testsuites/integration/acl/acl_extended_filters.robot
+++ b/robot/testsuites/integration/acl/acl_extended_filters.robot
@@ -2,11 +2,12 @@
 Variables       common.py
 
 Library         acl.py
+Library         container.py
+Library         contract_keywords.py
 Library         neofs.py
 Library         neofs_verbs.py
 Library         payment_neogo.py
 Library         Collections
-Library         contract_keywords.py
 
 Resource        common_steps_acl_extended.robot
 Resource        payment_operations.robot
@@ -47,18 +48,19 @@ Extended ACL Operations
 Check Filters
     [Arguments]    ${WALLET}    ${WALLET_OTH}
 
-                            Check eACL MatchType String Equal Object    ${WALLET}    ${WALLET_OTH}
-                            Check eACL MatchType String Not Equal Object    ${WALLET}    ${WALLET_OTH}
-                            Check eACL MatchType String Equal Request Deny    ${WALLET}    ${WALLET_OTH}
-                            Check eACL MatchType String Equal Request Allow    ${WALLET}    ${WALLET_OTH}
+    Check eACL MatchType String Equal Object    ${WALLET}    ${WALLET_OTH}
+    Check eACL MatchType String Not Equal Object    ${WALLET}    ${WALLET_OTH}
+    Check eACL MatchType String Equal Request Deny    ${WALLET}    ${WALLET_OTH}
+    Check eACL MatchType String Equal Request Allow    ${WALLET}    ${WALLET_OTH}
+
 
 Check eACL MatchType String Equal Request Deny
     [Arguments]    ${USER_WALLET}    ${OTHER_WALLET}
-    ${CID} =                Create Container Public    ${USER_WALLET}
-    ${S_OID_USER} =         Put object             ${USER_WALLET}     ${FILE_S}    ${CID}      user_headers=${USER_HEADER}
-                            Get object           ${USER_WALLET}    ${CID}       ${S_OID_USER}    ${EMPTY}    ${PATH}
+    ${CID} =                Create Container       ${USER_WALLET}    basic_acl=eacl-public-read-write
+    ${S_OID_USER} =         Put object             ${USER_WALLET}    ${FILE_S}    ${CID}      user_headers=${USER_HEADER}
+                            Get object             ${USER_WALLET}    ${CID}       ${S_OID_USER}    ${EMPTY}    ${PATH}
 
-                            Set eACL                ${USER_WALLET}    ${CID}    ${EACL_XHEADER_DENY_ALL}
+                            Set eACL               ${USER_WALLET}    ${CID}    ${EACL_XHEADER_DENY_ALL}
 
                             # The current ACL cache lifetime is 30 sec
                             Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}
@@ -94,9 +96,9 @@ Check eACL MatchType String Equal Request Deny
 Check eACL MatchType String Equal Request Allow
     [Arguments]    ${USER_WALLET}    ${OTHER_WALLET}
 
-    ${CID} =                Create Container Public    ${USER_WALLET}
-    ${S_OID_USER} =         Put Object    ${USER_WALLET}     ${FILE_S}    ${CID}
-                            Get Object    ${OTHER_WALLET}    ${CID}    ${S_OID_USER}    ${EMPTY}    ${PATH}
+    ${CID} =                Create Container    ${USER_WALLET}      basic_acl=eacl-public-read-write
+    ${S_OID_USER} =         Put Object          ${USER_WALLET}      ${FILE_S}   ${CID}
+                            Get Object          ${OTHER_WALLET}     ${CID}      ${S_OID_USER}    ${EMPTY}    ${PATH}
 
                             Set eACL    ${USER_WALLET}    ${CID}    ${EACL_XHEADER_ALLOW_ALL}
 
@@ -134,7 +136,7 @@ Check eACL MatchType String Equal Request Allow
 Check eACL MatchType String Equal Object
     [Arguments]    ${USER_WALLET}    ${OTHER_WALLET}
 
-    ${CID} =                Create Container Public    ${USER_WALLET}
+    ${CID} =                Create Container       ${USER_WALLET}   basic_acl=eacl-public-read-write
     ${S_OID_USER} =         Put Object    ${USER_WALLET}     ${FILE_S}    ${CID}    user_headers=${USER_HEADER}
                             Get Object    ${OTHER_WALLET}    ${CID}       ${S_OID_USER}    ${EMPTY}    ${PATH}
 
@@ -147,10 +149,9 @@ Check eACL MatchType String Equal Object
     ${rule1} =              Set Variable    deny get ${filters} others
     ${eACL_gen} =           Create List     ${rule1}
     ${EACL_CUSTOM} =        Create eACL     ${CID}    ${eACL_gen}
-                            Set eACL           ${USER_WALLET}       ${CID}    ${EACL_CUSTOM}
+                            Set eACL        ${USER_WALLET}       ${CID}    ${EACL_CUSTOM}
                             Run Keyword And Expect Error    *
                             ...  Get object    ${OTHER_WALLET}      ${CID}    ${S_OID_USER}     ${EMPTY}    ${PATH}
-
 
                             Log	                 Set eACL for Deny GET operation with StringEqual Object Extended User Header
 
@@ -170,7 +171,7 @@ Check eACL MatchType String Equal Object
 Check eACL MatchType String Not Equal Object
     [Arguments]    ${USER_WALLET}    ${OTHER_WALLET}
 
-    ${CID} =                Create Container Public    ${USER_WALLET}
+    ${CID} =                Create Container   ${USER_WALLET}       basic_acl=eacl-public-read-write
 
     ${S_OID_USER} =         Put object         ${USER_WALLET}     ${FILE_S}      ${CID}    user_headers=${USER_HEADER}
     ${S_OID_OTHER} =        Put object         ${OTHER_WALLET}    ${FILE_S_2}    ${CID}    user_headers=${ANOTHER_HEADER}
@@ -194,11 +195,11 @@ Check eACL MatchType String Not Equal Object
 
                             Log	               Set eACL for Deny GET operation with StringEqual Object Extended User Header
 
-    ${S_OID_USER_OTH} =     Put object         ${USER_WALLET}    ${FILE_S}    ${CID}    user_headers=${ANOTHER_HEADER}
-    ${filters} =            Set Variable    obj:${CUSTOM_FILTER}!=1
-    ${rule1} =              Set Variable    deny get ${filters} others
-    ${eACL_gen} =           Create List     ${rule1}
-    ${EACL_CUSTOM} =        Create eACL     ${CID}    ${eACL_gen}
+    ${S_OID_USER_OTH} =     Put object          ${USER_WALLET}    ${FILE_S}    ${CID}    user_headers=${ANOTHER_HEADER}
+    ${filters} =            Set Variable        obj:${CUSTOM_FILTER}!=1
+    ${rule1} =              Set Variable        deny get ${filters} others
+    ${eACL_gen} =           Create List         ${rule1}
+    ${EACL_CUSTOM} =        Create eACL         ${CID}    ${eACL_gen}
 
                             Set eACL             ${USER_WALLET}    ${CID}       ${EACL_CUSTOM}
                             Run Keyword And Expect Error    *

--- a/robot/testsuites/integration/acl/object_attributes/creation_epoch_filter.robot
+++ b/robot/testsuites/integration/acl/object_attributes/creation_epoch_filter.robot
@@ -3,6 +3,7 @@ Variables       common.py
 Variables       eacl_object_filters.py
 
 Library         acl.py
+Library         container.py
 Library         neofs.py
 Library         Collections
 Library         contract_keywords.py
@@ -24,9 +25,7 @@ Creation Epoch Object Filter for Extended ACL
 
     [Setup]                 Setup
 
-    Log    Check eACL creationEpoch Filter with MatchType String Equal
     Check eACL Filters with MatchType String Equal    $Object:creationEpoch
-    Log    Check eACL creationEpoch Filter with MatchType String Not Equal
     Check $Object:creationEpoch Filter with MatchType String Not Equal    $Object:creationEpoch
 
     [Teardown]          Teardown    creation_epoch_filter
@@ -39,17 +38,16 @@ Check $Object:creationEpoch Filter with MatchType String Not Equal
     ${WALLET}   ${_}    ${_} =    Prepare Wallet And Deposit
     ${WALLET_OTH}   ${_}    ${_} =    Prepare Wallet And Deposit
 
-    ${CID} =            Create Container Public    ${WALLET}
+    ${CID} =            Create Container    ${WALLET}       basic_acl=eacl-public-read-write
     ${FILE_S}    ${_} =    Generate file    ${SIMPLE_OBJ_SIZE}
 
     ${S_OID} =          Put Object    ${WALLET}    ${FILE_S}    ${CID}
-                        Tick Epoch
     ${S_OID_NEW} =      Put Object    ${WALLET}    ${FILE_S}    ${CID}
 
                         Get Object    ${WALLET}    ${CID}    ${S_OID_NEW}    ${EMPTY}    local_file_eacl
+    &{HEADER} =         Head Object    ${WALLET}    ${CID}    ${S_OID_NEW}
 
-    &{HEADER_DICT} =    Head Object    ${WALLET}    ${CID}    ${S_OID_NEW}
-    ${EACL_CUSTOM} =    Compose eACL Custom    ${CID}    ${HEADER_DICT}    !=    ${FILTER}    DENY    OTHERS
+    ${EACL_CUSTOM} =    Compose eACL Custom    ${CID}    ${HEADER}[header][creationEpoch]    !=    ${FILTER}    DENY    OTHERS
                         Set eACL    ${WALLET}    ${CID}    ${EACL_CUSTOM}
 
     Run Keyword And Expect Error   ${EACL_ERR_MSG}

--- a/robot/testsuites/integration/acl/object_attributes/object_id_filter.robot
+++ b/robot/testsuites/integration/acl/object_attributes/object_id_filter.robot
@@ -3,6 +3,7 @@ Variables       common.py
 Variables       eacl_object_filters.py
 
 Library         acl.py
+Library         container.py
 Library         neofs.py
 Library         Collections
 
@@ -18,48 +19,44 @@ ${EACL_ERR_MSG} =    *
 *** Test cases ***
 Object ID Object Filter for Extended ACL
     [Documentation]         Testcase to validate if $Object:objectID eACL filter is correctly handled.
-    [Tags]                  ACL  eACL  NeoFS  NeoCLI
+    [Tags]                  ACL  eACL
     [Timeout]               20 min
 
     [Setup]                 Setup
-    
-    Log    Check eACL objectID Filter with MatchType String Equal
+
     Check eACL Filters with MatchType String Equal    $Object:objectID
-    Log    Check eACL objectID Filter with MatchType String Not Equal
     Check eACL Filters with MatchType String Not Equal   $Object:objectID
 
     #################################################################################
     # If the first eACL rule contradicts the second, the second one won't be applied
     #################################################################################
-    Log    Check if the second rule that contradicts the first is not applied
     Check eACL Filters with MatchType String Equal with two contradicting filters    $Object:objectID
 
     ###########################################################################################################################
     # If both STRING_EQUAL and STRING_NOT_EQUAL matchTypes are applied for the same filter value, no object can be operated on
     ###########################################################################################################################
-    Log    Check two matchTypes applied
     Check eACL Filters, two matchTypes    $Object:objectID
 
     [Teardown]          Teardown    object_id
 
 
 *** Keywords ***
- 
+
 Check eACL Filters with MatchType String Equal with two contradicting filters
     [Arguments]    ${FILTER}
 
-    ${WALLET}   ${_}     ${_} =    Prepare Wallet And Deposit  
+    ${WALLET}   ${_}     ${_} =    Prepare Wallet And Deposit
     ${WALLET_OTH}   ${_}     ${_} =    Prepare Wallet And Deposit
 
-    ${CID} =            Create Container Public    ${WALLET} 
+    ${CID} =            Create Container         ${WALLET}      basic_acl=eacl-public-read-write
     ${FILE_S_USER}    ${_} =    Generate file    ${SIMPLE_OBJ_SIZE}
 
     ${S_OID_USER} =     Put Object    ${WALLET}     ${FILE_S_USER}    ${CID}    ${EMPTY}
-    &{HEADER_DICT_USER} =    Object Header Decoded    ${WALLET}    ${CID}    ${S_OID_USER}
-   
+
                         Get Object    ${WALLET_OTH}    ${CID}       ${S_OID_USER}    ${EMPTY}    ${OBJECT_PATH}
 
-    ${filter_value} =    Get From Dictionary    ${HEADER_DICT_USER}    ${EACL_OBJ_FILTERS}[${FILTER}]
+    &{HEADER} =         Head Object    ${WALLET}    ${CID}    ${S_OID_USER}
+    ${filter_value} =    Get From Dictionary    ${HEADER}    ${EACL_OBJ_FILTERS}[${FILTER}]
     ${filters} =        Set Variable    obj:${FILTER}=${filter_value}
     ${rule} =           Set Variable    allow get ${filters} others
     ${contradicting_filters} =     Set Variable    obj:$Object:payloadLength=${SIMPLE_OBJ_SIZE}
@@ -70,23 +67,24 @@ Check eACL Filters with MatchType String Equal with two contradicting filters
                         Set eACL    ${WALLET}    ${CID}    ${EACL_CUSTOM}
                         Get object    ${WALLET_OTH}    ${CID}    ${S_OID_USER}    ${EMPTY}    ${OBJECT_PATH}
 
+
 Check eACL Filters, two matchTypes
     [Arguments]    ${FILTER}
 
-    ${WALLET}   ${_}    ${_} =    Prepare Wallet And Deposit  
+    ${WALLET}   ${_}    ${_} =    Prepare Wallet And Deposit
     ${WALLET_OTH}   ${_}    ${_} =    Prepare Wallet And Deposit
 
-    ${CID} =            Create Container Public    ${WALLET}
+    ${CID} =            Create Container    ${WALLET}       basic_acl=eacl-public-read-write
     ${FILE_S}    ${_} =    Generate file    ${SIMPLE_OBJ_SIZE}
 
     ${S_OID_USER} =     Put Object    ${WALLET}    ${FILE_S}    ${CID}    ${EMPTY}
     ${S_OID_OTHER} =    Put Object    ${WALLET_OTH}    ${FILE_S}    ${CID}    ${EMPTY}
-    &{HEADER_DICT_USER} =    Object Header Decoded    ${WALLET}    ${CID}    ${S_OID_USER}
+    &{HEADER} =         Head Object   ${WALLET}    ${CID}    ${S_OID_USER}
 
                         Get Object    ${WALLET_OTH}    ${CID}    ${S_OID_USER}     ${EMPTY}    ${OBJECT_PATH}
                         Get Object    ${WALLET_OTH}    ${CID}    ${S_OID_OTHER}    ${EMPTY}    ${OBJECT_PATH}
 
-    ${filter_value} =    Get From Dictionary    ${HEADER_DICT_USER}    ${EACL_OBJ_FILTERS}[${FILTER}]
+    ${filter_value} =    Get From Dictionary    ${HEADER}    ${EACL_OBJ_FILTERS}[${FILTER}]
     ${noneq_filters} =    Set Variable    obj:${FILTER}!=${filter_value}
     ${rule_noneq_filter} =    Set Variable    deny get ${noneq_filters} others
     ${eq_filters} =     Set Variable    obj:${FILTER}=${filter_value}

--- a/robot/testsuites/integration/acl/object_attributes/payload_length_filter.robot
+++ b/robot/testsuites/integration/acl/object_attributes/payload_length_filter.robot
@@ -3,6 +3,7 @@ Variables    common.py
 Variables    eacl_object_filters.py
 
 Library     acl.py
+Library     container.py
 Library     neofs.py
 Library     Collections
 
@@ -23,9 +24,7 @@ Payload Length Object Filter for Extended ACL
 
     [Setup]                 Setup
 
-    Log    Check eACL payloadLength Filter with MatchType String Equal
     Check eACL Filters with MatchType String Equal    $Object:payloadLength
-    Log    Check eACL payloadLength Filter with MatchType String Not Equal
     Check $Object:payloadLength Filter with MatchType String Not Equal    $Object:payloadLength
 
     [Teardown]          Teardown    payload_length_filter
@@ -38,7 +37,7 @@ Check $Object:payloadLength Filter with MatchType String Not Equal
     ${WALLET}   ${_}    ${_} =    Prepare Wallet And Deposit
     ${WALLET_OTH}   ${_}    ${_} =    Prepare Wallet And Deposit
 
-    ${CID} =            Create Container Public    ${WALLET}
+    ${CID} =            Create Container    ${WALLET}   basic_acl=eacl-public-read-write
     ${FILE_S}    ${_} =    Generate file    ${SIMPLE_OBJ_SIZE}
     ${FILE_0}    ${_} =    Generate file    ${0}
 
@@ -46,10 +45,9 @@ Check $Object:payloadLength Filter with MatchType String Not Equal
     ${S_OID} =          Put Object    ${WALLET}    ${FILE_S}    ${CID}
 
                         Get Object    ${WALLET}    ${CID}    ${S_OID}    ${EMPTY}    local_file_eacl
-                        Head Object    ${WALLET}    ${CID}    ${S_OID}
+    &{HEADER} =         Head Object    ${WALLET}    ${CID}    ${S_OID}
 
-    &{HEADER_DICT} =    Object Header Decoded    ${WALLET}    ${CID}    ${S_OID}
-    ${EACL_CUSTOM} =    Compose eACL Custom    ${CID}    ${HEADER_DICT}    !=    ${FILTER}    DENY    OTHERS
+    ${EACL_CUSTOM} =    Compose eACL Custom    ${CID}    ${HEADER}[header][payloadLength]    !=    ${FILTER}    DENY    OTHERS
                         Set eACL    ${WALLET}    ${CID}    ${EACL_CUSTOM}
 
     Run Keyword And Expect Error   ${EACL_ERR_MSG}


### PR DESCRIPTION
Some of the changed tests don't work due to https://github.com/nspcc-dev/neofs-node/issues/1399

Signed-off-by: anastasia prasolova <anastasia@nspcc.ru>