### PR TITLE
Disable pre-commit CI interventions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,3 +9,7 @@ repos:
     hooks:
       - id: isort
         name: isort (python)
+
+ci:
+  autofix_prs: false
+  autoupdate_schedule: quarterly


### PR DESCRIPTION
Disable automatic setting for auto-fixing PRs, we want pre-commit to be triggered on commits locally. Interventions in PRs are annoying.

Auto-update schedule is set to quarterly, as it takes manual action to update tools versions in requirements.txt and it would be too annoying to do that every week.
