### PR TITLE
Cleanup pytest fixtures

### DIFF
--- a/pytest_tests/helpers/utility.py
+++ b/pytest_tests/helpers/utility.py
@@ -1,6 +1,5 @@
 import os
 import uuid
-from typing import List
 
 from common import ASSETS_DIR, SIMPLE_OBJ_SIZE
 
@@ -30,7 +29,7 @@ def get_file_content(file_path: str) -> str:
     return content
 
 
-def split_file(file_path: str, parts: int) -> List[str]:
+def split_file(file_path: str, parts: int) -> list[str]:
     files = []
     with open(file_path, 'rb') as in_file:
         data = in_file.read()

--- a/pytest_tests/testsuites/conftest.py
+++ b/pytest_tests/testsuites/conftest.py
@@ -2,23 +2,19 @@ import logging
 import os
 import shutil
 from re import search
-from time import sleep
 
 import allure
 import pytest
 from robot.api import deco
 
-import rpc_client
 import wallet
 from cli_helpers import _cmd_run
-from common import (ASSETS_DIR, COMMON_PLACEMENT_RULE, CONTROL_NODE_USER, CONTROL_NODE_PWD,
-                    FREE_STORAGE, MAINNET_WALLET_PATH, NEO_MAINNET_ENDPOINT, REMOTE_HOST)
+from common import ASSETS_DIR, FREE_STORAGE, MAINNET_WALLET_PATH
 from payment_neogo import neofs_deposit, transfer_mainnet_gas
-from python_keywords.container import create_container
-from ssh_helper import HostClient
-from wellknown_acl import PUBLIC_ACL
 
-deco.keyword = allure.step
+def robot_keyword_adapter(name=None, tags=(), types=()):
+    return allure.step(name)
+deco.keyword = robot_keyword_adapter
 
 logger = logging.getLogger('NeoLogger')
 
@@ -55,65 +51,12 @@ def init_wallet_with_address():
 @pytest.fixture(scope='session')
 @allure.title('Prepare wallet and deposit')
 def prepare_wallet_and_deposit(init_wallet_with_address):
-    local_wallet_path = None
     wallet, addr, _ = init_wallet_with_address
     logger.info(f'Init wallet: {wallet},\naddr: {addr}')
 
-    if REMOTE_HOST:
-        ssh_client = HostClient(REMOTE_HOST, CONTROL_NODE_USER, CONTROL_NODE_PWD)
-        local_wallet_path = os.path.join(ASSETS_DIR, os.path.basename(MAINNET_WALLET_PATH))
-        ssh_client.copy_file_from_host(MAINNET_WALLET_PATH, local_wallet_path)
-
     if not FREE_STORAGE:
         deposit = 30
-        transfer_mainnet_gas(wallet, deposit + 1, wallet_path=local_wallet_path or MAINNET_WALLET_PATH)
+        transfer_mainnet_gas(wallet, deposit + 1, wallet_path=MAINNET_WALLET_PATH)
         neofs_deposit(wallet, deposit)
 
     return wallet
-
-
-@pytest.fixture()
-@allure.title('Create Container')
-def prepare_container(prepare_wallet_and_deposit):
-    wallet = prepare_wallet_and_deposit
-    return prepare_container_impl(wallet)
-
-
-@pytest.fixture(scope='module')
-@allure.title('Create Public Container')
-def prepare_public_container(prepare_wallet_and_deposit):
-    placement_rule = 'REP 1 IN X CBF 1 SELECT 1 FROM * AS X'
-    wallet = prepare_wallet_and_deposit
-    return prepare_container_impl(wallet, rule=placement_rule, basic_acl=PUBLIC_ACL)
-
-
-def prepare_container_impl(wallet: str, rule=COMMON_PLACEMENT_RULE, basic_acl: str = ''):
-    cid = create_container(wallet, rule=rule, basic_acl=basic_acl)
-    return cid, wallet
-
-
-@allure.step('Wait until transaction accepted in block')
-def wait_until_transaction_accepted_in_block(tx_id: str):
-    """
-    This function return True in case of accepted TX.
-    Parameters:
-    :param tx_id:           transaction ID
-    """
-    mainnet_rpc_cli = rpc_client.RPCClient(NEO_MAINNET_ENDPOINT)
-
-    if isinstance(tx_id, bytes):
-        tx_id = tx_id.decode()
-
-    sleep_interval, attempts = 5, 10
-
-    for __attempt in range(attempts):
-        try:
-            resp = mainnet_rpc_cli.get_transaction_height(tx_id)
-            if resp is not None:
-                logger.info(f"got block height: {resp}")
-                return True
-        except Exception as e:
-            logger.info(f"request failed with error: {e}")
-            raise e
-        sleep(sleep_interval)
-    raise TimeoutError(f'Timeout {sleep_interval * attempts} sec. reached on waiting for transaction accepted')

--- a/pytest_tests/testsuites/object/test_object_api.py
+++ b/pytest_tests/testsuites/object/test_object_api.py
@@ -3,8 +3,9 @@ from time import sleep
 
 import allure
 import pytest
+from container import create_container
 from epoch import tick_epoch
-from python_keywords.neofs import verify_head_tombstone
+from tombstone import verify_head_tombstone
 from python_keywords.neofs_verbs import (delete_object, get_object, get_range,
                                          get_range_hash, head_object,
                                          put_object, search_object)
@@ -19,8 +20,9 @@ CLEANUP_TIMEOUT = 10
 @allure.title('Test native object API')
 @pytest.mark.sanity
 @pytest.mark.grpc_api
-def test_object_api(prepare_container):
-    cid, wallet = prepare_container
+def test_object_api(prepare_wallet_and_deposit):
+    wallet = prepare_wallet_and_deposit
+    cid = create_container(wallet)
     wallet_cid = {'wallet': wallet, 'cid': cid}
     file_usr_header = {'key1': 1, 'key2': 'abc'}
     file_usr_header_oth = {'key1': 2}

--- a/robot/resources/lib/python_keywords/data_formatters.py
+++ b/robot/resources/lib/python_keywords/data_formatters.py
@@ -1,16 +1,8 @@
-"""
-    A bunch of functions which might rearrange some data or
-    change their representation.
-"""
 
-from functools import reduce
-
-
-def dict_to_attrs(attrs: dict):
+def dict_to_attrs(attrs: dict) -> str:
     """
-    This function takes dictionary of object attributes and converts them
-    into the string. The string is passed to `--attributes` key of the
-    neofs-cli.
+    This function takes a dictionary of object's attributes and converts them
+    into string. The string is passed to `--attributes` key of neofs-cli.
 
     Args:
         attrs (dict): object attributes in {"a": "b", "c": "d"} format.
@@ -18,4 +10,4 @@ def dict_to_attrs(attrs: dict):
     Returns:
         (str): string in "a=b,c=d" format.
     """
-    return reduce(lambda a, b: f"{a},{b}", map(lambda i: f"{i}={attrs[i]}", attrs))
+    return ",".join(f"{key}={value}" for key, value in attrs.items())

--- a/robot/resources/lib/python_keywords/epoch.py
+++ b/robot/resources/lib/python_keywords/epoch.py
@@ -1,32 +1,20 @@
 #!/usr/bin/python3.9
 
-
 import contract
-import sys
 from robot.api import logger
 from robot.api.deco import keyword
-from robot.libraries.BuiltIn import BuiltIn
+
+from common import IR_WALLET_PATH, IR_WALLET_PASS, MORPH_ENDPOINT
 
 ROBOT_AUTO_KEYWORDS = False
-
-if "pytest" in sys.modules:
-    import os
-
-    IR_WALLET_PATH = os.getenv("IR_WALLET_PATH")
-    IR_WALLET_PASS = os.getenv("IR_WALLET_PASS")
-    SIDECHAIN_EP = os.getenv("MORPH_ENDPOINT")
-else:
-    IR_WALLET_PATH = BuiltIn().get_variable_value("${IR_WALLET_PATH}")
-    IR_WALLET_PASS = BuiltIn().get_variable_value("${IR_WALLET_PASS}")
-    SIDECHAIN_EP = BuiltIn().get_variable_value("${MORPH_ENDPOINT}")
 
 
 @keyword('Get Epoch')
 def get_epoch():
     epoch = int(contract.testinvoke_contract(
-        contract.get_netmap_contract_hash(SIDECHAIN_EP),
-        'epoch',
-        SIDECHAIN_EP)
+        contract.get_netmap_contract_hash(MORPH_ENDPOINT),
+        "epoch",
+        MORPH_ENDPOINT)
     )
     logger.info(f"Got epoch {epoch}")
     return epoch
@@ -36,6 +24,6 @@ def get_epoch():
 def tick_epoch():
     cur_epoch = get_epoch()
     return contract.invoke_contract_multisig(
-        contract.get_netmap_contract_hash(SIDECHAIN_EP),
+        contract.get_netmap_contract_hash(MORPH_ENDPOINT),
         f"newEpoch int:{cur_epoch+1}",
-        IR_WALLET_PATH, IR_WALLET_PASS, SIDECHAIN_EP)
+        IR_WALLET_PATH, IR_WALLET_PASS, MORPH_ENDPOINT)

--- a/robot/resources/lib/python_keywords/s3_gate_object.py
+++ b/robot/resources/lib/python_keywords/s3_gate_object.py
@@ -1,9 +1,9 @@
-#!/usr/bin/python3
+#!/usr/bin/python3.9
 
 import os
 import uuid
 from enum import Enum
-from typing import Optional, List
+from typing import Optional
 
 import urllib3
 from botocore.exceptions import ClientError
@@ -196,7 +196,7 @@ def create_multipart_upload_s3(s3_client, bucket_name: str, object_key: str) -> 
 
 
 @keyword('List multipart uploads S3')
-def list_multipart_uploads_s3(s3_client, bucket_name: str) -> Optional[List[dict]]:
+def list_multipart_uploads_s3(s3_client, bucket_name: str) -> Optional[list[dict]]:
     try:
         response = s3_client.list_multipart_uploads(Bucket=bucket_name)
         log_command_execution('S3 List multipart upload', response)
@@ -240,7 +240,7 @@ def upload_part_s3(s3_client, bucket_name: str, object_key: str, upload_id: str,
 
 
 @keyword('List parts S3')
-def list_parts_s3(s3_client, bucket_name: str, object_key: str, upload_id: str) -> List[dict]:
+def list_parts_s3(s3_client, bucket_name: str, object_key: str, upload_id: str) -> list[dict]:
     try:
         response = s3_client.list_parts(UploadId=upload_id, Bucket=bucket_name, Key=object_key)
         log_command_execution('S3 List part', response)

--- a/robot/variables/common.py
+++ b/robot/variables/common.py
@@ -28,8 +28,6 @@ GAS_HASH = '0xd2a4cff31913016155e38e474a2c06d08be276cf'
 
 NEOFS_CONTRACT = os.getenv("NEOFS_IR_CONTRACTS_NEOFS")
 
-COMMON_PLACEMENT_RULE = "REP 2 IN X CBF 1 SELECT 4 FROM * AS X"
-
 ASSETS_DIR = os.getenv("ASSETS_DIR", "TemporaryDir/")
 
 MORPH_MAGIC = os.getenv("MORPH_MAGIC")
@@ -74,6 +72,5 @@ STORAGE_WALLET_PATH = f"{DEVENV_SERVICES_PATH}/storage/wallet01.json"
 
 CONTROL_NODE_USER = os.getenv('CONTROL_NODE_USER', 'root')
 CONTROL_NODE_PWD = os.getenv('CONTROL_NODE_PWD')
-REMOTE_HOST = os.getenv('REMOTE_HOST')
 
 FREE_STORAGE = os.getenv('FREE_STORAGE', "false").lower() == "true"


### PR DESCRIPTION
Replace prepare_container*** fixtures with a function.
The change is motivated by variety of standard ACLs that will be hard to manage with set of fixtures.

Remove logic that initializes wallet from remote devenv host.
This setup action should be handled outside tests.

Add ability to establish SSH connection using SSH key instead of password.
