### PR TITLE
Add lock object deletion via control tests

### DIFF
--- a/pytest_tests/pytest.ini
+++ b/pytest_tests/pytest.ini
@@ -13,6 +13,7 @@ markers =
 #   functional markers
     container: tests for container creation
     grpc_api: standard gRPC API tests
+    grpc_control: tests related to using neofs-cli control commands
     grpc_object_lock: gRPC lock tests
     http_gate: HTTP gate contract
     s3_gate: All S3 gate tests


### PR DESCRIPTION
Added tests to check that locked object can still be deleted via `control drop-objects` command

Requires #457 

Related issue: https://github.com/nspcc-dev/neofs-node/issues/2145