### PR TITLE
[#330] Switch to new command netmap snapshot

### DIFF
--- a/pytest_tests/testsuites/network/test_node_management.py
+++ b/pytest_tests/testsuites/network/test_node_management.py
@@ -176,12 +176,9 @@ def test_nodes_management(prepare_tmp_dir):
     random_node = choice(list(NEOFS_NETMAP_DICT))
     alive_node = choice([node for node in NEOFS_NETMAP_DICT if node != random_node])
 
-    # Calculate public key that identifies node in netmap (we need base58-formatted key
-    # because keys of storage nodes are base58-encoded in netmap)
+    # Calculate public key that identifies node in netmap
     random_node_wallet_path = NEOFS_NETMAP_DICT[random_node]["wallet_path"]
-    random_node_netmap_key = get_wallet_public_key(
-        random_node_wallet_path, STORAGE_WALLET_PASS, format="base58"
-    )
+    random_node_netmap_key = get_wallet_public_key(random_node_wallet_path, STORAGE_WALLET_PASS)
 
     with allure.step("Check node {random_node} is in netmap"):
         snapshot = get_netmap_snapshot(node_name=alive_node)

--- a/robot/resources/lib/python_keywords/cli_utils/cli/cli.py
+++ b/robot/resources/lib/python_keywords/cli_utils/cli/cli.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+from cli_utils.cli.netmap import NeofsCliNetmap
 from common import NEOFS_CLI_EXEC
 
 from .accounting import NeofsCliAccounting
@@ -10,19 +11,23 @@ from .version import NeofsCliVersion
 
 
 class NeofsCli:
-    neofs_cli_exec_path: Optional[str] = None
-    config: Optional[str] = None
-    accounting: Optional[NeofsCliAccounting] = None
-    acl: Optional[NeofsCliACL] = None
-    container: Optional[NeofsCliContainer] = None
-    object: Optional[NeofsCliObject] = None
-    version: Optional[NeofsCliVersion] = None
+    accounting: NeofsCliAccounting
+    acl: NeofsCliACL
+    container: NeofsCliContainer
+    netmap: NeofsCliNetmap
+    object: NeofsCliObject
+    version: NeofsCliVersion
 
-    def __init__(self, neofs_cli_exec_path: Optional[str] = None, config: Optional[str] = None, timeout: int = 30):
-        self.config = config    # config(str):  config file (default is $HOME/.config/neofs-cli/config.yaml)
-        self.neofs_cli_exec_path = neofs_cli_exec_path or NEOFS_CLI_EXEC
-        self.accounting = NeofsCliAccounting(self.neofs_cli_exec_path, timeout=timeout, config=config)
-        self.acl = NeofsCliACL(self.neofs_cli_exec_path, timeout=timeout, config=config)
-        self.container = NeofsCliContainer(self.neofs_cli_exec_path, timeout=timeout, config=config)
-        self.object = NeofsCliObject(self.neofs_cli_exec_path, timeout=timeout, config=config)
-        self.version = NeofsCliVersion(self.neofs_cli_exec_path, timeout=timeout, config=config)
+    def __init__(
+        self,
+        neofs_cli_exec_path: Optional[str] = None,
+        config: Optional[str] = None,
+        timeout: int = 30,
+    ):
+        neofs_cli_exec_path = neofs_cli_exec_path or NEOFS_CLI_EXEC
+        self.accounting = NeofsCliAccounting(neofs_cli_exec_path, timeout=timeout, config=config)
+        self.acl = NeofsCliACL(neofs_cli_exec_path, timeout=timeout, config=config)
+        self.container = NeofsCliContainer(neofs_cli_exec_path, timeout=timeout, config=config)
+        self.netmap = NeofsCliNetmap(neofs_cli_exec_path, timeout=timeout, config=config)
+        self.object = NeofsCliObject(neofs_cli_exec_path, timeout=timeout, config=config)
+        self.version = NeofsCliVersion(neofs_cli_exec_path, timeout=timeout, config=config)

--- a/robot/resources/lib/python_keywords/cli_utils/cli/netmap.py
+++ b/robot/resources/lib/python_keywords/cli_utils/cli/netmap.py
@@ -1,0 +1,119 @@
+from typing import Optional
+
+from cli_utils.cli_command import NeofsCliCommand
+
+
+class NeofsCliNetmap(NeofsCliCommand):
+    def epoch(
+        self,
+        rpc_endpoint: str,
+        wallet: str,
+        address: Optional[str] = None,
+        generate_key: bool = False,
+        ttl: Optional[int] = None,
+        xhdr: Optional[dict] = None,
+    ) -> str:
+        """
+        Get current epoch number.
+
+        Args:
+            address:        address of wallet account
+            generate_key:   generate new private key
+            rpc_endpoint:   remote node address (as 'multiaddr' or '<host>:<port>')
+            ttl:            TTL value in request meta header (default 2)
+            wallet:         path to the wallet or binary key
+            xhdr:           request X-Headers in form of Key=Value
+
+        Returns:
+            str: Raw command output
+        """
+        return self._execute(
+            "netmap epoch",
+            **{param: value for param, value in locals().items() if param not in ["self"]},
+        )
+
+    def netinfo(
+        self,
+        rpc_endpoint: str,
+        wallet: str,
+        address: Optional[str] = None,
+        generate_key: bool = False,
+        ttl: Optional[int] = None,
+        xhdr: Optional[dict] = None,
+    ) -> str:
+        """
+        Get information about NeoFS network.
+
+        Args:
+            address:        address of wallet account
+            generate_key:   generate new private key
+            rpc_endpoint:   remote node address (as 'multiaddr' or '<host>:<port>')
+            ttl:            TTL value in request meta header (default 2)
+            wallet:         path to the wallet or binary key
+            xhdr:           request X-Headers in form of Key=Value
+
+        Returns:
+            str: Raw command output
+        """
+        return self._execute(
+            "netmap netinfo",
+            **{param: value for param, value in locals().items() if param not in ["self"]},
+        )
+
+    def nodeinfo(
+        self,
+        rpc_endpoint: str,
+        wallet: str,
+        address: Optional[str] = None,
+        generate_key: bool = False,
+        json: bool = False,
+        ttl: Optional[int] = None,
+        xhdr: Optional[dict] = None,
+    ) -> str:
+        """
+        Get target node info.
+
+        Args:
+            address:        address of wallet account
+            generate_key:   generate new private key
+            json:           print node info in JSON format
+            rpc_endpoint:   remote node address (as 'multiaddr' or '<host>:<port>')
+            ttl:            TTL value in request meta header (default 2)
+            wallet:         path to the wallet or binary key
+            xhdr:           request X-Headers in form of Key=Value
+
+        Returns:
+            str: Raw command output
+        """
+        return self._execute(
+            "netmap nodeinfo",
+            **{param: value for param, value in locals().items() if param not in ["self"]},
+        )
+
+    def snapshot(
+        self,
+        rpc_endpoint: str,
+        wallet: str,
+        address: Optional[str] = None,
+        generate_key: bool = False,
+        ttl: Optional[int] = None,
+        xhdr: Optional[dict] = None,
+    ) -> str:
+        """
+        Request current local snapshot of the network map.
+
+        Args:
+            address:        address of wallet account
+            generate_key:   generate new private key
+            rpc_endpoint:   remote node address (as 'multiaddr' or '<host>:<port>')
+            ttl:            TTL value in request meta header (default 2)
+            wallet:         path to the wallet or binary key
+            xhdr:           request X-Headers in form of Key=Value
+
+        Returns:
+            str: Raw command output
+        """
+        return self._execute(
+            "netmap snapshot",
+            **{param: value for param, value in locals().items() if param not in ["self"]},
+        )


### PR DESCRIPTION
1. Add netmap command to NeofsCli wrapper.
2. Update node_management steps to use netmap.snapshot method instead of deprecated "neofs-cli control netmap-snapshot" command.
3. Switch node's public key in netmap from base58-encoding to hex-encoding.
