### PR TITLE
[#191] Remove EACL_KEY

### DIFF
--- a/robot/resources/files/eacl_tables/gen_eacl_allow_pubkey_deny_OTHERS
+++ b/robot/resources/files/eacl_tables/gen_eacl_allow_pubkey_deny_OTHERS
@@ -7,7 +7,7 @@
             "targets": [
                 {
                     "keys": [
-                        "A9tDy6Ye+UimXCCzJrlAmRE0FDZHjf3XRyya9rELtgAA"
+                        "foo"
                     ]
                 }
             ]
@@ -19,7 +19,7 @@
             "targets": [
                 {
                     "keys": [
-                        "A9tDy6Ye+UimXCCzJrlAmRE0FDZHjf3XRyya9rELtgAA"
+                        "foo"
                     ]
                 }
             ]
@@ -31,7 +31,7 @@
             "targets": [
                 {
                     "keys": [
-                        "A9tDy6Ye+UimXCCzJrlAmRE0FDZHjf3XRyya9rELtgAA"
+                        "foo"
                     ]
                 }
             ]
@@ -43,7 +43,7 @@
             "targets": [
                 {
                     "keys": [
-                        "A9tDy6Ye+UimXCCzJrlAmRE0FDZHjf3XRyya9rELtgAA"
+                        "foo"
                     ]
                 }
             ]
@@ -55,7 +55,7 @@
             "targets": [
                 {
                     "keys": [
-                        "A9tDy6Ye+UimXCCzJrlAmRE0FDZHjf3XRyya9rELtgAA"
+                        "foo"
                     ]
                 }
             ]
@@ -67,7 +67,7 @@
             "targets": [
                 {
                     "keys": [
-                        "A9tDy6Ye+UimXCCzJrlAmRE0FDZHjf3XRyya9rELtgAA"
+                        "foo"
                     ]
                 }
             ]
@@ -79,7 +79,7 @@
             "targets": [
                 {
                     "keys": [
-                        "A9tDy6Ye+UimXCCzJrlAmRE0FDZHjf3XRyya9rELtgAA"
+                        "foo"
                     ]
                 }
             ]

--- a/robot/testsuites/integration/acl/acl_extended_actions_pubkey.robot
+++ b/robot/testsuites/integration/acl/acl_extended_actions_pubkey.robot
@@ -12,7 +12,6 @@ Resource     setup_teardown.robot
 Resource     eacl_tables.robot
 
 *** Variables ***
-${EACL_KEY} =   L1FGTLE6shum3EC7mNTPArUqSCKnmtEweRzyuawtYRZwGjpeRuw1
 &{USER_HEADER} =        key1=1      key2=abc
 &{USER_HEADER_DEL} =    key1=del    key2=del
 &{ANOTHER_HEADER} =     key1=oth    key2=oth
@@ -48,19 +47,19 @@ Check eACL Deny All Other and Allow All Pubkey
     ${CID} =                Create Container           ${USER_WALLET}     basic_acl=eacl-public-read-write
     ${S_OID_USER} =         Put object                 ${USER_WALLET}     ${FILE_S}        ${CID}    user_headers=${USER_HEADER}
     ${D_OID_USER} =         Put object                 ${USER_WALLET}     ${FILE_S}        ${CID}    user_headers=${USER_HEADER_DEL}
-    @{S_OBJ_H} =	    Create List	               ${S_OID_USER}
+    @{S_OBJ_H} =	        Create List	               ${S_OID_USER}
 
-    ${WALLET_EACL}    ${_} =    Prepare Wallet with WIF And Deposit    ${EACL_KEY}
+    ${WALLET_ALLOW}    ${_}    ${_} =    Prepare Wallet And Deposit
 
-                            Put object                  ${WALLET_EACL}    ${FILE_S}     ${CID}       user_headers=${ANOTHER_HEADER}
-                            Get object                  ${WALLET_EACL}    ${CID}        ${S_OID_USER}            ${EMPTY}            local_file_eacl
-                            Search object               ${WALLET_EACL}    ${CID}        ${EMPTY}                 ${EMPTY}            ${USER_HEADER}        ${S_OBJ_H}
-                            Head object                 ${WALLET_EACL}    ${CID}        ${S_OID_USER}
-                            Get Range                   ${WALLET_EACL}    ${CID}        ${S_OID_USER}            s_get_range         ${EMPTY}            0:256
-                            Get Range Hash              ${WALLET_EACL}    ${CID}        ${S_OID_USER}            ${EMPTY}            0:256
-                            Delete object               ${WALLET_EACL}    ${CID}        ${D_OID_USER}
+                            Put object                  ${WALLET_ALLOW}    ${FILE_S}     ${CID}       user_headers=${ANOTHER_HEADER}
+                            Get object                  ${WALLET_ALLOW}    ${CID}        ${S_OID_USER}            ${EMPTY}            local_file_eacl
+                            Search object               ${WALLET_ALLOW}    ${CID}        ${EMPTY}                 ${EMPTY}            ${USER_HEADER}        ${S_OBJ_H}
+                            Head object                 ${WALLET_ALLOW}    ${CID}        ${S_OID_USER}
+                            Get Range                   ${WALLET_ALLOW}    ${CID}        ${S_OID_USER}            s_get_range         ${EMPTY}            0:256
+                            Get Range Hash              ${WALLET_ALLOW}    ${CID}        ${S_OID_USER}            ${EMPTY}            0:256
+                            Delete object               ${WALLET_ALLOW}    ${CID}        ${D_OID_USER}
 
-                            Set eACL                    ${USER_WALLET}    ${CID}        ${EACL_ALLOW_ALL_Pubkey}
+                            Set eACL                    ${USER_WALLET}    ${CID}        ${EACL_ALLOW_ALL_Pubkey}    ${WALLET_ALLOW}
 
                             # The current ACL cache lifetime is 30 sec
                             Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}
@@ -82,10 +81,10 @@ Check eACL Deny All Other and Allow All Pubkey
                             Run Keyword And Expect Error        *
                             ...  Delete object                       ${WALLET_OTH}    ${CID}        ${S_OID_USER}
 
-                            Put object              ${WALLET_EACL}    ${FILE_S}     ${CID}    user_headers=${ANOTHER_HEADER}
-                            Get object              ${WALLET_EACL}    ${CID}        ${S_OID_USER}           ${EMPTY}            local_file_eacl
-                            Search object           ${WALLET_EACL}    ${CID}        ${EMPTY}                ${EMPTY}            ${USER_HEADER}     ${S_OBJ_H}
-                            Head object             ${WALLET_EACL}    ${CID}        ${S_OID_USER}
-                            Get Range               ${WALLET_EACL}    ${CID}        ${S_OID_USER}           s_get_range         ${EMPTY}            0:256
-                            Get Range Hash          ${WALLET_EACL}    ${CID}        ${S_OID_USER}           ${EMPTY}            0:256
-                            Delete object           ${WALLET_EACL}    ${CID}        ${S_OID_USER}
+                            Put object              ${WALLET_ALLOW}    ${FILE_S}     ${CID}    user_headers=${ANOTHER_HEADER}
+                            Get object              ${WALLET_ALLOW}    ${CID}        ${S_OID_USER}           ${EMPTY}            local_file_eacl
+                            Search object           ${WALLET_ALLOW}    ${CID}        ${EMPTY}                ${EMPTY}            ${USER_HEADER}     ${S_OBJ_H}
+                            Head object             ${WALLET_ALLOW}    ${CID}        ${S_OID_USER}
+                            Get Range               ${WALLET_ALLOW}    ${CID}        ${S_OID_USER}           s_get_range         ${EMPTY}            0:256
+                            Get Range Hash          ${WALLET_ALLOW}    ${CID}        ${S_OID_USER}           ${EMPTY}            0:256
+                            Delete object           ${WALLET_ALLOW}    ${CID}        ${S_OID_USER}


### PR DESCRIPTION
- `EACL_KEY` removed
- `robot/resources/files/eacl_tables/gen_eacl_allow_pubkey_deny_OTHERS` serves as a template
- variable names `wif` replaced with `wlt`

Signed-off-by: Elizaveta Chichindaeva <elizaveta@nspcc.ru>
[log_acl_extended_actions_pubkey.zip](https://github.com/nspcc-dev/neofs-testcases/files/9019094/log_acl_extended_actions_pubkey.zip)

