### PR TITLE
[#184]: keywords for nodes management put into separate library

### DIFF
--- a/robot/resources/lib/python/nodes_management.py
+++ b/robot/resources/lib/python/nodes_management.py
@@ -1,0 +1,47 @@
+#!/usr/bin/python3
+
+"""
+    This module contains keywords for management test stand
+    nodes. It assumes that nodes are docker containers.
+"""
+
+import random
+
+import docker
+
+from robot.api.deco import keyword
+
+ROBOT_AUTO_KEYWORDS = False
+
+@keyword('Stop Nodes')
+def stop_nodes(number: int, nodes: list):
+    """
+        The function shuts down the given number of randomly
+        selected nodes in docker.
+        Args:
+           number (int): the number of nodes to shut down
+           nodes (list): the list of nodes for possible shut down
+        Returns:
+            (list): the list of nodes which have been shut down
+    """
+    nodes = random.sample(nodes, number)
+    client = docker.APIClient()
+    for node in nodes:
+        node = node.split('.')[0]
+        client.stop(node)
+    return nodes
+
+
+@keyword('Start Nodes')
+def start_nodes(nodes: list):
+    """
+        The function raises the given nodes.
+        Args:
+           nodes (list): the list of nodes to raise
+        Returns:
+            (void)
+    """
+    client = docker.APIClient()
+    for node in nodes:
+        node = node.split('.')[0]
+        client.start(node)

--- a/robot/resources/lib/python/storage_policy.py
+++ b/robot/resources/lib/python/storage_policy.py
@@ -77,3 +77,49 @@ def get_complex_object_copies(wallet: str, cid: str, oid: str):
     """
     last_oid = complex_object_actions.get_last_object(wallet, cid, oid)
     return get_simple_object_copies(wallet, cid, last_oid)
+
+
+@keyword('Get Nodes With Object')
+def get_nodes_with_object(wallet: str, cid: str, oid: str):
+    """
+       The function returns list of nodes which store
+       the given object.
+       Args:
+            wallet (str): the path to the wallet on whose behalf
+                        we request the nodes
+            cid (str): ID of the container which store the object
+            oid (str): object ID
+       Returns:
+            (list): nodes which store the object
+    """
+    nodes_list = []
+    for node in NEOFS_NETMAP:
+        res = neofs_verbs.head_object(wallet, cid, oid,
+                        endpoint=node,
+                        is_direct=True)
+        if res is not None:
+            nodes_list.append(node)
+    return nodes_list
+
+
+@keyword('Get Nodes Without Object')
+def get_nodes_without_object(wallet: str, cid: str, oid: str):
+    """
+       The function returns list of nodes which do not store
+       the given object.
+       Args:
+            wallet (str): the path to the wallet on whose behalf
+                        we request the nodes
+            cid (str): ID of the container which store the object
+            oid (str): object ID
+       Returns:
+            (list): nodes which do not store the object
+    """
+    nodes_list = []
+    for node in NEOFS_NETMAP:
+        res = neofs_verbs.head_object(wallet, cid, oid,
+                        endpoint=node,
+                        is_direct=True)
+        if res is None:
+            nodes_list.append(node)
+    return nodes_list

--- a/robot/testsuites/integration/network/netmap_simple.robot
+++ b/robot/testsuites/integration/network/netmap_simple.robot
@@ -1,8 +1,5 @@
 *** Settings ***
-Variables   common.py
-
 Library     container.py
-Library     neofs.py
 Library     neofs_verbs.py
 Library     storage_policy.py
 Library     utility_keywords.py

--- a/robot/testsuites/integration/network/replication.robot
+++ b/robot/testsuites/integration/network/replication.robot
@@ -4,8 +4,8 @@ Variables   wellknown_acl.py
 
 Library     container.py
 Library     contract_keywords.py
-Library     neofs.py
 Library     neofs_verbs.py
+Library     nodes_management.py
 Library     storage_policy.py
 Library     utility_keywords.py
 
@@ -46,10 +46,9 @@ Check Replication
     ${COPIES} =             Get Object Copies   Simple      ${WALLET}   ${CID}  ${S_OID}
                             Should Be Equal     ${EXPECTED_COPIES}  ${COPIES}
 
-    @{NODES_OBJ} =          Get nodes with Object    ${WALLET}    ${CID}    ${S_OID}
-    ${NODES_LOG_TIME} =     Get Nodes Log Latest Timestamp
+    @{NODES_OBJ} =          Get Nodes With Object    ${WALLET}    ${CID}    ${S_OID}
 
-    @{NODES_OBJ_STOPPED} =  Stop nodes          1       ${NODES_OBJ}
+    @{NODES_OBJ_STOPPED} =  Stop Nodes          1       ${NODES_OBJ}
     @{NETMAP} =             Convert To List             ${NEOFS_NETMAP}
                             Remove Values From List     ${NETMAP}   ${NODES_OBJ_STOPPED}
 
@@ -65,8 +64,7 @@ Check Replication
     Run Keyword Unless      ${PASSED}     Fail
     ...     Storage policy for object ${S_OID} in container ${CID} isn't valid
 
-    Find in Nodes Log       object successfully replicated    ${NODES_LOG_TIME}
-    Start nodes             ${NODES_OBJ_STOPPED}
+    Start Nodes             ${NODES_OBJ_STOPPED}
     Tick Epoch
 
     # We have 2 or 3 copies. Expected behaviour: during two epochs potential 3rd copy should be removed.

--- a/robot/testsuites/integration/services/http_gate.robot
+++ b/robot/testsuites/integration/services/http_gate.robot
@@ -6,6 +6,7 @@ Library     container.py
 Library     neofs.py
 Library     neofs_verbs.py
 Library     http_gate.py
+Library     storage_policy.py
 Library     utility_keywords.py
 
 Resource    payment_operations.robot


### PR DESCRIPTION
- removed logs check in replication test, accordingly removed `Get Nodes Log Latest Timestamp` and `Find in Nodes Log` keywords
- `Get nodes with object` and `Get nodes without object` moved to `storage_policy.py` library
- `Stop Nodes` and `Start Nodes` moved to the separate `nodes_management.py` library