### PR TITLE
Refactor api tests, enhance get_range, get_range_hash

### DIFF
--- a/pytest_tests/helpers/grpc_responses.py
+++ b/pytest_tests/helpers/grpc_responses.py
@@ -9,6 +9,7 @@ OBJECT_ACCESS_DENIED = "code = 2048.*message = access to object operation denied
 OBJECT_NOT_FOUND = "code = 2049.*message = object not found"
 OBJECT_ALREADY_REMOVED = "code = 2052.*message = object already removed"
 SESSION_NOT_FOUND = "code = 4096.*message = session token not found"
+OUT_OF_RANGE = "code = 2053.*message = out of range"
 
 
 def error_matches_status(error: Exception, status_pattern: str) -> bool:

--- a/pytest_tests/testsuites/object/test_object_lifetime.py
+++ b/pytest_tests/testsuites/object/test_object_lifetime.py
@@ -1,0 +1,52 @@
+import logging
+
+import allure
+import pytest
+from common import COMPLEX_OBJ_SIZE, SIMPLE_OBJ_SIZE
+from container import create_container
+from epoch import get_epoch, tick_epoch
+from file_helper import generate_file, get_file_hash
+from grpc_responses import OBJECT_NOT_FOUND
+from neofs_testlib.shell import Shell
+from pytest import FixtureRequest
+from python_keywords.neofs_verbs import get_object, put_object
+from utility import wait_for_gc_pass_on_storage_nodes
+
+logger = logging.getLogger("NeoLogger")
+
+
+@allure.title("Test object life time")
+@pytest.mark.sanity
+@pytest.mark.grpc_api
+@pytest.mark.parametrize(
+    "object_size", [SIMPLE_OBJ_SIZE, COMPLEX_OBJ_SIZE], ids=["simple object", "complex object"]
+)
+def test_object_api_lifetime(
+    prepare_wallet_and_deposit: str, client_shell: Shell, request: FixtureRequest, object_size: int
+):
+    """
+    Test object deleted after expiration epoch.
+    """
+    wallet = prepare_wallet_and_deposit
+    cid = create_container(wallet, shell=client_shell)
+
+    allure.dynamic.title(f"Test object life time for {request.node.callspec.id}")
+
+    file_path = generate_file(object_size)
+    file_hash = get_file_hash(file_path)
+    epoch = get_epoch(shell=client_shell)
+
+    oid = put_object(wallet, file_path, cid, shell=client_shell, expire_at=epoch + 1)
+    got_file = get_object(wallet, cid, oid, shell=client_shell)
+    assert get_file_hash(got_file) == file_hash
+
+    with allure.step("Tick two epochs"):
+        for _ in range(2):
+            tick_epoch(shell=client_shell)
+
+    # Wait for GC, because object with expiration is counted as alive until GC removes it
+    wait_for_gc_pass_on_storage_nodes()
+
+    with allure.step("Check object deleted because it expires-on epoch"):
+        with pytest.raises(Exception, match=OBJECT_NOT_FOUND):
+            get_object(wallet, cid, oid, shell=client_shell)

--- a/venv/local-pytest/environment.sh
+++ b/venv/local-pytest/environment.sh
@@ -5,4 +5,4 @@ pushd $DEVENV_PATH > /dev/null
 export `make env`
 popd > /dev/null
 
-export PYTHONPATH=${PYTHONPATH}:${VIRTUAL_ENV}/../neofs-keywords/lib:${VIRTUAL_ENV}/../neofs-keywords/robot:${VIRTUAL_ENV}/../robot/resources/lib/:${VIRTUAL_ENV}/../robot/resources/lib/python_keywords:${VIRTUAL_ENV}/../robot/resources/lib/robot:${VIRTUAL_ENV}/../robot/variables:${VIRTUAL_ENV}/../pytest_tests/helpers
+export PYTHONPATH=${PYTHONPATH}:${VIRTUAL_ENV}/../neofs-keywords/lib:${VIRTUAL_ENV}/../neofs-keywords/robot:${VIRTUAL_ENV}/../robot/resources/lib/:${VIRTUAL_ENV}/../robot/resources/lib/python_keywords:${VIRTUAL_ENV}/../robot/resources/lib/robot:${VIRTUAL_ENV}/../robot/variables:${VIRTUAL_ENV}/../pytest_tests/helpers:${VIRTUAL_ENV}/../pytest_tests/steps


### PR DESCRIPTION
Decomposed api tests
Enhanced get_range, get_range_hash tests with static, sequential and random ranges, complex object searches with multiple parts involved (should be 2 guaranteed parts)
Actualized object search tests with proper parameters and added validation asserts

Signed-off-by: a.berezin [a.berezin@yadro.com](mailto:a.berezin@yadro.com)

Tests run:
https://obj-jenkins.spb.yadro.com/view/Ready%20to%20use/job/sbercloud_test/149/allure/#suites/
https://obj-jenkins.spb.yadro.com/view/Ready%20to%20use/job/neofs-testcases_run/237/

Logged an issue for get_ranges negative cases failures
https://github.com/nspcc-dev/neofs-node/issues/2007