### PR TITLE
Add non-global Generate File in acl_bearer_*

### DIFF
--- a/robot/resources/lib/robot/common_steps_acl_bearer.robot
+++ b/robot/resources/lib/robot/common_steps_acl_bearer.robot
@@ -2,12 +2,6 @@
 Variables   common.py
 
 *** Keywords ***
-Generate file
-    [Arguments]             ${SIZE}
-
-    ${FILE_S_GEN} =         Generate file of bytes    ${SIZE}
-    [Return]                ${FILE_S_GEN}
-
 
 Prepare eACL Role rules
     [Arguments]    ${CID}

--- a/robot/testsuites/integration/acl/acl_bearer_allow.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_allow.robot
@@ -1,15 +1,12 @@
 *** Settings ***
 Variables   common.py
 
-Library     Collections
 Library     acl.py
 Library     container.py
-Library     neofs.py
 Library     neofs_verbs.py
-Library     payment_neogo.py
+Library     utility_keywords.py
 
 Resource    eacl_tables.robot
-Resource    common_steps_acl_bearer.robot
 Resource    payment_operations.robot
 Resource    setup_teardown.robot
 
@@ -29,11 +26,11 @@ BearerToken Operations
     ${WALLET}   ${_}     ${_} =   Prepare Wallet And Deposit
 
                             Log    Check Bearer token with simple object
-    ${FILE_S} =             Generate file    ${SIMPLE_OBJ_SIZE}
+    ${FILE_S}    ${_} =     Generate file    ${SIMPLE_OBJ_SIZE}
                             Check eACL Deny and Allow All Bearer    ${WALLET}    ${FILE_S}
 
                             Log    Check Bearer token with complex object
-    ${FILE_S} =             Generate file    ${COMPLEX_OBJ_SIZE}
+    ${FILE_S}    ${_} =     Generate file    ${COMPLEX_OBJ_SIZE}
                             Check eACL Deny and Allow All Bearer    ${WALLET}    ${FILE_S}
 
 

--- a/robot/testsuites/integration/acl/acl_bearer_allow_storagegroup.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_allow_storagegroup.robot
@@ -24,10 +24,10 @@ BearerToken Operations
 
     ${WALLET}   ${_}     ${_} =   Prepare Wallet And Deposit
 
-    ${FILE_S} =             Generate file    ${SIMPLE_OBJ_SIZE}
+    ${FILE_S}    ${_} =     Generate file    ${SIMPLE_OBJ_SIZE}
                             Check eACL Deny and Allow All Bearer    Simple    ${WALLET}    ${FILE_S}
 
-    ${FILE_S} =             Generate file    ${COMPLEX_OBJ_SIZE}
+    ${FILE_S}    ${_} =     Generate file    ${COMPLEX_OBJ_SIZE}
                             Check eACL Deny and Allow All Bearer    Complex    ${WALLET}    ${FILE_S}
 
     [Teardown]              Teardown    acl_bearer_allow_storagegroup

--- a/robot/testsuites/integration/acl/acl_bearer_compound.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_compound.robot
@@ -1,12 +1,10 @@
 *** Settings ***
 Variables   common.py
 
-Library     Collections
 Library     acl.py
 Library     container.py
-Library     neofs.py
 Library     neofs_verbs.py
-Library     payment_neogo.py
+Library     utility_keywords.py
 
 Resource    eacl_tables.robot
 Resource    common_steps_acl_bearer.robot
@@ -20,24 +18,24 @@ ${SYSTEM_KEY} =     ${NEOFS_IR_WIF}
 
 *** Test cases ***
 BearerToken Operations for Сompound Operations
-    [Documentation]     Testcase to validate NeoFS operations with BearerToken for Сompound Operations.
-    [Tags]              ACL   BearerToken
-    [Timeout]           20 min
+    [Documentation]         Testcase to validate NeoFS operations with BearerToken for Сompound Operations.
+    [Tags]                  ACL   BearerToken
+    [Timeout]               20 min
 
-    [Setup]             Setup
+    [Setup]                 Setup
 
     ${WALLET}   ${_}     ${_} =   Prepare Wallet And Deposit
     ${WALLET_OTH}   ${_}     ${_} =   Prepare Wallet And Deposit
 
-                        Log    Check Bearer token with simple object
-    ${FILE_S} =         Generate file    ${SIMPLE_OBJ_SIZE}
-                        Check Сompound Operations    ${WALLET}    ${WALLET_OTH}    ${FILE_S}
+                            Log    Check Bearer token with simple object
+    ${FILE_S}    ${_} =     Generate file    ${SIMPLE_OBJ_SIZE}
+                            Check Сompound Operations    ${WALLET}    ${WALLET_OTH}    ${FILE_S}
 
-                        Log    Check Bearer token with complex object
-    ${FILE_S} =         Generate file    ${COMPLEX_OBJ_SIZE}
-                        Check Сompound Operations    ${WALLET}    ${WALLET_OTH}    ${FILE_S}
+                            Log    Check Bearer token with complex object
+    ${FILE_S}    ${_} =     Generate file    ${COMPLEX_OBJ_SIZE}
+                            Check Сompound Operations    ${WALLET}    ${WALLET_OTH}    ${FILE_S}
 
-    [Teardown]          Teardown    acl_bearer_compound
+    [Teardown]              Teardown    acl_bearer_compound
 
 
 *** Keywords ***

--- a/robot/testsuites/integration/acl/acl_bearer_filter_oid_equal.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_filter_oid_equal.robot
@@ -1,12 +1,11 @@
 *** Settings ***
 Variables   common.py
 
-Library     Collections
 Library     acl.py
 Library     container.py
-Library     neofs.py
 Library     neofs_verbs.py
 Library     payment_neogo.py
+Library     utility_keywords.py
 
 Resource    eacl_tables.robot
 Resource    common_steps_acl_bearer.robot
@@ -26,15 +25,15 @@ BearerToken Operations with Filter OID Equal
 
     [Setup]                 Setup
 
-    ${WALLET}   ${_}     ${_} =   Prepare Wallet And Deposit
+    ${WALLET}    ${_}    ${_} =   Prepare Wallet And Deposit
 
                             Log    Check Bearer token with simple object
-    ${FILE_S} =             Generate file    ${SIMPLE_OBJ_SIZE}
+    ${FILE_S}    ${_} =     Generate file    ${SIMPLE_OBJ_SIZE}
                             Check eACL Deny and Allow All Bearer Filter OID Equal    ${WALLET}    ${FILE_S}
 
                             Log    Check Bearer token with complex object
 
-    ${FILE_S} =             Generate file    ${COMPLEX_OBJ_SIZE}
+    ${FILE_S}    ${_} =     Generate file    ${COMPLEX_OBJ_SIZE}
                             Check eACL Deny and Allow All Bearer Filter OID Equal    ${WALLET}    ${FILE_S}
 
     [Teardown]              Teardown    acl_bearer_filter_oid_equal

--- a/robot/testsuites/integration/acl/acl_bearer_filter_oid_not_equal.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_filter_oid_not_equal.robot
@@ -1,12 +1,10 @@
 *** Settings ***
 Variables   common.py
 
-Library     Collections
 Library     acl.py
 Library     container.py
-Library     neofs.py
 Library     neofs_verbs.py
-Library     payment_neogo.py
+Library     utility_keywords.py
 
 Resource    eacl_tables.robot
 Resource    common_steps_acl_bearer.robot
@@ -28,11 +26,11 @@ BearerToken Operations with Filter OID NotEqual
     ${WALLET}   ${_}     ${_} =   Prepare Wallet And Deposit
 
                             Log    Check Bearer token with simple object
-    ${FILE_S} =             Generate file    ${SIMPLE_OBJ_SIZE}
+    ${FILE_S}    ${_} =     Generate file    ${SIMPLE_OBJ_SIZE}
                             Check eACL Deny and Allow All Bearer Filter OID NotEqual    ${WALLET}    ${FILE_S}
 
                             Log    Check Bearer token with complex object
-    ${FILE_S} =             Generate file    ${COMPLEX_OBJ_SIZE}
+    ${FILE_S}    ${_} =     Generate file    ${COMPLEX_OBJ_SIZE}
                             Check eACL Deny and Allow All Bearer Filter OID NotEqual    ${WALLET}    ${FILE_S}
 
     [Teardown]              Teardown    acl_bearer_filter_oid_not_equal

--- a/robot/testsuites/integration/acl/acl_bearer_filter_userheader_equal.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_filter_userheader_equal.robot
@@ -1,12 +1,10 @@
 *** Settings ***
 Variables   common.py
 
-Library     Collections
 Library     acl.py
 Library     container.py
-Library     neofs.py
 Library     neofs_verbs.py
-Library     payment_neogo.py
+Library     utility_keywords.py
 
 Resource    eacl_tables.robot
 Resource    common_steps_acl_bearer.robot
@@ -29,12 +27,12 @@ BearerToken Operations with Filter UserHeader Equal
     ${WALLET}   ${_}     ${_} =   Prepare Wallet And Deposit
 
                             Log    Check Bearer token with simple object
-    ${FILE_S} =             Generate file    ${SIMPLE_OBJ_SIZE}
+    ${FILE_S}    ${_} =     Generate file    ${SIMPLE_OBJ_SIZE}
                             Check eACL Deny and Allow All Bearer Filter UserHeader Equal    ${WALLET}    ${FILE_S}
 
 
                             Log    Check Bearer token with complex object
-    ${FILE_S} =             Generate file    ${COMPLEX_OBJ_SIZE}
+    ${FILE_S}    ${_} =     Generate file    ${COMPLEX_OBJ_SIZE}
                             Check eACL Deny and Allow All Bearer Filter UserHeader Equal    ${WALLET}    ${FILE_S}
 
     [Teardown]              Teardown    acl_bearer_filter_userheader_equal

--- a/robot/testsuites/integration/acl/acl_bearer_filter_userheader_not_equal.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_filter_userheader_not_equal.robot
@@ -1,12 +1,10 @@
 *** Settings ***
 Variables   common.py
 
-Library     Collections
 Library     acl.py
 Library     container.py
-Library     neofs.py
 Library     neofs_verbs.py
-Library     payment_neogo.py
+Library     utility_keywords.py
 
 Resource    common_steps_acl_bearer.robot
 Resource    eacl_tables.robot
@@ -29,11 +27,11 @@ BearerToken Operations Filter UserHeader NotEqual
     ${WALLET}   ${_}     ${_} =   Prepare Wallet And Deposit
 
                             Log    Check Bearer token with simple object
-    ${FILE_S} =             Generate file    ${SIMPLE_OBJ_SIZE}
+    ${FILE_S}    ${_} =     Generate file    ${SIMPLE_OBJ_SIZE}
                             Check eACL Deny and Allow All Bearer Filter UserHeader NotEqual    ${WALLET}    ${FILE_S}
 
                             Log    Check Bearer token with complex object
-    ${FILE_S} =             Generate file    ${COMPLEX_OBJ_SIZE}
+    ${FILE_S}    ${_} =     Generate file    ${COMPLEX_OBJ_SIZE}
                             Check eACL Deny and Allow All Bearer Filter UserHeader NotEqual    ${WALLET}    ${FILE_S}
 
     [Teardown]              Teardown    acl_bearer_filter_userheader_not_equal

--- a/robot/testsuites/integration/acl/acl_bearer_inaccessible.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_inaccessible.robot
@@ -1,12 +1,10 @@
 *** Settings ***
 Variables   common.py
 
-Library     Collections
 Library     acl.py
 Library     container.py
-Library     neofs.py
 Library     neofs_verbs.py
-Library     payment_neogo.py
+Library     utility_keywords.py
 
 Resource    eacl_tables.robot
 Resource    common_steps_acl_bearer.robot
@@ -24,11 +22,11 @@ BearerToken Operations for Inaccessible Container
     ${WALLET}   ${_}     ${_} =   Prepare Wallet And Deposit
 
                             Log    Check Bearer token with simple object
-    ${FILE_S} =             Generate file    ${SIMPLE_OBJ_SIZE}
+    ${FILE_S}    ${_} =     Generate file    ${SIMPLE_OBJ_SIZE}
                             Check Container Inaccessible and Allow All Bearer    ${WALLET}    ${FILE_S}
 
                             Log    Check Bearer token with complex object
-    ${FILE_S} =             Generate file    ${COMPLEX_OBJ_SIZE}
+    ${FILE_S}    ${_} =     Generate file    ${COMPLEX_OBJ_SIZE}
                             Check Container Inaccessible and Allow All Bearer    ${WALLET}    ${FILE_S}
 
     [Teardown]              Teardown    acl_bearer_inaccessible

--- a/robot/testsuites/integration/acl/acl_bearer_request_filter_xheader_deny.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_request_filter_xheader_deny.robot
@@ -1,12 +1,10 @@
 *** Settings ***
 Variables   common.py
 
-Library     Collections
 Library     acl.py
 Library     container.py
-Library     neofs.py
 Library     neofs_verbs.py
-Library     payment_neogo.py
+Library     utility_keywords.py
 
 Resource    eacl_tables.robot
 Resource    common_steps_acl_bearer.robot
@@ -29,11 +27,11 @@ BearerToken Operations
     ${WALLET}   ${_}     ${_} =   Prepare Wallet And Deposit
 
                             Log    Check Bearer token with simple object
-    ${FILE_S} =             Generate file    ${SIMPLE_OBJ_SIZE}
+    ${FILE_S}    ${_} =     Generate file    ${SIMPLE_OBJ_SIZE}
                             Check eACL Allow All Bearer Filter Requst Equal Deny    ${WALLET}    ${FILE_S}
 
                             Log    Check Bearer token with complex object
-    ${FILE_S} =             Generate file    ${COMPLEX_OBJ_SIZE}
+    ${FILE_S}    ${_} =     Generate file    ${COMPLEX_OBJ_SIZE}
                             Check eACL Allow All Bearer Filter Requst Equal Deny    ${WALLET}    ${FILE_S}
 
     [Teardown]              Teardown    acl_bearer_request_filter_xheader_deny

--- a/robot/testsuites/integration/acl/acl_bearer_request_filter_xheader_equal.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_request_filter_xheader_equal.robot
@@ -1,12 +1,10 @@
 *** Settings ***
 Variables   common.py
 
-Library     Collections
 Library     acl.py
 Library     container.py
-Library     neofs.py
 Library     neofs_verbs.py
-Library     payment_neogo.py
+Library     utility_keywords.py
 
 Resource    eacl_tables.robot
 Resource    common_steps_acl_bearer.robot
@@ -29,11 +27,11 @@ BearerToken Operations with Filter Requst Equal
     ${WALLET}   ${_}     ${_} =   Prepare Wallet And Deposit
 
                             Log    Check Bearer token with simple object
-    ${FILE_S} =             Generate file    ${SIMPLE_OBJ_SIZE}
+    ${FILE_S}    ${_} =     Generate file    ${SIMPLE_OBJ_SIZE}
                             Check eACL Deny and Allow All Bearer Filter Requst Equal    ${WALLET}    ${FILE_S}
 
                             Log    Check Bearer token with complex object
-    ${FILE_S} =             Generate file    ${COMPLEX_OBJ_SIZE}
+    ${FILE_S}    ${_} =     Generate file    ${COMPLEX_OBJ_SIZE}
                             Check eACL Deny and Allow All Bearer Filter Requst Equal    ${WALLET}    ${FILE_S}
 
     [Teardown]              Teardown    acl_bearer_request_filter_xheader_equal

--- a/robot/testsuites/integration/acl/acl_bearer_request_filter_xheader_not_equal.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_request_filter_xheader_not_equal.robot
@@ -1,12 +1,10 @@
 *** Settings ***
 Variables   common.py
 
-Library     Collections
 Library     acl.py
 Library     container.py
-Library     neofs.py
 Library     neofs_verbs.py
-Library     payment_neogo.py
+Library     utility_keywords.py
 
 Resource    eacl_tables.robot
 Resource    common_steps_acl_bearer.robot
@@ -29,11 +27,11 @@ BearerToken Operations with Filter Requst NotEqual
     ${WALLET}    ${_}    ${_} =   Prepare Wallet And Deposit
 
                             Log    Check Bearer token with simple object
-    ${FILE_S} =             Generate file    ${SIMPLE_OBJ_SIZE}
+    ${FILE_S}    ${_} =     Generate file    ${SIMPLE_OBJ_SIZE}
                             Check eACL Deny and Allow All Bearer Filter Requst NotEqual    ${WALLET}    ${FILE_S}
 
                             Log    Check Bearer token with complex object
-    ${FILE_S} =             Generate file    ${COMPLEX_OBJ_SIZE}
+    ${FILE_S}    ${_} =     Generate file    ${COMPLEX_OBJ_SIZE}
                             Check eACL Deny and Allow All Bearer Filter Requst NotEqual    ${WALLET}    ${FILE_S}
 
     [Teardown]              Teardown    acl_bearer_request_filter_xheader_not_equal


### PR DESCRIPTION
- `Generate file` creating global variables replaced with `Generate file` creating non-global variables in tests for bearer acl
- Libraries that are no more necessary removed from those tests

#199
Signed-off-by: Elizaveta Chichindaeva <elizaveta@nspcc.ru>