### PR TITLE
Add non-global Generate File in acl_extended_*

### DIFF
--- a/robot/resources/lib/robot/common_steps_acl_extended.robot
+++ b/robot/resources/lib/robot/common_steps_acl_extended.robot
@@ -10,7 +10,6 @@ Library     neofs_verbs.py
 Library     Collections
 Library     String
 
-Resource    common_steps_acl_basic.robot
 Resource    payment_operations.robot
 
 *** Variables ***
@@ -21,15 +20,6 @@ ${OBJECT_PATH} =        testfile
 ${EACL_ERR_MSG} =       *
 
 *** Keywords ***
-
-Generate files
-    [Arguments]             ${SIZE}
-
-    ${FILE_S_GEN_1} =       Generate file of bytes    ${SIZE}
-    ${FILE_S_GEN_2} =       Generate file of bytes    ${SIZE}
-                            Set Global Variable       ${FILE_S}      ${FILE_S_GEN_1}
-                            Set Global Variable       ${FILE_S_2}    ${FILE_S_GEN_2}
-
 
 Check eACL Deny and Allow All
     [Arguments]     ${WALLET}    ${DENY_EACL}    ${ALLOW_EACL}    ${USER_WALLET}

--- a/robot/testsuites/integration/acl/acl_extended_actions_other.robot
+++ b/robot/testsuites/integration/acl/acl_extended_actions_other.robot
@@ -1,8 +1,7 @@
 *** Settings ***
 Variables    common.py
 
-Library     neofs.py
-Library     payment_neogo.py
+Library      utility_keywords.py
 
 Resource     common_steps_acl_extended.robot
 Resource     payment_operations.robot
@@ -21,11 +20,11 @@ Extended ACL Operations
     ${WALLET_OTH}   ${_}     ${_} =   Prepare Wallet And Deposit
 
                             Log    Check extended ACL with simple object
-    ${FILE_S} =             Generate file of bytes    ${SIMPLE_OBJ_SIZE}
+    ${FILE_S}    ${_} =     Generate file    ${SIMPLE_OBJ_SIZE}
                             Check eACL Deny and Allow All Other    ${WALLET}    ${WALLET_OTH}
 
                             Log    Check extended ACL with complex object
-    ${FILE_S} =             Generate file of bytes    ${COMPLEX_OBJ_SIZE}
+    ${FILE_S}    ${_} =     Generate file    ${COMPLEX_OBJ_SIZE}
                             Check eACL Deny and Allow All Other    ${WALLET}    ${WALLET_OTH}
 
     [Teardown]              Teardown    acl_extended_actions_other

--- a/robot/testsuites/integration/acl/acl_extended_actions_pubkey.robot
+++ b/robot/testsuites/integration/acl/acl_extended_actions_pubkey.robot
@@ -1,12 +1,10 @@
 *** Settings ***
 Variables    common.py
 
-Library      Collections
 Library      acl.py
 Library      container.py
-Library      neofs.py
 Library      neofs_verbs.py
-Library      payment_neogo.py
+Library      utility_keywords.py
 
 Resource     common_steps_acl_extended.robot
 Resource     payment_operations.robot
@@ -32,11 +30,11 @@ Extended ACL Operations
     ${WALLET_OTH}   ${_}     ${_} =   Prepare Wallet And Deposit
 
                             Log    Check extended ACL with simple object
-    ${FILE_S} =             Generate file of bytes    ${SIMPLE_OBJ_SIZE}
+    ${FILE_S}    ${_} =     Generate file    ${SIMPLE_OBJ_SIZE}
                             Check eACL Deny All Other and Allow All Pubkey    ${WALLET}    ${FILE_S}    ${WALLET_OTH}
 
                             Log    Check extended ACL with complex object
-    ${FILE_S} =             Generate file of bytes    ${COMPLEX_OBJ_SIZE}
+    ${FILE_S}    ${_} =     Generate file    ${COMPLEX_OBJ_SIZE}
                             Check eACL Deny All Other and Allow All Pubkey    ${WALLET}    ${FILE_S}    ${WALLET_OTH}
 
 

--- a/robot/testsuites/integration/acl/acl_extended_actions_system.robot
+++ b/robot/testsuites/integration/acl/acl_extended_actions_system.robot
@@ -1,12 +1,10 @@
 *** Settings ***
 Variables    common.py
 
-Library     Collections
 Library     acl.py
 Library     container.py
-Library     neofs.py
 Library     neofs_verbs.py
-Library     payment_neogo.py
+Library     utility_keywords.py
 
 Resource    common_steps_acl_extended.robot
 Resource    payment_operations.robot
@@ -29,11 +27,11 @@ Extended ACL Operations
     ${WALLET}   ${_}     ${_} =   Prepare Wallet And Deposit
 
                             Log    Check extended ACL with simple object
-    ${FILE_S} =             Generate file of bytes    ${SIMPLE_OBJ_SIZE}
+    ${FILE_S}    ${_} =     Generate file    ${SIMPLE_OBJ_SIZE}
                             Check eACL Deny and Allow All System    ${WALLET}    ${FILE_S}
 
                             Log    Check extended ACL with complex object
-    ${FILE_S} =             Generate file of bytes    ${COMPLEX_OBJ_SIZE}
+    ${FILE_S}    ${_} =     Generate file    ${COMPLEX_OBJ_SIZE}
                             Check eACL Deny and Allow All System    ${WALLET}    ${FILE_S}
 
     [Teardown]              Teardown    acl_extended_actions_system

--- a/robot/testsuites/integration/acl/acl_extended_actions_user.robot
+++ b/robot/testsuites/integration/acl/acl_extended_actions_user.robot
@@ -1,10 +1,7 @@
 *** Settings ***
 Variables    common.py
 
-Library     Collections
-Library     neofs.py
-Library     payment_neogo.py
-Library     acl.py
+Library      utility_keywords.py
 
 Resource     common_steps_acl_extended.robot
 Resource     payment_operations.robot
@@ -22,11 +19,11 @@ Extended ACL Operations
     ${WALLET}   ${_}     ${_} =   Prepare Wallet And Deposit
 
                             Log    Check extended ACL with simple object
-    ${FILE_S} =             Generate file of bytes    ${SIMPLE_OBJ_SIZE}
+    ${FILE_S}    ${_} =     Generate file    ${SIMPLE_OBJ_SIZE}
                             Check eACL Deny and Allow All User    ${WALLET}
 
                             Log    Check extended ACL with complex object
-    ${FILE_S} =             Generate file of bytes    ${COMPLEX_OBJ_SIZE}
+    ${FILE_S}    ${_} =     Generate file    ${COMPLEX_OBJ_SIZE}
                             Check eACL Deny and Allow All User    ${WALLET}
 
     [Teardown]              Teardown    acl_extended_action_user

--- a/robot/testsuites/integration/acl/acl_extended_compound.robot
+++ b/robot/testsuites/integration/acl/acl_extended_compound.robot
@@ -1,12 +1,10 @@
 *** Settings ***
 Variables    common.py
 
-Library     Collections
 Library     acl.py
 Library     container.py
-Library     neofs.py
 Library     neofs_verbs.py
-Library     payment_neogo.py
+Library     utility_keywords.py
 
 Resource     common_steps_acl_extended.robot
 Resource     payment_operations.robot
@@ -31,11 +29,11 @@ Extended ACL Operations
     ${WALLET_OTH}   ${_}     ${_} =   Prepare Wallet And Deposit
 
                             Log    Check extended ACL with simple object
-    ${FILE_S} =             Generate file of bytes    ${SIMPLE_OBJ_SIZE}
+    ${FILE_S}    ${_} =     Generate file    ${SIMPLE_OBJ_SIZE}
                             Check Сompound Operations    ${WALLET}    ${WALLET_OTH}    ${FILE_S}
 
                             Log    Check extended ACL with complex object
-    ${FILE_S} =             Generate file of bytes    ${COMPLEX_OBJ_SIZE}
+    ${FILE_S}    ${_} =     Generate file    ${COMPLEX_OBJ_SIZE}
                             Check Сompound Operations    ${WALLET}    ${WALLET_OTH}    ${FILE_S}
 
     [Teardown]      Teardown    acl_extended_compound

--- a/robot/testsuites/integration/acl/acl_extended_deny_replication.robot
+++ b/robot/testsuites/integration/acl/acl_extended_deny_replication.robot
@@ -5,11 +5,8 @@ Library     container.py
 Library     neofs.py
 Library     neofs_verbs.py
 Library     acl.py
-Library     payment_neogo.py
 Library     contract_keywords.py
-Library     wallet_keywords.py
-
-Library     Collections
+Library     utility_keywords.py
 
 Resource    eacl_tables.robot
 Resource    common_steps_acl_bearer.robot
@@ -38,8 +35,8 @@ eACL Deny Replication Operations
 
                         # https://github.com/nspcc-dev/neofs-node/issues/881
 
-    ${FILE} =           Generate file of bytes      ${SIMPLE_OBJ_SIZE}
-    ${CID} =            Create container            ${WALLET}    basic_acl=${PUBLIC_ACL}   rule=${FULL_PLACEMENT_RULE}
+    ${FILE}    ${_} =    Generate file      ${SIMPLE_OBJ_SIZE}
+    ${CID} =            Create container            ${WALLET}    basic_acl=eacl-public-read-write   rule=${FULL_PLACEMENT_RULE}
                         Prepare eACL Role rules     ${CID}
 
     ${OID} =            Put object    ${WALLET}    ${FILE}    ${CID}


### PR DESCRIPTION
- `Generate file` creating global variables replaced with `Generate file` creating non-global variables in `acl_extended_*` tests
- Libraries that are no more necessary removed from those tests
- `Generate files` removed

#199
Signed-off-by: Elizaveta Chichindaeva [elizaveta@nspcc.ru](mailto:elizaveta@nspcc.ru)