### PR TITLE
Add Generate File and File Hash in acl_basic_*

### DIFF
--- a/robot/resources/lib/robot/common_steps_acl_basic.robot
+++ b/robot/resources/lib/robot/common_steps_acl_basic.robot
@@ -1,7 +1,0 @@
-*** Keywords ***
-
-Generate file
-    [Arguments]             ${SIZE}
-    ${FILE_S_GEN} =         Generate file of bytes    ${SIZE}
-    ${FILE_S_HASH_GEN} =    Get file hash             ${FILE_S_GEN}
-    [Return]     ${FILE_S_GEN}    ${FILE_S_HASH_GEN}

--- a/robot/testsuites/integration/acl/acl_basic_private_container.robot
+++ b/robot/testsuites/integration/acl/acl_basic_private_container.robot
@@ -2,11 +2,9 @@
 Variables       common.py
 
 Library         container.py
-Library         neofs.py
 Library         neofs_verbs.py
-Library         payment_neogo.py
+Library         utility_keywords.py
 
-Resource        common_steps_acl_basic.robot
 Resource        payment_operations.robot
 Resource        setup_teardown.robot
 

--- a/robot/testsuites/integration/acl/acl_basic_private_container_storagegroup.robot
+++ b/robot/testsuites/integration/acl/acl_basic_private_container_storagegroup.robot
@@ -2,16 +2,12 @@
 Variables    common.py
 
 Library     container.py
-Library     neofs.py
 Library     neofs_verbs.py
-Library     payment_neogo.py
-Library     storage_group.py
-Library     Collections
+Library     utility_keywords.py
 
 Resource    payment_operations.robot
 Resource    setup_teardown.robot
 Resource    storage_group.robot
-Resource    common_steps_acl_basic.robot
 
 
 *** Test cases ***

--- a/robot/testsuites/integration/acl/acl_basic_public_container.robot
+++ b/robot/testsuites/integration/acl/acl_basic_public_container.robot
@@ -2,11 +2,9 @@
 Variables    common.py
 
 Library      container.py
-Library      neofs.py
 Library      neofs_verbs.py
-Library      payment_neogo.py
+Library      utility_keywords.py
 
-Resource     common_steps_acl_basic.robot
 Resource     payment_operations.robot
 Resource     setup_teardown.robot
 

--- a/robot/testsuites/integration/acl/acl_basic_public_container_storagegroup.robot
+++ b/robot/testsuites/integration/acl/acl_basic_public_container_storagegroup.robot
@@ -2,13 +2,9 @@
 Variables    common.py
 
 Library     container.py
-Library     neofs.py
 Library     neofs_verbs.py
-Library     payment_neogo.py
-Library     contract_keywords.py
-Library     storage_group.py
+Library     utility_keywords.py
 
-Resource    common_steps_acl_basic.robot
 Resource    payment_operations.robot
 Resource    setup_teardown.robot
 Resource    storage_group.robot
@@ -52,4 +48,4 @@ Check Public Container
 
                         # System isn't allowed to DELETE in Public Container
                         Run Storage Group Operations On System's Behalf In RO Container
-                        ...                         ${PUBLIC_CID}   ${OBJECTS}  ${RUN_TYPE}
+                        ...     ${PUBLIC_CID}   ${OBJECTS}  ${RUN_TYPE}

--- a/robot/testsuites/integration/acl/acl_basic_readonly_container.robot
+++ b/robot/testsuites/integration/acl/acl_basic_readonly_container.robot
@@ -2,11 +2,9 @@
 Variables    common.py
 
 Library     container.py
-Library     neofs.py
 Library     neofs_verbs.py
-Library     payment_neogo.py
+Library     utility_keywords.py
 
-Resource    common_steps_acl_basic.robot
 Resource    payment_operations.robot
 Resource    setup_teardown.robot
 

--- a/robot/testsuites/integration/acl/acl_basic_readonly_container_storagegroup.robot
+++ b/robot/testsuites/integration/acl/acl_basic_readonly_container_storagegroup.robot
@@ -2,12 +2,9 @@
 Variables    common.py
 
 Library     container.py
-Library     neofs.py
 Library     neofs_verbs.py
-Library     payment_neogo.py
-Library     storage_group.py
+Library     utility_keywords.py
 
-Resource    common_steps_acl_basic.robot
 Resource    payment_operations.robot
 Resource    setup_teardown.robot
 Resource    storage_group.robot


### PR DESCRIPTION
- `Generate file` keyword in `utility_keywords.py`
- `Generate file` creating global variables replaced with `Generate file` creating non-global variables in tests for basic acl
- Libraries that are no more necessary removed from those tests
- `utility_keywords.py` checked with pylint

#199

Signed-off-by: Elizaveta Chichindaeva <elizaveta@nspcc.ru>