### PR TITLE
Remove wif from the output of Get Control Endpoint

### DIFF
--- a/robot/resources/lib/python_keywords/neofs.py
+++ b/robot/resources/lib/python_keywords/neofs.py
@@ -57,22 +57,31 @@ def verify_head_tombstone(wallet_path: str, cid: str, oid_ts: str, oid: str):
                               msg="Header Session OID is wrong")
 
 
-@keyword('Get control endpoint with wif')
-def get_control_endpoint_with_wif(endpoint_number: str = ''):
+@keyword('Get control endpoint and wallet')
+def get_control_endpoint_and_wallet(endpoint_number: str = ''):
+    """
+        Gets control endpoint for a random or given node
+
+        Args:
+            endpoint_number (optional, str): the number of the node
+                                        in the form of 's01', 's02', etc.
+                                        given in NEOFS_NETMAP_DICT as keys 
+        Returns:
+            (str): the number of the node
+            (str): endpoint control for the node
+            (str): the wallet of the respective node
+    """    
     if endpoint_number == '':
-        netmap = []
-        for key in NEOFS_NETMAP_DICT.keys():
-            netmap.append(key)
-        endpoint_num = random.sample(netmap, 1)[0]
+        endpoint_num = random.choice(list(NEOFS_NETMAP_DICT.keys()))
         logger.info(f'Random node chosen: {endpoint_num}')
     else:
         endpoint_num = endpoint_number
 
     endpoint_values = NEOFS_NETMAP_DICT[f'{endpoint_num}']
     endpoint_control = endpoint_values['control']
-    wif = endpoint_values['wif']
+    wlt = endpoint_values['wallet_path']
 
-    return endpoint_num, endpoint_control, wif
+    return endpoint_num, endpoint_control, wlt
 
 
 @keyword('Get Locode')

--- a/robot/testsuites/integration/acl/acl_extended_deny_replication.robot
+++ b/robot/testsuites/integration/acl/acl_extended_deny_replication.robot
@@ -27,8 +27,7 @@ eACL Deny Replication Operations
 
     [Setup]                 Setup
 
-    ${_}     ${NODE}    ${WIF_STORAGE} =     Get control endpoint with wif
-    ${WALLET_STORAGE}    ${_} =    Prepare Wallet with WIF And Deposit    ${WIF_STORAGE}
+    ${_}    ${NODE}    ${STORAGE_WALLET} =    Get control endpoint and wallet
 
     ${WALLET}    ${_}    ${_} =    Prepare Wallet And Deposit
 
@@ -49,13 +48,13 @@ eACL Deny Replication Operations
                         ...  Put object    ${WALLET}    ${FILE}    ${CID}
 
                         # Drop object to check replication
-                        Drop object    ${NODE}    ${WALLET_STORAGE}    ${CID}    ${OID}
+                        Drop object    ${NODE}    ${STORAGE_WALLET}    ${CID}    ${OID}
 
                         Tick Epoch
                         Sleep   ${NEOFS_CONTRACT_CACHE_TIMEOUT}
 
                         # We assume that during one epoch object should be replicated
-    ${COPIES} =         Get Object Copies   Simple      ${WALLET_STORAGE}   ${CID}  ${OID}
+    ${COPIES} =         Get Object Copies   Simple      ${STORAGE_WALLET}   ${CID}  ${OID}
                         Should Be Equal As Numbers      ${EXPECTED_COPIES}  ${COPIES}
                         ...     msg="Dropped object should be replicated in one epoch"
 

--- a/robot/testsuites/integration/network/netmap_control.robot
+++ b/robot/testsuites/integration/network/netmap_control.robot
@@ -18,37 +18,36 @@ Control Operations with storage nodes
 
     [Setup]                 Setup
 
-    ${NODE_NUM}    ${NODE}    ${WIF} =     Get control endpoint with wif
-    ${WALLET_STORAGE}    ${ADDR_STORAGE} =    Prepare Wallet with WIF And Deposit    ${WIF}     
+    ${NODE_NUM}    ${NODE}    ${STORAGE_WALLET} =    Get control endpoint and wallet
     ${empty_list} =         Create List
 
-    ${SNAPSHOT} =           Run Process    ${NEOFS_CLI_EXEC} control netmap-snapshot --endpoint ${NODE} --wallet ${WALLET_STORAGE} --config ${WALLET_CONFIG}    shell=True
-    ${HEALTHCHECK} =        Run Process    ${NEOFS_CLI_EXEC} control healthcheck --endpoint ${NODE} --wallet ${WALLET_STORAGE} --config ${WALLET_CONFIG}    shell=True
+    ${SNAPSHOT} =           Run Process    ${NEOFS_CLI_EXEC} control netmap-snapshot --endpoint ${NODE} --wallet ${STORAGE_WALLET} --config ${WALLET_CONFIG}    shell=True
+    ${HEALTHCHECK} =        Run Process    ${NEOFS_CLI_EXEC} control healthcheck --endpoint ${NODE} --wallet ${STORAGE_WALLET} --config ${WALLET_CONFIG}    shell=True
                             Should Be Equal As Integers    ${HEALTHCHECK.rc}    0
 
-                            Run Process    ${NEOFS_CLI_EXEC} control set-status --endpoint ${NODE} --wallet ${WALLET_STORAGE} --config ${WALLET_CONFIG} --status 'offline'    shell=True
+                            Run Process    ${NEOFS_CLI_EXEC} control set-status --endpoint ${NODE} --wallet ${STORAGE_WALLET} --config ${WALLET_CONFIG} --status 'offline'    shell=True
                             
                             Sleep    ${MAINNET_BLOCK_TIME}
                             Tick Epoch
 
-    ${SNAPSHOT_OFFLINE}=    Run Process    ${NEOFS_CLI_EXEC} control netmap-snapshot --endpoint ${NODE} --wallet ${WALLET_STORAGE} --config ${WALLET_CONFIG}    shell=True
+    ${SNAPSHOT_OFFLINE}=    Run Process    ${NEOFS_CLI_EXEC} control netmap-snapshot --endpoint ${NODE} --wallet ${STORAGE_WALLET} --config ${WALLET_CONFIG}    shell=True
     ${NODE_NUM_OFFLINE}=    Get Regexp Matches        ${SNAPSHOT_OFFLINE.stdout}    ${NODE_NUM}
                             Should Be Equal    ${NODE_NUM_OFFLINE}    ${empty_list}
 
-    ${HEALTHCHECK_OFFLINE} =    Run Process    ${NEOFS_CLI_EXEC} control healthcheck --endpoint ${NODE} --wallet ${WALLET_STORAGE} --config ${WALLET_CONFIG}    shell=True
+    ${HEALTHCHECK_OFFLINE} =    Run Process    ${NEOFS_CLI_EXEC} control healthcheck --endpoint ${NODE} --wallet ${STORAGE_WALLET} --config ${WALLET_CONFIG}    shell=True
                             Should Be Equal As Integers    ${HEALTHCHECK_OFFLINE.rc}    0
                             Should Not Be Equal    ${HEALTHCHECK.stdout}    ${HEALTHCHECK_OFFLINE.stdout} 
     
-                            Run Process    ${NEOFS_CLI_EXEC} control set-status --endpoint ${NODE} --wallet ${WALLET_STORAGE} --config ${WALLET_CONFIG} --status 'online'    shell=True
+                            Run Process    ${NEOFS_CLI_EXEC} control set-status --endpoint ${NODE} --wallet ${STORAGE_WALLET} --config ${WALLET_CONFIG} --status 'online'    shell=True
 
                             Sleep    ${MAINNET_BLOCK_TIME}
                             Tick Epoch
 
-    ${SNAPSHOT_ONLINE} =    Run Process    ${NEOFS_CLI_EXEC} control netmap-snapshot --endpoint ${NODE} --wallet ${WALLET_STORAGE} --config ${WALLET_CONFIG}    shell=True
+    ${SNAPSHOT_ONLINE} =    Run Process    ${NEOFS_CLI_EXEC} control netmap-snapshot --endpoint ${NODE} --wallet ${STORAGE_WALLET} --config ${WALLET_CONFIG}    shell=True
     ${NODE_NUM_ONLINE} =    Get Regexp Matches        ${SNAPSHOT_ONLINE.stdout}    ${NODE_NUM}    
                             Should Be Equal    ${NODE_NUM_ONLINE}[0]    ${NODE_NUM}
 
-    ${HEALTHCHECK_ONLINE} =    Run Process    ${NEOFS_CLI_EXEC} control healthcheck --endpoint ${NODE} --wallet ${WALLET_STORAGE} --config ${WALLET_CONFIG}    shell=True
+    ${HEALTHCHECK_ONLINE} =    Run Process    ${NEOFS_CLI_EXEC} control healthcheck --endpoint ${NODE} --wallet ${STORAGE_WALLET} --config ${WALLET_CONFIG}    shell=True
                             Should Be Equal As Integers    ${HEALTHCHECK_ONLINE.rc}    0
                             Should Be Equal    ${HEALTHCHECK.stdout}    ${HEALTHCHECK_ONLINE.stdout}    
 

--- a/robot/testsuites/integration/network/netmap_control_drop.robot
+++ b/robot/testsuites/integration/network/netmap_control_drop.robot
@@ -19,8 +19,7 @@ Drop command in control group
 
     [Setup]                 Setup
 
-    ${_}    ${NODE}    ${WIF_STORAGE} =     Get control endpoint with wif
-    ${WALLET_STORAGE}    ${_} =          Prepare Wallet with WIF And Deposit    ${WIF_STORAGE}
+    ${_}    ${NODE}    ${STORAGE_WALLET}=     Get control endpoint and wallet
     ${LOCODE} =         Get Locode
 
     ${FILE_SIMPLE}    ${_} =    Generate file    ${SIMPLE_OBJ_SIZE}
@@ -39,7 +38,7 @@ Drop command in control group
                         Get object    ${WALLET}    ${PRIV_CID}    ${S_OID}    ${EMPTY}    s_file_read
                         Head object    ${WALLET}    ${PRIV_CID}    ${S_OID}
 
-                        Drop object    ${NODE}    ${WALLET_STORAGE}    ${PRIV_CID}    ${S_OID}
+                        Drop object    ${NODE}    ${STORAGE_WALLET}    ${PRIV_CID}    ${S_OID}
 
                         Wait Until Keyword Succeeds    3x    ${SHARD_0_GC_SLEEP}
                         ...  Run Keyword And Expect Error    Error:*
@@ -48,7 +47,7 @@ Drop command in control group
                         ...  Run Keyword And Expect Error    Error:*
                         ...  Head object    ${WALLET}    ${PRIV_CID}    ${S_OID}    options=--ttl 1
 
-                        Drop object    ${NODE}    ${WALLET_STORAGE}    ${PRIV_CID}    ${S_OID}
+                        Drop object    ${NODE}    ${STORAGE_WALLET}    ${PRIV_CID}    ${S_OID}
 
     ##########################
     # Dropping complex object
@@ -58,14 +57,14 @@ Drop command in control group
                         Get object    ${WALLET}    ${PRIV_CID}    ${C_OID}    ${EMPTY}    s_file_read
                         Head object    ${WALLET}    ${PRIV_CID}    ${C_OID}
 
-                        Drop object    ${NODE}    ${WALLET_STORAGE}    ${PRIV_CID}    ${C_OID}
+                        Drop object    ${NODE}    ${STORAGE_WALLET}    ${PRIV_CID}    ${C_OID}
 
                         Get object    ${WALLET}    ${PRIV_CID}    ${C_OID}    ${EMPTY}    s_file_read
                         Head object    ${WALLET}    ${PRIV_CID}    ${C_OID}
 
     @{SPLIT_OIDS} =     Get Object Parts By Link Object    ${WALLET}    ${PRIV_CID}   ${C_OID}
     FOR    ${CHILD_OID}    IN    @{SPLIT_OIDS}
-        Drop object    ${NODE}    ${WALLET_STORAGE}    ${PRIV_CID}    ${CHILD_OID}
+        Drop object    ${NODE}    ${STORAGE_WALLET}    ${PRIV_CID}    ${CHILD_OID}
 
     END
 

--- a/robot/variables/common.py
+++ b/robot/variables/common.py
@@ -46,21 +46,22 @@ STORAGE_NODE_2 = os.getenv('DATA_NODE_2', 's02.neofs.devenv:8080')
 STORAGE_NODE_3 = os.getenv('DATA_NODE_3', 's03.neofs.devenv:8080')
 STORAGE_NODE_4 = os.getenv('DATA_NODE_4', 's04.neofs.devenv:8080')
 
+DEVENV_SERVICES_PATH = f"{os.getenv('DEVENV_PATH')}/services"
 NEOFS_NETMAP_DICT = {'s01': {'rpc': STORAGE_NODE_1,
                              'control': 's01.neofs.devenv:8081',
-                             'wif': 'Kwk6k2eC3L3QuPvD8aiaNyoSXgQ2YL1bwS5CP1oKoA9waeAze97s',
+                             'wallet_path':f"{DEVENV_SERVICES_PATH}/storage/wallet01.json",
                              'UN-LOCODE': 'RU MOW'},
                      's02': {'rpc': STORAGE_NODE_2,
                              'control': 's02.neofs.devenv:8081',
-                             'wif': 'L1NdHdnrTNGQZH1fJSrdUZJyeYFHvaQSSHZHxhK3udiGFdr5YaZ6',
+                             'wallet_path': f"{DEVENV_SERVICES_PATH}/storage/wallet02.json",
                              'UN-LOCODE': 'RU LED'},
                      's03': {'rpc': STORAGE_NODE_3,
                              'control': 's03.neofs.devenv:8081',
-                             'wif': 'KzN38k39af6ACWJjK8YrnARWo86ddcc1EuBWz7xFEdcELcP3ZTym',
+                             'wallet_path': f"{DEVENV_SERVICES_PATH}/storage/wallet03.json",
                              'UN-LOCODE': 'SE STO'},
                      's04': {'rpc': STORAGE_NODE_4,
                              'control': 's04.neofs.devenv:8081',
-                             'wif': 'Kzk1Z3dowAqfNyjqeYKWenZMduFV3NAKgXg9K1sA4jRKYxEc8HEW',
+                             'wallet_path': f"{DEVENV_SERVICES_PATH}/storage/wallet04.json",
                              'UN-LOCODE': 'FI HEL'}
                      }
 NEOFS_NETMAP = [i['rpc'] for i in NEOFS_NETMAP_DICT.values()]
@@ -68,11 +69,11 @@ NEOGO_EXECUTABLE = os.getenv('NEOGO_EXECUTABLE', 'neo-go')
 NEOFS_CLI_EXEC = os.getenv('NEOFS_CLI_EXEC', 'neofs-cli')
 
 WALLET_CONFIG = f"{os.getcwd()}/neofs_cli_configs/empty_passwd.yml"
-MAINNET_WALLET_PATH = f"{os.getenv('DEVENV_PATH')}/services/chain/node-wallet.json"
+MAINNET_WALLET_PATH = f"{DEVENV_SERVICES_PATH}/chain/node-wallet.json"
 MAINNET_WALLET_CONFIG = f"{os.getcwd()}/neofs_cli_configs/mainnet_wallet_passwd.yml"
 MAINNET_SINGLE_ADDR = 'NfgHwwTi3wHAS8aFAN243C5vGbkYDpqLHP'
 MAINNET_WALLET_PASS = 'one'
-IR_WALLET_PATH = f"{os.getenv('DEVENV_PATH')}/services/ir/wallet01.json"
+IR_WALLET_PATH = f"{DEVENV_SERVICES_PATH}/ir/wallet01.json"
 IR_WALLET_CONFIG = f"{os.getcwd()}/neofs_cli_configs/ir_wallet_passwd.yml"
 IR_WALLET_PASS = 'one'
-STORAGE_WALLET_PATH = f"{os.getenv('DEVENV_PATH')}/services/storage/wallet01.json"
+STORAGE_WALLET_PATH = f"{DEVENV_SERVICES_PATH}/storage/wallet01.json"


### PR DESCRIPTION
Since we try to avoid WIFs as much as possible, I offer not to return `wif` while getting endpoint control (as we don't need it to initiate a wallet for a storage node). 

Signed-off-by: Elizaveta Chichindaeva <elizaveta@nspcc.ru>
[logs.zip](https://github.com/nspcc-dev/neofs-testcases/files/8976152/logs.zip)

