### PR TITLE
Fix: IndexError: list index out of range

### DIFF
--- a/robot/resources/lib/python_keywords/http_gate.py
+++ b/robot/resources/lib/python_keywords/http_gate.py
@@ -286,10 +286,10 @@ def get_object_and_verify_hashes(
         nodes=nodes,
     )
     # for some reason we can face with case when nodes_list is empty due to object resides in all nodes
-    if nodes_list is None:
-        random_node = random.choice(nodes)
-    else:
+    if nodes_list:
         random_node = random.choice(nodes_list)
+    else:
+        random_node = random.choice(nodes)
 
     object_getter = object_getter or get_via_http_gate
 


### PR DESCRIPTION
PR fixes the following error:
```
    def choice(self, seq):
        """Choose a random element from a non-empty sequence."""
        # raises IndexError if seq is empty
>       return seq[self._randbelow(len(seq))]
E       IndexError: list index out of range

/usr/lib/python3.9/random.py:347: IndexError
```
Signed-off-by: Vladislav Karakozov <v.karakozov@yadro.com>