### PR TITLE
Bump neofs-testlib to 0.8.1 (Fix logging problem)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ neo-mamba==0.10.0
 neo3crypto==0.2.1
 neo3vm==0.9.0
 neo3vm-stubs==0.9.0
-neofs-testlib==0.8.0
+neofs-testlib==0.8.1
 netaddr==0.8.0
 orjson==3.6.8
 packaging==21.3


### PR DESCRIPTION
Bump neofs-testlib to 0.8.1 (Fix logging problem)

Signed-off-by: Vladimir Avdeev <v.avdeev@yadro.com>