### PR TITLE
Update timer up to 5 mins to retry start/stop services

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
       - id: black
         language_version: python3.9
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort (python)

--- a/pytest_tests/helpers/cluster.py
+++ b/pytest_tests/helpers/cluster.py
@@ -46,11 +46,11 @@ class NodeBase:
     def label(self) -> str:
         return self.name
 
-    @wait_for_success(60, 1)
+    @wait_for_success(300, 1)
     def start_service(self):
         self.host.start_service(self.name)
 
-    @wait_for_success(60, 1)
+    @wait_for_success(300, 1)
     def stop_service(self):
         self.host.stop_service(self.name)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ Events==0.4
 flake8==4.0.1
 idna==3.3
 iniconfig==1.1.1
-isort==5.10.1
+isort==5.12.0
 jmespath==0.10.0
 jsonschema==4.5.1
 lz4==3.1.3


### PR DESCRIPTION
The wait time for start/stop services has been expanded due to test results shown that 1 minute is not enough to stop `neofs-storage` service when the cluster is under load:
```
20:15:25 [INFO] HOST: 10.78.69.121
COMMAND:
 sudo /usr/bin/neofs-cli control set-status --status offline --endpoint localhost:8091 --wallet /etc/neofs/storage/wallet.json --config /tmp/s04-config.yaml
RC:
 0
STDOUT:
 Network status update request successfully sent.
 
20:17:21 [INFO] HOST: 10.78.69.121
COMMAND:
 sudo systemctl stop neofs-storage.service
RC:
 0
STDOUT

Start / End / Elapsed	 20:18:11.637407 / 20:18:11.908446 / 0:00:00.271039
20:18:17 [INFO] Execute command "sudo systemctl status neofs-storage.service --lines=0" on "10.78.69.121"
20:18:18 [INFO] HOST: 10.78.69.121
COMMAND:
 sudo systemctl status neofs-storage.service --lines=0
RC:
 3
STDOUT:
 ● neofs-storage.service - NeoFS Storage-neofs-storage node
      Loaded: loaded (/lib/systemd/system/neofs-storage.service; enabled; vendor preset: enabled)
     Drop-In: /etc/systemd/system/neofs-storage.service.d
              └─limits.conf
      Active: failed (Result: timeout) since Wed 2023-02-01 20:17:21 UTC; 56s ago
     Process: 30334 ExecStart=/usr/bin/neofs-node --config /etc/neofs/storage/config.yml (code=killed, signal=KILL)
    Main PID: 30334 (code=killed, signal=KILL)
         CPU: 3w 5h 5min 27.024s
 ```


Also, I have updated isort due to faced the problem with isort 5.10.1:
```
((local-pytest)) root@NB-2140-wsl:~/neofs-testcases# git commit -m "Update timer up to 5 mins to retry start/stop services" --signoff
[INFO] Initializing environment for https://github.com/psf/black.
[INFO] Initializing environment for https://github.com/pycqa/isort.
[INFO] Installing environment for https://github.com/psf/black.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/pycqa/isort.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
An unexpected error has occurred: CalledProcessError: command: ('/root/.cache/pre-commit/repount7kt2i/py_env-python3/bin/python', '-mpip', 'install', '.')
return code: 1
expected return code: 0
stdout:
    Processing /root/.cache/pre-commit/repount7kt2i
      Installing build dependencies: started
      Installing build dependencies: finished with status 'done'
      Getting requirements to build wheel: started
      Getting requirements to build wheel: finished with status 'done'
      Preparing metadata (pyproject.toml): started
      Preparing metadata (pyproject.toml): finished with status 'error'

stderr:
      error: subprocess-exited-with-error

      × Preparing metadata (pyproject.toml) did not run successfully.
      │ exit code: 1
      ╰─> [14 lines of output]
          Traceback (most recent call last):
            File "/root/.cache/pre-commit/repount7kt2i/py_env-python3/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 351, in <module>
              main()
            File "/root/.cache/pre-commit/repount7kt2i/py_env-python3/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 333, in main
              json_out['return_val'] = hook(**hook_input['kwargs'])
            File "/root/.cache/pre-commit/repount7kt2i/py_env-python3/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 152, in prepare_metadata_for_build_wheel
              return hook(metadata_directory, config_settings)
            File "/tmp/pip-build-env-e9kxmdue/overlay/lib/python3.9/site-packages/poetry/core/masonry/api.py", line 40, in prepare_metadata_for_build_wheel
              poetry = Factory().create_poetry(Path(".").resolve(), with_groups=False)
            File "/tmp/pip-build-env-e9kxmdue/overlay/lib/python3.9/site-packages/poetry/core/factory.py", line 57, in create_poetry
              raise RuntimeError("The Poetry configuration is invalid:\n" + message)
          RuntimeError: The Poetry configuration is invalid:
            - [extras.pipfile_deprecated_finder.2] 'pip-shims<=0.3.4' does not match '^[a-zA-Z-_.0-9]+$'

          [end of output]

      note: This error originates from a subprocess, and is likely not a problem with pip.
    error: metadata-generation-failed

    × Encountered error while generating package metadata.
    ╰─> See above for output.

    note: This is an issue with the package mentioned above, not pip.
    hint: See above for details.

Check the log at /root/.cache/pre-commit/pre-commit.log

```

Signed-off-by: Vladislav Karakozov <v.karakozov@yadro.com>