### PR TITLE
fix skipping s3 test by python mistake

### DIFF
--- a/pytest_tests/steps/aws_cli_client.py
+++ b/pytest_tests/steps/aws_cli_client.py
@@ -282,7 +282,7 @@ class AwsCliClient:
             f"aws {self.common_flags} s3api get-object-tagging --bucket {Bucket} --key {Key} "
             f"{version}  --endpoint {S3_GATE}"
         )
-        output = _cmd_run(cmd)
+        output = _cmd_run(cmd, REGULAR_TIMEOUT)
         return self._to_json(output)
 
     def delete_object_tagging(self, Bucket: str, Key: str) -> dict:
@@ -365,7 +365,7 @@ class AwsCliClient:
             f"--upload-id {UploadId} --part-number {PartNumber} --body {Body} "
             f"--endpoint-url {S3_GATE}"
         )
-        output = _cmd_run(cmd)
+        output = _cmd_run(cmd, LONG_TIMEOUT)
         return self._to_json(output)
 
     def list_parts(self, UploadId: str, Bucket: str, Key: str) -> dict:

--- a/pytest_tests/steps/s3_gate_object.py
+++ b/pytest_tests/steps/s3_gate_object.py
@@ -11,6 +11,7 @@ import allure
 import urllib3
 from botocore.exceptions import ClientError
 from cli_helpers import log_command_execution
+
 from steps.aws_cli_client import AwsCliClient
 from steps.s3_gate_bucket import S3_SYNC_WAIT_TIME
 
@@ -441,7 +442,7 @@ def get_object_attributes(
             bucket_name,
             object_key,
             *attributes,
-            VersionId=version_id,
+            version_id=version_id,
             max_parts=max_parts,
             part_number=part_number,
         )


### PR DESCRIPTION
Fix errors: 
- TypeError: get_object_attributes() got an unexpected keyword argument 'VersionId'
- TimeoutExpired: Command 'aws --no-verify-ssl --no-paginate s3api upload-part ...
- check_objects_in_bucket() missing 1 required positional argument: 'bucket'
- check_objects_in_bucket() missing 1 required positional argument: 'expected_objects'
- try_to_get_objects_and_expect_error() missing 1 required positional argument: 'object_keys'
- TimeoutExpired: Command 'aws --no-verify-ssl --no-paginate s3api get-object-tagging ....