### PR TITLE
Remove unnecessary args in Get Range

### DIFF
--- a/pytest_tests/testsuites/object/test_object_api.py
+++ b/pytest_tests/testsuites/object/test_object_api.py
@@ -52,7 +52,7 @@ def test_object_api(prepare_wallet_and_deposit):
     with allure.step('Get range/range hash'):
         get_range_hash(**wallet_cid, oid=oids[0], bearer_token='', range_cut=range_cut)
         get_range_hash(**wallet_cid, oid=oids[1], bearer_token='', range_cut=range_cut)
-        get_range(**wallet_cid, oid=oids[1], file_path='s_get_range', bearer='', range_cut=range_cut)
+        get_range(**wallet_cid, oid=oids[1], bearer='', range_cut=range_cut)
 
     with allure.step('Search objects'):
         search_object(**wallet_cid, expected_objects_list=oids)

--- a/robot/resources/lib/python_keywords/neofs_verbs.py
+++ b/robot/resources/lib/python_keywords/neofs_verbs.py
@@ -150,11 +150,9 @@ def delete_object(wallet: str, cid: str, oid: str, bearer: str = "", wallet_conf
     return tombstone.strip()
 
 
-# TODO: remove `file_path` parameter as it is a boilerplate
-# TODO: make `bearer` an optional parameter
 @keyword('Get Range')
-def get_range(wallet: str, cid: str, oid: str, file_path: str, bearer: str, range_cut: str,
-              wallet_config: str = WALLET_CONFIG, options: str = ""):
+def get_range(wallet: str, cid: str, oid: str, range_cut: str,
+              wallet_config: str = WALLET_CONFIG, bearer: str = "", options: str = ""):
     """
     GETRANGE an Object.
 
@@ -162,7 +160,6 @@ def get_range(wallet: str, cid: str, oid: str, file_path: str, bearer: str, rang
         wallet (str): wallet on whose behalf GETRANGE is done
         cid (str): ID of Container where we get the Object from
         oid (str): ID of Object we are going to request
-        file_path (str): file path
         range_cut (str): range to take data from in the form offset:length
         bearer (optional, str): path to Bearer Token file, appends to `--bearer` key
         wallet_config(optional, str): path to the wallet config

--- a/robot/resources/lib/robot/common_steps_acl_extended.robot
+++ b/robot/resources/lib/robot/common_steps_acl_extended.robot
@@ -35,7 +35,7 @@ Check eACL Deny and Allow All
                             Search object       ${WALLET}    ${CID}         ${EMPTY}         ${EMPTY}    ${USER_HEADER}    ${S_OBJ_H}
                             Head object         ${WALLET}    ${CID}         ${S_OID_USER}
 
-                            Get Range           ${WALLET}    ${CID}         ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+                            Get Range           ${WALLET}    ${CID}         ${S_OID_USER}    0:256
                             Get Range Hash      ${WALLET}    ${CID}         ${S_OID_USER}    ${EMPTY}    0:256
                             Delete object       ${WALLET}    ${CID}         ${D_OID_USER}
 
@@ -53,7 +53,7 @@ Check eACL Deny and Allow All
                             Run Keyword And Expect Error        *
                             ...  Head object                         ${WALLET}    ${CID}       ${S_OID_USER}
                             Run Keyword And Expect Error        *
-                            ...  Get Range                           ${WALLET}    ${CID}       ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+                            ...  Get Range                           ${WALLET}    ${CID}       ${S_OID_USER}    0:256
                             Run Keyword And Expect Error        *
                             ...  Get Range Hash                      ${WALLET}    ${CID}       ${S_OID_USER}    ${EMPTY}    0:256
                             Run Keyword And Expect Error        *
@@ -68,7 +68,7 @@ Check eACL Deny and Allow All
                             Get object        ${WALLET}    ${CID}        ${S_OID_USER}     ${EMPTY}    local_file_eacl
                             Search object     ${WALLET}    ${CID}        ${EMPTY}          ${EMPTY}    ${USER_HEADER}    ${S_OBJ_H}
                             Head object       ${WALLET}    ${CID}        ${S_OID_USER}
-                            Get Range         ${WALLET}    ${CID}        ${S_OID_USER}     s_get_range    ${EMPTY}    0:256
+                            Get Range         ${WALLET}    ${CID}        ${S_OID_USER}     0:256
                             Get Range Hash    ${WALLET}    ${CID}        ${S_OID_USER}     ${EMPTY}    0:256
                             Delete object     ${WALLET}    ${CID}        ${S_OID_USER}
 
@@ -107,7 +107,7 @@ Check eACL Filters with MatchType String Equal
                         Get Object          ${WALLET_OTH}    ${CID}    ${S_OID_USER}    ${EMPTY}    local_file_eacl
                         Search Object       ${WALLET_OTH}    ${CID}    ${EMPTY}    ${EMPTY}    ${USER_HEADER}    ${S_OBJ_H}
     &{HEADER} =         Head Object         ${WALLET_OTH}    ${CID}    ${S_OID_USER}
-                        Get Range           ${WALLET_OTH}    ${CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+                        Get Range           ${WALLET_OTH}    ${CID}    ${S_OID_USER}    0:256
                         Get Range Hash      ${WALLET_OTH}    ${CID}    ${S_OID_USER}    ${EMPTY}    0:256
                         Delete Object       ${WALLET_OTH}    ${CID}    ${D_OID_USER}
 
@@ -135,7 +135,7 @@ Check eACL Filters with MatchType String Equal
     END
     IF    'RANGE' in ${VERB_FILTER_DEP}[${FILTER}]
         Run Keyword And Expect error    ${EACL_ERR_MSG}
-        ...  Get Range    ${WALLET_OTH}    ${CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+        ...  Get Range    ${WALLET_OTH}    ${CID}    ${S_OID_USER}    0:256
     END
     IF    'SEARCH' in ${VERB_FILTER_DEP}[${FILTER}]
         Run Keyword And Expect Error   ${EACL_ERR_MSG}
@@ -167,7 +167,7 @@ Check eACL Filters with MatchType String Not Equal
                         Get Object      ${WALLET}    ${CID}    ${S_OID_USER}    ${EMPTY}    local_file_eacl
     &{HEADER} =         Head Object     ${WALLET}    ${CID}    ${S_OID_USER}
                         Search Object   ${WALLET}    ${CID}    ${EMPTY}    ${EMPTY}    ${USER_HEADER}    ${S_OBJ_H}
-                        Get Range       ${WALLET}    ${CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+                        Get Range       ${WALLET}    ${CID}    ${S_OID_USER}    0:256
                         Get Range Hash  ${WALLET}    ${CID}    ${S_OID_USER}    ${EMPTY}    0:256
 
     ${K}    ${V} =      Split String            ${FILTER}    :
@@ -201,8 +201,8 @@ Check eACL Filters with MatchType String Not Equal
     END
     IF    'RANGE' in ${VERB_FILTER_DEP}[${FILTER}]
         Run Keyword And Expect error    ${EACL_ERR_MSG}
-        ...  Get Range    ${WALLET_OTH}    ${CID}    ${S_OID_OTH}    s_get_range    ${EMPTY}    0:256
-        Get Range    ${WALLET_OTH}    ${CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+        ...  Get Range    ${WALLET_OTH}    ${CID}    ${S_OID_OTH}    0:256
+        Get Range    ${WALLET_OTH}    ${CID}    ${S_OID_USER}    0:256
     END
     IF    'RANGEHASH' in ${VERB_FILTER_DEP}[${FILTER}]
         Run Keyword And Expect error    ${EACL_ERR_MSG}

--- a/robot/resources/lib/robot/verbs.robot
+++ b/robot/resources/lib/robot/verbs.robot
@@ -33,17 +33,15 @@ Run All Verbs Except Delete And Expect Success
         ...             Get file hash       ${OBJ_PATH}
                         Should Be Equal     ${DOWNLOADED_FILE_HASH}   ${FILE_HASH}
 
-    # TODO: get rid of ${EMPTY}
     ${RANGE_FILE}
     ...     ${DATA_RANGE} =
-    ...                 Get Range           ${WALLET}    ${CID}    ${OID}   file_path=${EMPTY}
+    ...                 Get Range           ${WALLET}    ${CID}    ${OID}
                                             ...     bearer=${BEARER_TOKEN}
                                             ...     range_cut=0:10
                                             ...     options=${REQUEST_HEADERS}
     ${FILE_CONTENT} =   Get Binary File     ${FILE}
                         Should Contain      ${FILE_CONTENT}     ${DATA_RANGE}
 
-    # TODO: get rid of ${EMPTY}
     ${RANGE_HASH} =     Get Range Hash      ${WALLET}    ${CID}    ${OID}
                                             ...     bearer_token=${BEARER_TOKEN}
                                             ...     range_cut=0:10
@@ -97,9 +95,8 @@ Run All Verbs And Expect Failure
                 ...     Get object      ${WALLET}   ${CID}       ${OID}
                 Should Contain          ${ERR}    ${ERROR}
 
-    # TODO: get rid of ${EMPTY}
     ${ERR} =    Run Keyword And Expect Error       *
-                ...     Get Range       ${WALLET}   ${CID}    ${OID}   ${EMPTY}    ${EMPTY}   0:10
+                ...     Get Range       ${WALLET}   ${CID}    ${OID}   0:10
                 Should Contain          ${ERR}    ${ERROR}
 
     # TODO: get rid of ${EMPTY}

--- a/robot/testsuites/integration/acl/acl_basic_private_container.robot
+++ b/robot/testsuites/integration/acl/acl_basic_private_container.robot
@@ -67,13 +67,13 @@ Check Private Container
                         Get Object         ${STORAGE_WALLET_PATH}    ${PRIV_CID}    ${S_OID_USER}    ${EMPTY}      s_file_read
 
     # Get Range
-                        Get Range         ${USER_WALLET}    ${PRIV_CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+                        Get Range         ${USER_WALLET}    ${PRIV_CID}    ${S_OID_USER}    0:256
                         Run Keyword And Expect Error        *
-                        ...  Get Range    ${WALLET_OTH}    ${PRIV_CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+                        ...  Get Range    ${WALLET_OTH}    ${PRIV_CID}    ${S_OID_USER}    0:256
                         Run Keyword And Expect Error        *
-                        ...  Get Range    ${IR_WALLET_PATH}    ${PRIV_CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256    wallet_config=${IR_WALLET_CONFIG}
+                        ...  Get Range    ${IR_WALLET_PATH}    ${PRIV_CID}    ${S_OID_USER}    0:256    wallet_config=${IR_WALLET_CONFIG}
                         Run Keyword And Expect Error        *
-                        ...  Get Range    ${STORAGE_WALLET_PATH}    ${PRIV_CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+                        ...  Get Range    ${STORAGE_WALLET_PATH}    ${PRIV_CID}    ${S_OID_USER}    0:256
 
     # Get Range Hash
                         Get Range hash         ${USER_WALLET}    ${PRIV_CID}    ${S_OID_USER}    ${EMPTY}    0:256

--- a/robot/testsuites/integration/acl/acl_basic_public_container.robot
+++ b/robot/testsuites/integration/acl/acl_basic_public_container.robot
@@ -59,12 +59,12 @@ Check Public Container
                             Get Object    ${STORAGE_WALLET_PATH}    ${PUBLIC_CID}    ${S_OID_USER}    ${EMPTY}    s_file_read
 
     # Get Range
-                            Get Range           ${USER_WALLET}    ${PUBLIC_CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
-                            Get Range           ${WALLET_OTH}    ${PUBLIC_CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+                            Get Range           ${USER_WALLET}    ${PUBLIC_CID}    ${S_OID_USER}    0:256
+                            Get Range           ${WALLET_OTH}    ${PUBLIC_CID}    ${S_OID_USER}    0:256
                             Run Keyword And Expect Error        *
-                            ...    Get Range    ${IR_WALLET_PATH}    ${PUBLIC_CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256    wallet_config=${IR_WALLET_CONFIG}
+                            ...    Get Range    ${IR_WALLET_PATH}    ${PUBLIC_CID}    ${S_OID_USER}    0:256    wallet_config=${IR_WALLET_CONFIG}
                             Run Keyword And Expect Error        *
-                            ...    Get Range    ${STORAGE_WALLET_PATH}    ${PUBLIC_CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+                            ...    Get Range    ${STORAGE_WALLET_PATH}    ${PUBLIC_CID}    ${S_OID_USER}    0:256
 
 
     # Get Range Hash

--- a/robot/testsuites/integration/acl/acl_basic_readonly_container.robot
+++ b/robot/testsuites/integration/acl/acl_basic_readonly_container.robot
@@ -62,12 +62,12 @@ Check Read-Only Container
                         Get Object    ${STORAGE_WALLET_PATH}    ${READONLY_CID}    ${S_OID_USER}    ${EMPTY}    s_file_read
 
     # Get Range
-                        Get Range           ${USER_WALLET}    ${READONLY_CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
-                        Get Range           ${WALLET_OTH}    ${READONLY_CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+                        Get Range           ${USER_WALLET}    ${READONLY_CID}    ${S_OID_USER}    0:256
+                        Get Range           ${WALLET_OTH}    ${READONLY_CID}    ${S_OID_USER}    0:256
                         Run Keyword And Expect Error        *
-                        ...    Get Range    ${IR_WALLET_PATH}    ${READONLY_CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256    wallet_config=${IR_WALLET_CONFIG}
+                        ...    Get Range    ${IR_WALLET_PATH}    ${READONLY_CID}    ${S_OID_USER}    0:256    wallet_config=${IR_WALLET_CONFIG}
                         Run Keyword And Expect Error        *
-                        ...    Get Range    ${STORAGE_WALLET_PATH}    ${READONLY_CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+                        ...    Get Range    ${STORAGE_WALLET_PATH}    ${READONLY_CID}    ${S_OID_USER}    0:256
 
 
     # Get Range Hash

--- a/robot/testsuites/integration/acl/acl_bearer_allow.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_allow.robot
@@ -52,7 +52,7 @@ Check eACL Deny and Allow All Bearer
                         Get object        ${WALLET}    ${CID}        ${S_OID_USER}    ${EMPTY}       local_file_eacl
                         Search object     ${WALLET}    ${CID}        ${EMPTY}         ${EMPTY}       ${USER_HEADER}    ${S_OBJ_H}
                         Head object       ${WALLET}    ${CID}        ${S_OID_USER}
-                        Get Range         ${WALLET}    ${CID}        ${S_OID_USER}    s_get_range    ${EMPTY}      0:256
+                        Get Range         ${WALLET}    ${CID}        ${S_OID_USER}      0:256
                         Delete object     ${WALLET}    ${CID}        ${D_OID_USER}
 
                         Set eACL          ${WALLET}    ${CID}        ${EACL_DENY_ALL_USER}
@@ -81,7 +81,7 @@ Check eACL Deny and Allow All Bearer
                         Run Keyword And Expect Error    *
                         ...  Head object    ${WALLET}    ${CID}       ${S_OID_USER}
                         Run Keyword And Expect Error    *
-                        ...  Get Range      ${WALLET}    ${CID}       ${S_OID_USER}    s_get_range    ${EMPTY}      0:256
+                        ...  Get Range      ${WALLET}    ${CID}       ${S_OID_USER}      0:256
                         Run Keyword And Expect Error    *
                         ...  Delete object  ${WALLET}    ${CID}       ${S_OID_USER}
 
@@ -90,5 +90,5 @@ Check eACL Deny and Allow All Bearer
                         Get object          ${WALLET}    ${CID}       ${S_OID_USER}    ${EACL_TOKEN}    local_file_eacl
                         Search object       ${WALLET}    ${CID}       ${EMPTY}         ${EACL_TOKEN}    ${USER_HEADER}       ${S_OBJ_H}
                         Head object         ${WALLET}    ${CID}       ${S_OID_USER}    bearer_token=${EACL_TOKEN}
-                        Get Range           ${WALLET}    ${CID}       ${S_OID_USER}    s_get_range      ${EACL_TOKEN}    0:256
+                        Get Range           ${WALLET}    ${CID}       ${S_OID_USER}    0:256    bearer=${EACL_TOKEN}
                         Delete object       ${WALLET}    ${CID}       ${S_OID_USER}    bearer=${EACL_TOKEN}

--- a/robot/testsuites/integration/acl/acl_bearer_compound.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_compound.robot
@@ -85,9 +85,9 @@ Check Bearer Сompound Get
                         Get Object    ${WALLET}    ${CID}    ${S_OID_USER}    ${EACL_TOKEN}      local_file_eacl
                         IF    "${WALLET}" == "${IR_WALLET_PATH}"
                             Run Keyword And Expect Error    *
-                            ...    Get Range    ${WALLET}    ${CID}    ${S_OID_USER}    s_get_range        ${EACL_TOKEN}       0:256
+                            ...    Get Range    ${WALLET}    ${CID}    ${S_OID_USER}    0:256    bearer=${EACL_TOKEN}
                         ELSE
-                            Get Range    ${WALLET}    ${CID}    ${S_OID_USER}    s_get_range        ${EACL_TOKEN}       0:256
+                            Get Range    ${WALLET}    ${CID}    ${S_OID_USER}    0:256    bearer=${EACL_TOKEN}
                         END
                         Get Range Hash    ${WALLET}    ${CID}    ${S_OID_USER}    ${EACL_TOKEN}      0:256
 
@@ -148,7 +148,7 @@ Check Bearer Сompound Get Range Hash
     ${EACL_TOKEN} =     Form BearerToken File      ${USER_WALLET}    ${CID}    ${eACL_gen}
 
                         Run Keyword And Expect Error    *
-                        ...  Get Range      ${WALLET}    ${CID}    ${S_OID_USER}    s_get_range    ${EACL_TOKEN}    0:256
+                        ...  Get Range      ${WALLET}    ${CID}    ${S_OID_USER}    0:256    bearer=${EACL_TOKEN}
                         Run Keyword And Expect Error    *
                         ...  Get object     ${WALLET}    ${CID}    ${S_OID_USER}    ${EACL_TOKEN}    local_file_eacl
 

--- a/robot/testsuites/integration/acl/acl_bearer_filter_oid_equal.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_filter_oid_equal.robot
@@ -56,7 +56,7 @@ Check eACL Deny and Allow All Bearer Filter OID Equal
                             Get object         ${WALLET}    ${CID}        ${S_OID_USER}        ${EMPTY}      local_file_eacl
                             Search object      ${WALLET}    ${CID}        ${EMPTY}             ${EMPTY}      ${USER_HEADER}    ${S_OBJ_H}
                             Head object        ${WALLET}    ${CID}        ${S_OID_USER}
-                            Get Range          ${WALLET}    ${CID}        ${S_OID_USER}        s_get_range       ${EMPTY}          0:256
+                            Get Range          ${WALLET}    ${CID}        ${S_OID_USER}        0:256
                             Delete object      ${WALLET}    ${CID}        ${D_OID_USER}
 
                             Set eACL           ${WALLET}    ${CID}        ${EACL_DENY_ALL_USER}
@@ -87,7 +87,7 @@ Check eACL Deny and Allow All Bearer Filter OID Equal
                         Run Keyword And Expect Error        *
                         ...  Head object    ${WALLET}    ${CID}    ${S_OID_USER}
                         Run Keyword And Expect Error        *
-                        ...  Get Range      ${WALLET}    ${CID}    ${S_OID_USER}    s_get_range    ${EMPTY}      0:256
+                        ...  Get Range      ${WALLET}    ${CID}    ${S_OID_USER}      0:256
                         Run Keyword And Expect Error        *
                         ...  Delete object  ${WALLET}    ${CID}    ${S_OID_USER}
                         Run Keyword And Expect Error        *
@@ -98,7 +98,7 @@ Check eACL Deny and Allow All Bearer Filter OID Equal
                         ...  Get object     ${WALLET}    ${CID}      ${S_OID_USER_2}    ${EACL_TOKEN}       local_file_eacl
 
                         Get object       ${WALLET}    ${CID}      ${S_OID_USER}      ${EACL_TOKEN}       local_file_eacl
-                        Get Range        ${WALLET}    ${CID}      ${S_OID_USER}      s_get_range     ${EACL_TOKEN}   0:256
+                        Get Range        ${WALLET}    ${CID}      ${S_OID_USER}    0:256    bearer=${EACL_TOKEN}
 
                         Head object      ${WALLET}    ${CID}      ${S_OID_USER}      bearer_token=${EACL_TOKEN}
                         Delete object    ${WALLET}    ${CID}      ${S_OID_USER}      bearer=${EACL_TOKEN}

--- a/robot/testsuites/integration/acl/acl_bearer_filter_oid_not_equal.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_filter_oid_not_equal.robot
@@ -53,7 +53,7 @@ Check eACL Deny and Allow All Bearer Filter OID NotEqual
                             Get object          ${WALLET}    ${CID}        ${S_OID_USER}    ${EMPTY}       local_file_eacl
                             Search object       ${WALLET}    ${CID}        ${EMPTY}         ${EMPTY}       ${USER_HEADER}     ${S_OBJ_H}
                             Head object         ${WALLET}    ${CID}        ${S_OID_USER}
-                            Get Range           ${WALLET}    ${CID}        ${S_OID_USER}    s_get_range    ${EMPTY}      0:256
+                            Get Range           ${WALLET}    ${CID}        ${S_OID_USER}      0:256
                             Delete object       ${WALLET}    ${CID}        ${D_OID_USER}
 
                             Set eACL            ${WALLET}    ${CID}        ${EACL_DENY_ALL_USER}
@@ -84,7 +84,7 @@ Check eACL Deny and Allow All Bearer Filter OID NotEqual
                         Run Keyword And Expect Error        *
                         ...  Head object     ${WALLET}    ${CID}        ${S_OID_USER}
                         Run Keyword And Expect Error        *
-                        ...  Get Range       ${WALLET}    ${CID}        ${S_OID_USER}        s_get_range        ${EMPTY}      0:256
+                        ...  Get Range       ${WALLET}    ${CID}        ${S_OID_USER}    0:256
                         Run Keyword And Expect Error        *
                         ...  Delete object   ${WALLET}    ${CID}        ${S_OID_USER}
 
@@ -94,9 +94,9 @@ Check eACL Deny and Allow All Bearer Filter OID NotEqual
                         Run Keyword And Expect Error        *
                         ...  Get object      ${WALLET}    ${CID}     ${S_OID_USER_2}      ${EACL_TOKEN}       local_file_eacl
 
-                        Get Range      ${WALLET}    ${CID}        ${S_OID_USER}        s_get_range        ${EACL_TOKEN}       0:256
+                        Get Range      ${WALLET}    ${CID}        ${S_OID_USER}    0:256    bearer=${EACL_TOKEN}
                         Run Keyword And Expect Error        *
-                        ...  Get Range      ${WALLET}    ${CID}        ${S_OID_USER_2}      s_get_range        ${EACL_TOKEN}       0:256
+                        ...  Get Range      ${WALLET}    ${CID}        ${S_OID_USER_2}    0:256    bearer=${EACL_TOKEN}
 
                         Head object         ${WALLET}    ${CID}        ${S_OID_USER}    bearer_token=${EACL_TOKEN}
                         Run Keyword And Expect Error        *

--- a/robot/testsuites/integration/acl/acl_bearer_filter_userheader_equal.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_filter_userheader_equal.robot
@@ -51,7 +51,7 @@ Check eACL Deny and Allow All Bearer Filter UserHeader Equal
                             Get object       ${WALLET}    ${CID}       ${S_OID_USER}        ${EMPTY}      local_file_eacl
                             Search object    ${WALLET}    ${CID}       ${EMPTY}             ${EMPTY}      ${USER_HEADER}     ${S_OBJ_H}
                             Head object      ${WALLET}    ${CID}       ${S_OID_USER}
-                            Get Range        ${WALLET}    ${CID}       ${S_OID_USER}        s_get_range       ${EMPTY}      0:256
+                            Get Range        ${WALLET}    ${CID}       ${S_OID_USER}        0:256
                             Delete object    ${WALLET}    ${CID}       ${D_OID_USER}
 
                             Set eACL         ${WALLET}    ${CID}       ${EACL_DENY_ALL_USER}
@@ -82,7 +82,7 @@ Check eACL Deny and Allow All Bearer Filter UserHeader Equal
                         Run Keyword And Expect Error        *
                         ...  Head object    ${WALLET}    ${CID}      ${S_OID_USER}
                         Run Keyword And Expect Error        *
-                        ...  Get Range      ${WALLET}    ${CID}      ${S_OID_USER}    s_get_range    ${EMPTY}      0:256
+                        ...  Get Range      ${WALLET}    ${CID}      ${S_OID_USER}    0:256
                         Run Keyword And Expect Error        *
                         ...  Delete object  ${WALLET}    ${CID}      ${S_OID_USER}
                         Run Keyword And Expect Error        *
@@ -96,7 +96,7 @@ Check eACL Deny and Allow All Bearer Filter UserHeader Equal
                         ...  Get object     ${WALLET}    ${CID}        ${S_OID_USER_2}      ${EACL_TOKEN}       local_file_eacl
 
                         Run Keyword And Expect Error        *
-                        ...  Get Range      ${WALLET}    ${CID}        ${S_OID_USER}        s_get_range         ${EACL_TOKEN}       0:256
+                        ...  Get Range      ${WALLET}    ${CID}        ${S_OID_USER}        0:256    bearer=${EACL_TOKEN}
 
                         Run Keyword And Expect Error        *
                         ...  Get Range Hash     ${WALLET}    ${CID}    ${S_OID_USER}        ${EACL_TOKEN}   0:256

--- a/robot/testsuites/integration/acl/acl_bearer_filter_userheader_not_equal.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_filter_userheader_not_equal.robot
@@ -52,7 +52,7 @@ Check eACL Deny and Allow All Bearer Filter UserHeader NotEqual
                         Get object          ${WALLET}    ${CID}        ${S_OID_USER}        ${EMPTY}      local_file_eacl
                         Search object       ${WALLET}    ${CID}        ${EMPTY}             ${EMPTY}      ${USER_HEADER}     ${S_OBJ_H}
                         Head object         ${WALLET}    ${CID}        ${S_OID_USER}
-                        Get Range           ${WALLET}    ${CID}        ${S_OID_USER}        s_get_range    ${EMPTY}      0:256
+                        Get Range           ${WALLET}    ${CID}        ${S_OID_USER}        0:256
                         Delete object       ${WALLET}    ${CID}        ${D_OID_USER}
 
                         Set eACL            ${WALLET}    ${CID}        ${EACL_DENY_ALL_USER}
@@ -83,7 +83,7 @@ Check eACL Deny and Allow All Bearer Filter UserHeader NotEqual
                     Run Keyword And Expect Error        *
                     ...  Head object       ${WALLET}    ${CID}        ${S_OID_USER}
                     Run Keyword And Expect Error        *
-                    ...  Get Range         ${WALLET}    ${CID}        ${S_OID_USER}      s_get_range    ${EMPTY}    0:256
+                    ...  Get Range         ${WALLET}    ${CID}        ${S_OID_USER}      0:256
                     Run Keyword And Expect Error        *
                     ...  Delete object     ${WALLET}    ${CID}        ${S_OID_USER}      ${EMPTY}
 
@@ -101,7 +101,7 @@ Check eACL Deny and Allow All Bearer Filter UserHeader NotEqual
                     ...  Get object        ${WALLET}    ${CID}        ${S_OID_USER_2}    ${EACL_TOKEN}    local_file_eacl
 
                     Run Keyword And Expect Error        *
-                    ...  Get Range         ${WALLET}    ${CID}        ${S_OID_USER}      s_get_range    ${EACL_TOKEN}    0:256
+                    ...  Get Range         ${WALLET}    ${CID}        ${S_OID_USER}      0:256    bearer=${EACL_TOKEN}
 
                     Run Keyword And Expect Error        *
                     ...  Get Range Hash    ${WALLET}    ${CID}        ${S_OID_USER}      ${EACL_TOKEN}    0:256

--- a/robot/testsuites/integration/acl/acl_bearer_inaccessible.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_inaccessible.robot
@@ -49,7 +49,7 @@ Check Container Inaccessible and Allow All Bearer
                 Run Keyword And Expect Error        *
                 ...  Head object       ${WALLET}    ${CID}        ${S_OID_USER}
                 Run Keyword And Expect Error        *
-                ...  Get Range         ${WALLET}    ${CID}        ${S_OID_USER}    s_get_range    ${EMPTY}      0:256
+                ...  Get Range         ${WALLET}    ${CID}        ${S_OID_USER}    0:256
                 Run Keyword And Expect Error        *
                 ...  Delete object     ${WALLET}    ${CID}        ${S_OID_USER}
 

--- a/robot/testsuites/integration/acl/acl_bearer_request_filter_xheader_deny.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_request_filter_xheader_deny.robot
@@ -65,10 +65,10 @@ Check eACL Allow All Bearer Filter Requst Equal Deny
 
                         Put object      ${WALLET}    ${FILE_S}     ${CID}           bearer=${EACL_TOKEN}    user_headers=${ANOTHER_HEADER}   options=--xhdr a=2
                         Get object      ${WALLET}    ${CID}        ${S_OID_USER}    ${EACL_TOKEN}    local_file_eacl      ${EMPTY}      --xhdr a=2
-                        Search object   ${WALLET}    ${CID}        ${EMPTY}         ${EACL_TOKEN}    ${USER_HEADER}   ${S_OBJ_H}    --xhdr a=2
+                        Search object   ${WALLET}    ${CID}        ${EMPTY}         ${EACL_TOKEN}    ${USER_HEADER}   ${S_OBJ_H}    options=--xhdr a=2
                         Head object     ${WALLET}    ${CID}        ${S_OID_USER}    bearer_token=${EACL_TOKEN}    options=--xhdr a=2
-                        Get Range       ${WALLET}    ${CID}        ${S_OID_USER}    s_get_range      ${EACL_TOKEN}    0:256         --xhdr a=2
-                        Get Range Hash  ${WALLET}    ${CID}        ${S_OID_USER}    ${EACL_TOKEN}    0:256            --xhdr a=2
+                        Get Range       ${WALLET}    ${CID}        ${S_OID_USER}    0:256    bearer=${EACL_TOKEN}    options=--xhdr a=2
+                        Get Range Hash  ${WALLET}    ${CID}        ${S_OID_USER}    ${EACL_TOKEN}    0:256            options=--xhdr a=2
                         Delete object   ${WALLET}    ${CID}        ${D_OID_USER}    bearer=${EACL_TOKEN}    options=--xhdr a=2
 
                         Run Keyword And Expect Error    *
@@ -80,7 +80,7 @@ Check eACL Allow All Bearer Filter Requst Equal Deny
                         Run Keyword And Expect Error    *
                         ...  Head object     ${WALLET}    ${CID}       ${S_OID_USER}    bearer_token=${EACL_TOKEN}    options=--xhdr a=256
                         Run Keyword And Expect Error    *
-                        ...  Get Range       ${WALLET}    ${CID}       ${S_OID_USER}    s_get_range      ${EACL_TOKEN}    0:256      --xhdr a=256
+                        ...  Get Range       ${WALLET}    ${CID}       ${S_OID_USER}    0:256    bearer=${EACL_TOKEN}      options=--xhdr a=256
                         Run Keyword And Expect Error    *
                         ...  Get Range Hash  ${WALLET}    ${CID}       ${S_OID_USER}    ${EACL_TOKEN}    0:256    --xhdr a=256
                         Run Keyword And Expect Error    *

--- a/robot/testsuites/integration/acl/acl_bearer_request_filter_xheader_not_equal.robot
+++ b/robot/testsuites/integration/acl/acl_bearer_request_filter_xheader_not_equal.robot
@@ -52,7 +52,7 @@ Check eACL Deny and Allow All Bearer Filter Requst NotEqual
                             Get object         ${WALLET}    ${CID}        ${S_OID_USER}    ${EMPTY}      local_file_eacl
                             Search object      ${WALLET}    ${CID}        ${EMPTY}         ${EMPTY}      ${USER_HEADER}     ${S_OBJ_H}
                             Head object        ${WALLET}    ${CID}        ${S_OID_USER}
-                            Get Range          ${WALLET}    ${CID}        ${S_OID_USER}    s_get_range       ${EMPTY}      0:256
+                            Get Range          ${WALLET}    ${CID}        ${S_OID_USER}    0:256
                             Delete object      ${WALLET}    ${CID}        ${D_OID_USER}
 
                             Set eACL           ${WALLET}    ${CID}        ${EACL_DENY_ALL_USER}
@@ -80,7 +80,7 @@ Check eACL Deny and Allow All Bearer Filter Requst NotEqual
                         Run Keyword And Expect Error    *
                         ...  Head object     ${WALLET}    ${CID}       ${S_OID_USER}
                         Run Keyword And Expect Error    *
-                        ...  Get Range       ${WALLET}    ${CID}       ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+                        ...  Get Range       ${WALLET}    ${CID}       ${S_OID_USER}    0:256
                         Run Keyword And Expect Error    *
                         ...  Delete object   ${WALLET}    ${CID}       ${S_OID_USER}
 
@@ -88,6 +88,6 @@ Check eACL Deny and Allow All Bearer Filter Requst NotEqual
                         Get object       ${WALLET}    ${CID}       ${S_OID_USER}    ${EACL_TOKEN}    local_file_eacl      ${EMPTY}       --xhdr a=2
                         Search object    ${WALLET}    ${CID}       ${EMPTY}         ${EACL_TOKEN}    ${USER_HEADER}   ${EMPTY}       --xhdr a=2
                         Head object      ${WALLET}    ${CID}       ${S_OID_USER}    bearer_token=${EACL_TOKEN}    options=--xhdr a=2
-                        Get Range        ${WALLET}    ${CID}       ${S_OID_USER}    s_get_range      ${EACL_TOKEN}    0:256          --xhdr a=2
+                        Get Range        ${WALLET}    ${CID}       ${S_OID_USER}    0:256    bearer=${EACL_TOKEN}          --xhdr a=2
                         Get Range Hash   ${WALLET}    ${CID}       ${S_OID_USER}    ${EACL_TOKEN}    0:256            --xhdr a=2
                         Delete object    ${WALLET}    ${CID}       ${S_OID_USER}    bearer=${EACL_TOKEN}    options=--xhdr a=2

--- a/robot/testsuites/integration/acl/acl_extended_actions_pubkey.robot
+++ b/robot/testsuites/integration/acl/acl_extended_actions_pubkey.robot
@@ -56,7 +56,7 @@ Check eACL Deny All Other and Allow All Pubkey
                             Get object                  ${WALLET_ALLOW}    ${CID}        ${S_OID_USER}            ${EMPTY}            local_file_eacl
                             Search object               ${WALLET_ALLOW}    ${CID}        ${EMPTY}                 ${EMPTY}            ${USER_HEADER}        ${S_OBJ_H}
                             Head object                 ${WALLET_ALLOW}    ${CID}        ${S_OID_USER}
-                            Get Range                   ${WALLET_ALLOW}    ${CID}        ${S_OID_USER}            s_get_range         ${EMPTY}            0:256
+                            Get Range                   ${WALLET_ALLOW}    ${CID}        ${S_OID_USER}            0:256
                             Get Range Hash              ${WALLET_ALLOW}    ${CID}        ${S_OID_USER}            ${EMPTY}            0:256
                             Delete object               ${WALLET_ALLOW}    ${CID}        ${D_OID_USER}
 
@@ -81,7 +81,7 @@ Check eACL Deny All Other and Allow All Pubkey
                             Run Keyword And Expect Error        *
                             ...  Head object                         ${WALLET_OTH}    ${CID}        ${S_OID_USER}
                             Run Keyword And Expect Error        *
-                            ...  Get Range                           ${WALLET_OTH}    ${CID}        ${S_OID_USER}     s_get_range     ${EMPTY}            0:256
+                            ...  Get Range                           ${WALLET_OTH}    ${CID}        ${S_OID_USER}     0:256
                             Run Keyword And Expect Error        *
                             ...  Get Range Hash                      ${WALLET_OTH}    ${CID}        ${S_OID_USER}     ${EMPTY}        0:256
                             Run Keyword And Expect Error        *
@@ -91,6 +91,6 @@ Check eACL Deny All Other and Allow All Pubkey
                             Get object              ${WALLET_ALLOW}    ${CID}        ${S_OID_USER}           ${EMPTY}            local_file_eacl
                             Search object           ${WALLET_ALLOW}    ${CID}        ${EMPTY}                ${EMPTY}            ${USER_HEADER}     ${S_OBJ_H}
                             Head object             ${WALLET_ALLOW}    ${CID}        ${S_OID_USER}
-                            Get Range               ${WALLET_ALLOW}    ${CID}        ${S_OID_USER}           s_get_range         ${EMPTY}            0:256
+                            Get Range               ${WALLET_ALLOW}    ${CID}        ${S_OID_USER}           0:256
                             Get Range Hash          ${WALLET_ALLOW}    ${CID}        ${S_OID_USER}           ${EMPTY}            0:256
                             Delete object           ${WALLET_ALLOW}    ${CID}        ${S_OID_USER}

--- a/robot/testsuites/integration/acl/acl_extended_actions_system.robot
+++ b/robot/testsuites/integration/acl/acl_extended_actions_system.robot
@@ -73,9 +73,9 @@ Check eACL Deny and Allow All System
                         Head object          ${STORAGE_WALLET_PATH}    ${CID}    ${S_OID_USER}
 
                         Run Keyword And Expect Error    *
-                        ...    Get Range            ${IR_WALLET_PATH}    ${CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256     wallet_config=${IR_WALLET_CONFIG}
+                        ...    Get Range            ${IR_WALLET_PATH}    ${CID}    ${S_OID_USER}    0:256     wallet_config=${IR_WALLET_CONFIG}
                         Run Keyword And Expect Error    *
-                        ...    Get Range            ${STORAGE_WALLET_PATH}    ${CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+                        ...    Get Range            ${STORAGE_WALLET_PATH}    ${CID}    ${S_OID_USER}    0:256
 
                         #Get Range Hash       ${IR_WALLET_PATH}    ${CID}    ${S_OID_USER}    ${EMPTY}    0:256     wallet_config=${IR_WALLET_CONFIG}
                         #Get Range Hash       ${STORAGE_WALLET_PATH}    ${CID}    ${S_OID_USER}    ${EMPTY}    0:256
@@ -112,9 +112,9 @@ Check eACL Deny and Allow All System
                         ...  Head object                ${STORAGE_WALLET_PATH}    ${CID}    ${S_OID_USER}
 
                         Run Keyword And Expect Error        *
-                        ...  Get Range                  ${IR_WALLET_PATH}    ${CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256     wallet_config=${IR_WALLET_CONFIG}
+                        ...  Get Range                  ${IR_WALLET_PATH}    ${CID}    ${S_OID_USER}    0:256     wallet_config=${IR_WALLET_CONFIG}
                         Run Keyword And Expect Error        *
-                        ...  Get Range                  ${STORAGE_WALLET_PATH}    ${CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+                        ...  Get Range                  ${STORAGE_WALLET_PATH}    ${CID}    ${S_OID_USER}    0:256
 
 
                         Run Keyword And Expect Error        *
@@ -154,9 +154,9 @@ Check eACL Deny and Allow All System
                         Head object          ${STORAGE_WALLET_PATH}    ${CID}    ${S_OID_USER}
 
                         Run Keyword And Expect Error        *
-                        ...  Get Range            ${IR_WALLET_PATH}    ${CID}    ${S_OID_USER}    s_get_range      ${EMPTY}    0:256     wallet_config=${IR_WALLET_CONFIG}
+                        ...  Get Range            ${IR_WALLET_PATH}    ${CID}    ${S_OID_USER}    0:256     wallet_config=${IR_WALLET_CONFIG}
                         Run Keyword And Expect Error        *
-                        ...  Get Range            ${STORAGE_WALLET_PATH}    ${CID}    ${S_OID_USER}    s_get_range      ${EMPTY}    0:256
+                        ...  Get Range            ${STORAGE_WALLET_PATH}    ${CID}    ${S_OID_USER}    0:256
 
                         #Get Range Hash       ${IR_WALLET_PATH}    ${CID}    ${S_OID_USER}    ${EMPTY}    0:256     wallet_config=${IR_WALLET_CONFIG}
                         #Get Range Hash       ${STORAGE_WALLET_PATH}    ${CID}    ${S_OID_USER}    ${EMPTY}    0:256

--- a/robot/testsuites/integration/acl/acl_extended_compound.robot
+++ b/robot/testsuites/integration/acl/acl_extended_compound.robot
@@ -79,9 +79,9 @@ Check eACL Сompound Get
                             Get object        ${WALLET}    ${CID}    ${S_OID_USER}    ${EMPTY}    local_file_eacl
                             IF    "${WALLET}" == "${IR_WALLET_PATH}"
                                 Run Keyword And Expect Error    *
-                                ...    Get Range    ${WALLET}    ${CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+                                ...    Get Range    ${WALLET}    ${CID}    ${S_OID_USER}    0:256
                             ELSE
-                                Get Range     ${WALLET}    ${CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+                                Get Range     ${WALLET}    ${CID}    ${S_OID_USER}    0:256
                             END
                             Get Range Hash    ${WALLET}    ${CID}    ${S_OID_USER}    ${EMPTY}       0:256
 
@@ -133,7 +133,7 @@ Check eACL Сompound Get Range Hash
                             Sleep    ${NEOFS_CONTRACT_CACHE_TIMEOUT}
 
                             Run Keyword And Expect Error    *
-                            ...  Get Range     ${WALLET}    ${CID}    ${S_OID_USER}    s_get_range    ${EMPTY}    0:256
+                            ...  Get Range     ${WALLET}    ${CID}    ${S_OID_USER}    0:256
                             Run Keyword And Expect Error    *
                             ...  Get object    ${WALLET}    ${CID}    ${S_OID_USER}    ${EMPTY}    local_file_eacl
 

--- a/robot/testsuites/integration/acl/acl_extended_filters.robot
+++ b/robot/testsuites/integration/acl/acl_extended_filters.robot
@@ -74,7 +74,7 @@ Check eACL MatchType String Equal Request Deny
                             Run Keyword And Expect Error    *
                             ...  Head object                ${OTHER_WALLET}    ${CID}        ${S_OID_USER}    options=--xhdr a=2
                             Run Keyword And Expect Error    *
-                            ...  Get Range                  ${OTHER_WALLET}    ${CID}        ${S_OID_USER}    s_get_range    ${EMPTY}              0:256         --xhdr a="2"
+                            ...  Get Range                  ${OTHER_WALLET}    ${CID}        ${S_OID_USER}    0:256         options=--xhdr a="2"
                             Run Keyword And Expect Error    *
                             ...  Get Range Hash             ${OTHER_WALLET}    ${CID}        ${S_OID_USER}    ${EMPTY}       0:256                 --xhdr a=2
                             Run Keyword And Expect Error    *
@@ -84,7 +84,7 @@ Check eACL MatchType String Equal Request Deny
                             Get object                      ${OTHER_WALLET}    ${CID}        ${S_OID_USER}    ${EMPTY}       ${PATH}       ${EMPTY}        --xhdr a=*
                             Search object                   ${OTHER_WALLET}    ${CID}        ${EMPTY}         ${EMPTY}       ${USER_HEADER}    ${EMPTY}        --xhdr a=
                             Head object                     ${OTHER_WALLET}    ${CID}        ${S_OID_USER}    options=--xhdr a=.*
-                            Get Range                       ${OTHER_WALLET}    ${CID}        ${S_OID_USER}    s_get_range    ${EMPTY}              0:256           --xhdr a="2 2"
+                            Get Range                       ${OTHER_WALLET}    ${CID}        ${S_OID_USER}    0:256           options=--xhdr a="2 2"
                             Get Range Hash                  ${OTHER_WALLET}    ${CID}        ${S_OID_USER}    ${EMPTY}       0:256                 --xhdr a=256
                             Delete object                   ${OTHER_WALLET}    ${CID}        ${S_OID_USER}    options=--xhdr a=22
 
@@ -114,7 +114,7 @@ Check eACL MatchType String Equal Request Allow
                             Run Keyword And Expect Error    *
                             ...  Head object                ${OTHER_WALLET}    ${CID}        ${S_OID_USER}
                             Run Keyword And Expect Error    *
-                            ...  Get Range                  ${OTHER_WALLET}    ${CID}        ${S_OID_USER}    s_get_range    ${EMPTY}              0:256
+                            ...  Get Range                  ${OTHER_WALLET}    ${CID}        ${S_OID_USER}    0:256
                             Run Keyword And Expect Error    *
                             ...  Get Range Hash             ${OTHER_WALLET}    ${CID}        ${S_OID_USER}    ${EMPTY}       0:256
                             Run Keyword And Expect Error    *
@@ -124,7 +124,7 @@ Check eACL MatchType String Equal Request Allow
                             Get object                      ${OTHER_WALLET}    ${CID}        ${S_OID_USER}    ${EMPTY}       ${PATH}       ${EMPTY}        --xhdr a=2
                             Search object                   ${OTHER_WALLET}    ${CID}        ${EMPTY}         ${EMPTY}       ${USER_HEADER}    ${EMPTY}        --xhdr a=2
                             Head object                     ${OTHER_WALLET}    ${CID}        ${S_OID_USER}    options=--xhdr a=2
-                            Get Range                       ${OTHER_WALLET}    ${CID}        ${S_OID_USER}    s_get_range    ${EMPTY}              0:256           --xhdr a=2
+                            Get Range                       ${OTHER_WALLET}    ${CID}        ${S_OID_USER}    0:256           options=--xhdr a=2
                             Get Range Hash                  ${OTHER_WALLET}    ${CID}        ${S_OID_USER}    ${EMPTY}       0:256                 --xhdr a=2
                             Delete object                   ${OTHER_WALLET}    ${CID}        ${S_OID_USER}    options=--xhdr a=2
 


### PR DESCRIPTION
- `file_path` was no more needed for `Get Range`
- `bearer` for `Get Range` is made optional

Signed-off-by: Elizaveta Chichindaeva <elizaveta@nspcc.ru>