### PR TITLE
[#199] Add non-global Generate File for the rest of the tests

### DIFF
--- a/robot/resources/lib/python/utility_keywords.py
+++ b/robot/resources/lib/python/utility_keywords.py
@@ -15,19 +15,6 @@ from robot.libraries.BuiltIn import BuiltIn
 
 ROBOT_AUTO_KEYWORDS = False
 
-@keyword('Generate file of bytes')
-def generate_file_of_bytes(size: str) -> str:
-    """
-    Function generates big binary file with the specified size in bytes.
-    :param size:        the size in bytes, can be declared as 6e+6 for example
-    """
-    size = int(float(size))
-    filename = f"{os.getcwd()}/{ASSETS_DIR}/{uuid.uuid4()}"
-    with open(filename, 'wb') as fout:
-        fout.write(os.urandom(size))
-    logger.info(f"file with size {size} bytes has been generated: {filename}")
-    return filename
-
 @keyword('Generate file')
 def generate_file_and_file_hash(size: str) -> str:
     """
@@ -44,9 +31,28 @@ def generate_file_and_file_hash(size: str) -> str:
         fout.write(os.urandom(size))
     logger.info(f"file with size {size} bytes has been generated: {filename}")
 
-    file_hash = _get_file_hash(filename)
+    file_hash = get_file_hash(filename)
 
     return filename, file_hash
+
+
+@keyword('Get File Hash')
+def get_file_hash(filename: str):
+    """
+    This function generates hash for the specified file.
+    Args:
+        filename (str): the path to the file to generate hash for
+    Returns:
+        (str): the hash of the file
+    """
+    blocksize = 65536
+    file_hash = hashlib.md5()
+    with open(filename, "rb") as out:
+        for block in iter(lambda: out.read(blocksize), b""):
+            file_hash.update(block)
+    logger.info(f"Hash: {file_hash.hexdigest()}")
+    return file_hash.hexdigest()
+    
 
 @keyword('Get Docker Logs')
 def get_container_logs(testcase_name: str) -> None:
@@ -102,12 +108,3 @@ def make_down(services: list=[]):
         _cmd_run(cmd, timeout=60)
 
     os.chdir(test_path)
-
-def _get_file_hash(filename: str):
-    blocksize = 65536
-    file_hash = hashlib.md5()
-    with open(filename, "rb") as out:
-        for block in iter(lambda: out.read(blocksize), b""):
-            file_hash.update(block)
-    logger.info(f"Hash: {file_hash.hexdigest()}")
-    return file_hash.hexdigest()

--- a/robot/testsuites/integration/acl/object_attributes/creation_epoch_filter.robot
+++ b/robot/testsuites/integration/acl/object_attributes/creation_epoch_filter.robot
@@ -4,12 +4,9 @@ Variables       eacl_object_filters.py
 
 Library         acl.py
 Library         container.py
-Library         neofs.py
-Library         Collections
-Library         contract_keywords.py
+Library         utility_keywords.py
 
 Resource        common_steps_acl_extended.robot
-Resource        common_steps_acl_basic.robot
 Resource        payment_operations.robot
 Resource        setup_teardown.robot
 

--- a/robot/testsuites/integration/acl/object_attributes/object_id_filter.robot
+++ b/robot/testsuites/integration/acl/object_attributes/object_id_filter.robot
@@ -4,11 +4,9 @@ Variables       eacl_object_filters.py
 
 Library         acl.py
 Library         container.py
-Library         neofs.py
-Library         Collections
+Library         utility_keywords.py
 
 Resource        common_steps_acl_extended.robot
-Resource        common_steps_acl_basic.robot
 Resource        payment_operations.robot
 Resource        setup_teardown.robot
 

--- a/robot/testsuites/integration/acl/object_attributes/payload_length_filter.robot
+++ b/robot/testsuites/integration/acl/object_attributes/payload_length_filter.robot
@@ -4,11 +4,9 @@ Variables    eacl_object_filters.py
 
 Library     acl.py
 Library     container.py
-Library     neofs.py
-Library     Collections
+Library     utility_keywords.py
 
 Resource    common_steps_acl_extended.robot
-Resource    common_steps_acl_basic.robot
 Resource    payment_operations.robot
 Resource    setup_teardown.robot
 

--- a/robot/testsuites/integration/acl/storage_group/bearer_allow_sg.robot
+++ b/robot/testsuites/integration/acl/storage_group/bearer_allow_sg.robot
@@ -6,6 +6,7 @@ Library     acl.py
 Library     container.py
 Library     neofs.py
 Library     neofs_verbs.py
+Library     utility_keywords.py
 
 Resource    common_steps_acl_bearer.robot
 Resource    eacl_tables.robot

--- a/robot/testsuites/integration/network/netmap_control_drop.robot
+++ b/robot/testsuites/integration/network/netmap_control_drop.robot
@@ -3,13 +3,9 @@ Variables    common.py
 Variables    wellknown_acl.py
 
 Library     container.py
-Library     contract_keywords.py
 Library     neofs.py
 Library     neofs_verbs.py
-Library     payment_neogo.py
-
-Library     String
-Library     Process
+Library     utility_keywords.py
 
 Resource    setup_teardown.robot
 Resource    payment_operations.robot
@@ -27,12 +23,12 @@ Drop command in control group
     ${WALLET_STORAGE}    ${_} =          Prepare Wallet with WIF And Deposit    ${WIF_STORAGE}
     ${LOCODE} =         Get Locode
 
-    ${FILE_SIMPLE} =    Generate file of bytes    ${SIMPLE_OBJ_SIZE}
-    ${FILE_COMPLEX} =   Generate file of bytes    ${COMPLEX_OBJ_SIZE}
+    ${FILE_SIMPLE}    ${_} =    Generate file    ${SIMPLE_OBJ_SIZE}
+    ${FILE_COMPLEX}    ${_} =   Generate file    ${COMPLEX_OBJ_SIZE}
 
     ${WALLET}    ${_}    ${_} =    Prepare Wallet And Deposit
 
-    ${PRIV_CID} =       Create container             ${WALLET}    basic_acl=${PRIVATE_ACL_F}
+    ${PRIV_CID} =       Create Container    ${WALLET}
                         ...     rule=REP 1 CBF 1 SELECT 1 FROM * FILTER 'UN-LOCODE' EQ '${LOCODE}' AS LOC
 
     #########################

--- a/robot/testsuites/integration/network/netmap_simple.robot
+++ b/robot/testsuites/integration/network/netmap_simple.robot
@@ -4,9 +4,7 @@ Variables   common.py
 Library     container.py
 Library     neofs.py
 Library     neofs_verbs.py
-Library     payment_neogo.py
-Library     wallet_keywords.py
-Library     rpc_call_keywords.py
+Library     utility_keywords.py
 
 Resource    payment_operations.robot
 Resource    setup_teardown.robot
@@ -23,7 +21,7 @@ NeoFS Simple Netmap
     [Setup]             Setup
 
     ${WALLET}   ${_}    ${_} =    Prepare Wallet And Deposit
-    ${FILE} =          Generate file of bytes    ${SIMPLE_OBJ_SIZE}
+    ${FILE}    ${_} =          Generate file    ${SIMPLE_OBJ_SIZE}
 
     Validate Policy    ${WALLET}    ${FILE}    REP 2 IN X CBF 2 SELECT 2 FROM * AS X    2    @{EMPTY}
 

--- a/robot/testsuites/integration/network/replication.robot
+++ b/robot/testsuites/integration/network/replication.robot
@@ -3,12 +3,10 @@ Variables   common.py
 Variables   wellknown_acl.py
 
 Library     container.py
-Library     payment_neogo.py
 Library     neofs.py
 Library     neofs_verbs.py
-Library     wallet_keywords.py
-Library     rpc_call_keywords.py
 Library     contract_keywords.py
+Library     utility_keywords.py
 
 Library     Collections
 
@@ -41,8 +39,7 @@ Check Replication
     ${WALLET}   ${_}     ${_} =    Prepare Wallet And Deposit
     ${CID} =                Create Container    ${WALLET}    basic_acl=${ACL}
 
-    ${FILE} =               Generate file of bytes    ${SIMPLE_OBJ_SIZE}
-    ${FILE_HASH} =          Get file hash    ${FILE}
+    ${FILE}    ${_} =       Generate file    ${SIMPLE_OBJ_SIZE}
 
     ${S_OID} =              Put Object    ${WALLET}    ${FILE}    ${CID}
                             Validate storage policy for object    ${WALLET}    ${EXPECTED_COPIES}    ${CID}    ${S_OID}

--- a/robot/testsuites/integration/object/object_attributes.robot
+++ b/robot/testsuites/integration/object/object_attributes.robot
@@ -3,10 +3,8 @@ Variables   common.py
 Variables   wellknown_acl.py
 
 Library     container.py
-Library     neofs.py
 Library     neofs_verbs.py
-Library     payment_neogo.py
-Library     String
+Library     utility_keywords.py
 Library     Collections
 
 Resource    setup_teardown.robot
@@ -30,7 +28,7 @@ Duplicated Object Attributes
     ${WALLET}   ${_}     ${_} =    Prepare Wallet And Deposit
 
     ${PUBLIC_CID} =             Create Container       ${WALLET}    basic_acl=${PUBLIC_ACL_F}
-    ${FILE_S} =                 Generate file of bytes            ${SIMPLE_OBJ_SIZE}
+    ${FILE_S}    ${_} =         Generate File    ${SIMPLE_OBJ_SIZE}
 
 
     ###################################################

--- a/robot/testsuites/integration/object/object_complex.robot
+++ b/robot/testsuites/integration/object/object_complex.robot
@@ -4,9 +4,9 @@ Variables   common.py
 Library     neofs_verbs.py
 Library     complex_object_actions.py
 Library     neofs.py
-Library     payment_neogo.py
 Library     contract_keywords.py
 Library     Collections
+Library     utility_keywords.py
 
 Resource    common_steps_object.robot
 Resource    setup_teardown.robot
@@ -30,8 +30,7 @@ NeoFS Complex Object Operations
     ${WALLET}   ${ADDR}     ${WIF} =   Prepare Wallet And Deposit
     ${CID} =            Prepare container       ${WIF}    ${WALLET}
 
-    ${FILE} =           Generate file of bytes              ${COMPLEX_OBJ_SIZE}
-    ${FILE_HASH} =      Get file hash                       ${FILE}
+    ${FILE}    ${FILE_HASH} =    Generate file    ${COMPLEX_OBJ_SIZE}
 
     ${S_OID} =          Put object                 ${WALLET}    ${FILE}       ${CID}
     ${H_OID} =          Put object                 ${WALLET}    ${FILE}       ${CID}        user_headers=${FILE_USR_HEADER}

--- a/robot/testsuites/integration/object/object_expiration.robot
+++ b/robot/testsuites/integration/object/object_expiration.robot
@@ -1,10 +1,9 @@
 *** Settings ***
 Variables   common.py
 
-Library     neofs.py
 Library     neofs_verbs.py
-Library     payment_neogo.py
 Library     contract_keywords.py
+Library     utility_keywords.py
 
 Resource    common_steps_object.robot
 Resource    setup_teardown.robot
@@ -24,9 +23,7 @@ NeoFS Simple Object Operations
     ${WALLET}   ${_}     ${WIF} =   Prepare Wallet And Deposit
     ${CID} =    Prepare container      ${WIF}    ${WALLET}
 
-    ${FILE} =           Generate file of bytes    ${SIMPLE_OBJ_SIZE}
-    ${FILE_HASH} =      Get file hash    ${FILE}
-
+    ${FILE}    ${FILE_HASH} =    Generate File    ${SIMPLE_OBJ_SIZE}
     ${EPOCH} =          Get Epoch
 
     ${EPOCH_PRE} =      Evaluate    ${EPOCH}-1

--- a/robot/testsuites/integration/object/object_simple.robot
+++ b/robot/testsuites/integration/object/object_simple.robot
@@ -3,9 +3,9 @@ Variables   common.py
 
 Library     neofs.py
 Library     neofs_verbs.py
-Library     payment_neogo.py
 Library     contract_keywords.py
 Library     Collections
+Library     utility_keywords.py
 
 Resource    common_steps_object.robot
 Resource    payment_operations.robot
@@ -28,9 +28,7 @@ NeoFS Simple Object Operations
     ${WALLET}   ${ADDR}     ${WIF} =   Prepare Wallet And Deposit
     ${CID} =    Prepare container      ${WIF}    ${WALLET}
 
-    ${FILE} =           Generate file of bytes              ${SIMPLE_OBJ_SIZE}
-    ${FILE_HASH} =      Get file hash                       ${FILE}
-
+    ${FILE}    ${FILE_HASH} =    Generate file    ${SIMPLE_OBJ_SIZE}
 
     ${S_OID} =          Put object          ${WALLET}    ${FILE}       ${CID}
     ${H_OID} =          Put object          ${WALLET}    ${FILE}       ${CID}      user_headers=${FILE_USR_HEADER}

--- a/robot/testsuites/integration/object/storage_group/sg_of_complex_objects.robot
+++ b/robot/testsuites/integration/object/storage_group/sg_of_complex_objects.robot
@@ -5,6 +5,7 @@ Library     neofs.py
 Library     neofs_verbs.py
 Library     storage_group.py
 Library     Collections
+Library     utility_keywords.py
 
 Resource    common_steps_object.robot
 Resource    setup_teardown.robot
@@ -25,7 +26,7 @@ NeoFS Complex Storagegroup
     ${WALLET}   ${_}     ${WIF} =   Prepare Wallet And Deposit
     ${CID} =            Prepare container    ${WIF}    ${WALLET}
 
-    ${FILE} =           Generate file of bytes     ${COMPLEX_OBJ_SIZE}
+    ${FILE}    ${_} =    Generate file    ${COMPLEX_OBJ_SIZE}
 
     ${OID_1} =          Put object    ${WALLET}    ${FILE}    ${CID}
     ${OID_2} =          Put object    ${WALLET}    ${FILE}    ${CID}

--- a/robot/testsuites/integration/object/storage_group/sg_of_simple_objects.robot
+++ b/robot/testsuites/integration/object/storage_group/sg_of_simple_objects.robot
@@ -1,10 +1,9 @@
 *** Settings ***
 Variables   common.py
 
-Library     neofs.py
 Library     neofs_verbs.py
-Library     payment_neogo.py
 Library     storage_group.py
+Library     utility_keywords.py
 
 Resource    common_steps_object.robot
 Resource    setup_teardown.robot
@@ -25,7 +24,7 @@ NeoFS Simple Storagegroup
     ${WALLET}   ${_}     ${WIF} =   Prepare Wallet And Deposit
     ${CID} =            Prepare container      ${WIF}    ${WALLET}
 
-    ${FILE_S} =         Generate file of bytes            ${SIMPLE_OBJ_SIZE}
+    ${FILE_S}    ${_} =    Generate file            ${SIMPLE_OBJ_SIZE}
 
     ${OID_1} =          Put object    ${WALLET}    ${FILE_S}    ${CID}
     ${OID_2} =          Put object    ${WALLET}    ${FILE_S}    ${CID}

--- a/robot/testsuites/integration/services/http_gate.robot
+++ b/robot/testsuites/integration/services/http_gate.robot
@@ -6,6 +6,7 @@ Library     container.py
 Library     neofs.py
 Library     neofs_verbs.py
 Library     http_gate.py
+Library     utility_keywords.py
 
 Resource    payment_operations.robot
 Resource    setup_teardown.robot
@@ -24,11 +25,9 @@ NeoFS HTTP Gateway
                         Make Up    ${INCLUDE_SVC}
 
     ${WALLET}   ${_}     ${_} =   Prepare Wallet And Deposit
-    ${CID} =            Create container                    ${WALLET}    rule=${PLACEMENT_RULE}  basic_acl=${PUBLIC_ACL}
-    ${FILE} =           Generate file of bytes              ${SIMPLE_OBJ_SIZE}
-    ${FILE_L} =         Generate file of bytes              ${COMPLEX_OBJ_SIZE}
-    ${FILE_HASH} =      Get file hash                       ${FILE}
-    ${FILE_L_HASH} =    Get file hash                       ${FILE_L}
+    ${CID} =    Create container                    ${WALLET}    rule=${PLACEMENT_RULE}  basic_acl=${PUBLIC_ACL}
+    ${FILE}    ${HASH} =    Generate file    ${SIMPLE_OBJ_SIZE}
+    ${FILE_L}    ${L_HASH} =    Generate file    ${COMPLEX_OBJ_SIZE}
 
     ${S_OID} =          Put object                 ${WALLET}    ${FILE}      ${CID}
     ${L_OID} =          Put object                 ${WALLET}    ${FILE_L}    ${CID}
@@ -43,8 +42,8 @@ NeoFS HTTP Gateway
 
     ${PLAIN_FILE_HASH} =    Get file hash       ${GET_OBJ_S}
     ${GATE_FILE_HASH} =     Get file hash       ${FILEPATH}
-                            Should Be Equal     ${FILE_HASH}      ${PLAIN_FILE_HASH}
-                            Should Be Equal     ${FILE_HASH}      ${GATE_FILE_HASH}
+                            Should Be Equal     ${HASH}      ${PLAIN_FILE_HASH}
+                            Should Be Equal     ${HASH}      ${GATE_FILE_HASH}
 
     @{GET_NODE_LIST} =  Get nodes without object            ${WALLET}    ${CID}    ${L_OID}
     ${NODE} =           Evaluate                            random.choice($GET_NODE_LIST)    random
@@ -54,7 +53,7 @@ NeoFS HTTP Gateway
 
     ${PLAIN_FILE_HASH} =    Get file hash       ${GET_OBJ_L}
     ${GATE_FILE_HASH} =     Get file hash       ${FILEPATH}
-                            Should Be Equal     ${FILE_L_HASH}      ${PLAIN_FILE_HASH}
-                            Should Be Equal     ${FILE_L_HASH}      ${GATE_FILE_HASH}
+                            Should Be Equal     ${L_HASH}      ${PLAIN_FILE_HASH}
+                            Should Be Equal     ${L_HASH}      ${GATE_FILE_HASH}
 
     [Teardown]          Teardown    http_gate

--- a/robot/testsuites/integration/services/s3_gate_bucket.robot
+++ b/robot/testsuites/integration/services/s3_gate_bucket.robot
@@ -7,6 +7,7 @@ Library     OperatingSystem
 Library     neofs.py
 Library     s3_gate.py
 Library     contract_keywords.py
+Library     utility_keywords.py
 
 Resource    setup_teardown.robot
 Resource    payment_operations.robot
@@ -23,7 +24,7 @@ Buckets in NeoFS S3 Gateway
                                 Make Up    ${INCLUDE_SVC}
 
     ${WALLET}   ${_}    ${WIF} =        Prepare Wallet And Deposit
-    ${FILE_S3} =                        Generate file of bytes      ${COMPLEX_OBJ_SIZE}
+    ${FILE_S3}    ${_} =    Generate file    ${COMPLEX_OBJ_SIZE}
     ${_}        ${S3_OBJECT_KEY} =      Split Path                  ${FILE_S3}
 
     ${CID}

--- a/robot/testsuites/integration/services/s3_gate_object.robot
+++ b/robot/testsuites/integration/services/s3_gate_object.robot
@@ -8,6 +8,7 @@ Library     container.py
 Library     neofs.py
 Library     s3_gate.py
 Library     contract_keywords.py
+Library     utility_keywords.py
 
 Resource    payment_operations.robot
 Resource    setup_teardown.robot
@@ -26,8 +27,7 @@ Objects in NeoFS S3 Gateway
 
     ${WALLET}   ${_}    ${_} =    Prepare Wallet And Deposit
 
-    ${FILE_S3} =                Generate file of bytes    ${COMPLEX_OBJ_SIZE}
-    ${FILE_S3_HASH} =           Get file hash             ${FILE_S3}
+    ${FILE_S3}    ${FILE_S3_HASH} =    Generate file    ${COMPLEX_OBJ_SIZE}
     ${_}    ${S3_OBJECT_KEY} =  Split Path                ${FILE_S3}
 
     ${CID}


### PR DESCRIPTION
- `neofs.py` checked with pylint
- `Generate file of bytes` removed from `utility_keywords.py` (replaced with `Generate file`)
- `Get File Hash` added into `utility_keywords.py`
- `Generate file` creating global variables replaced with `Generate file` creating non-global variables in `network/`, `object/`, `services/` tests
- Libraries that are no more necessary removed from those tests

#199 
Signed-off-by: Elizaveta Chichindaeva <elizaveta@nspcc.ru>