### PR TITLE
Return to session log analyzer

### DIFF
--- a/pytest_tests/pytest.ini
+++ b/pytest_tests/pytest.ini
@@ -6,8 +6,6 @@ log_format = %(asctime)s [%(levelname)4s] %(message)s
 log_cli_date_format = %Y-%m-%d %H:%M:%S
 log_date_format = %H:%M:%S
 markers =
-#   controller markers
-    no_log_analyze: skip critical errors analyzer at the end of test
 #   special markers
     staging: test to be excluded from run in verifier/pr-validation/sanity jobs and run test in staging job
     sanity: test runs in sanity testrun


### PR DESCRIPTION
+ Per test log analyzer is not convenient since it skips a lot of setup and teardown logic time where OOM and PANICs may occur
+ If one host logs collection failed, continue to get logs from other hosts

Signed-off-by: Andrey Berezin <a.berezin@yadro.com>