### PR TITLE
Remove wait_for_success for start/stop service methods

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
       - id: black
         language_version: python3.9
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort (python)

--- a/pytest_tests/helpers/cluster.py
+++ b/pytest_tests/helpers/cluster.py
@@ -46,11 +46,9 @@ class NodeBase:
     def label(self) -> str:
         return self.name
 
-    @wait_for_success(60, 1)
     def start_service(self):
         self.host.start_service(self.name)
 
-    @wait_for_success(60, 1)
     def stop_service(self):
         self.host.stop_service(self.name)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ Events==0.4
 flake8==4.0.1
 idna==3.3
 iniconfig==1.1.1
-isort==5.10.1
+isort==5.12.0
 jmespath==0.10.0
 jsonschema==4.5.1
 lz4==3.1.3


### PR DESCRIPTION
The code aimed to delete wait_for_success for start/stop methods due to inside those methods it's already implemented.
Signed-off-by: Vladislav Karakozov <v.karakozov@yadro.com>