### PR TITLE
updated `requirements.txt` for venv.localtest

### DIFF
--- a/venv/localtest/requirements.txt
+++ b/venv/localtest/requirements.txt
@@ -6,3 +6,13 @@ docker==4.4.0
 botocore==1.19.33
 urllib3==1.26.3
 base58==2.1.0
+robotframework==4.1.2
+requests==2.25.1
+pexpect==4.8.0
+boto3==1.16.33
+docker==4.4.0
+botocore==1.19.33
+urllib3==1.26.3
+base58==2.1.0
+allure-pytest==2.9.45
+pytest==7.1.2


### PR DESCRIPTION
As pytest dependencies (like `allure`) are included into the common test libraries, we need to install them into the `venv.localtest`. It's difficult to install the deps from inside the venv, so the decision is to copy all the pytest deps.

Signed-off-by: anastasia prasolova <anastasia@nspcc.ru>