### PR TITLE
Add waiting for epoch align for storage group lifetime test

### DIFF
--- a/pytest_tests/steps/cluster_test_base.py
+++ b/pytest_tests/steps/cluster_test_base.py
@@ -24,6 +24,9 @@ class ClusterTestBase:
     def tick_epoch(self):
         epoch.tick_epoch(self.shell, self.cluster)
 
+    def wait_for_epochs_align(self):
+        epoch.wait_for_epochs_align(self.shell, self.cluster)
+
     def get_epoch(self):
         return epoch.get_epoch(self.shell, self.cluster)
 

--- a/pytest_tests/testsuites/acl/storage_group/test_storagegroup.py
+++ b/pytest_tests/testsuites/acl/storage_group/test_storagegroup.py
@@ -253,6 +253,7 @@ class TestStorageGroup(ClusterTestBase):
         with allure.step("Tick two epochs"):
             for _ in range(2):
                 self.tick_epoch()
+        self.wait_for_epochs_align()
         with pytest.raises(Exception, match=OBJECT_NOT_FOUND):
             get_storagegroup(
                 shell=self.shell,

--- a/pytest_tests/testsuites/services/http_gate/test_http_system_header.py
+++ b/pytest_tests/testsuites/services/http_gate/test_http_system_header.py
@@ -6,7 +6,7 @@ from typing import Optional
 import allure
 import pytest
 from container import create_container
-from epoch import align_epochs, get_epoch
+from epoch import get_epoch, wait_for_epochs_align
 from file_helper import generate_file
 from grpc_responses import OBJECT_NOT_FOUND
 from http_gate import (
@@ -232,7 +232,7 @@ class Test_http_system_header(ClusterTestBase):
             ), f"Epochs should be equal: {get_epoch(self.shell, self.cluster)} != {expected_epoch + 1}"
 
             with allure.step("Check object deleted because it expires-on epoch"):
-                align_epochs(self.shell, self.cluster)
+                wait_for_epochs_align(self.shell, self.cluster)
                 try_to_get_object_and_expect_error(
                     cid=user_container,
                     oid=oid,
@@ -286,7 +286,7 @@ class Test_http_system_header(ClusterTestBase):
             ), f"Epochs should be equal: {get_epoch(self.shell, self.cluster)} != {expected_epoch + 1}"
 
             with allure.step("Check object deleted because it expires-on epoch"):
-                align_epochs(self.shell, self.cluster)
+                wait_for_epochs_align(self.shell, self.cluster)
                 try_to_get_object_and_expect_error(
                     cid=user_container,
                     oid=oid,
@@ -340,7 +340,7 @@ class Test_http_system_header(ClusterTestBase):
             ), f"Epochs should be equal: {get_epoch(self.shell, self.cluster)} != {expected_epoch + 1}"
 
             with allure.step("Check object deleted because it expires-on epoch"):
-                align_epochs(self.shell, self.cluster)
+                wait_for_epochs_align(self.shell, self.cluster)
                 try_to_get_object_and_expect_error(
                     cid=user_container,
                     oid=oid,
@@ -392,7 +392,7 @@ class Test_http_system_header(ClusterTestBase):
             ), f"Epochs should be equal: {get_epoch(self.shell, self.cluster)} != {expected_epoch + 1}"
 
             with allure.step("Check object deleted because it expires-on epoch"):
-                align_epochs(self.shell, self.cluster)
+                wait_for_epochs_align(self.shell, self.cluster)
                 try_to_get_object_and_expect_error(
                     cid=user_container,
                     oid=oid,

--- a/robot/resources/lib/python_keywords/epoch.py
+++ b/robot/resources/lib/python_keywords/epoch.py
@@ -34,9 +34,9 @@ def ensure_fresh_epoch(
     return epoch
 
 
-@allure.step("Align epochs for the whole cluster")
+@allure.step("Wait for epochs align in whole cluster")
 @wait_for_success(60, 5)
-def align_epochs(shell: Shell, cluster: Cluster) -> bool:
+def wait_for_epochs_align(shell: Shell, cluster: Cluster) -> bool:
     epochs = []
     for node in cluster.storage_nodes:
         epochs.append(get_epoch(shell, cluster, node))


### PR DESCRIPTION
Epoch change is a complex process with network/events/notifications models, so for lifetime test we need to wait for epoch alignment before checking the expired object

Signed-off-by: Andrey Berezin <a.berezin@yadro.com>