### PR TITLE
object: mark as skip tests

### DIFF
--- a/pytest_tests/testsuites/object/test_object_api.py
+++ b/pytest_tests/testsuites/object/test_object_api.py
@@ -138,6 +138,8 @@ def storage_objects(
 @pytest.mark.grpc_api
 class TestObjectApi(ClusterTestBase):
     @allure.title("Validate object storage policy by native API")
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/519")
+    @pytest.mark.nspcc_dev__neofs_testcases__issue_519
     def test_object_storage_policies(
         self, request: FixtureRequest, storage_objects: list[StorageObjectInfo], simple_object_size
     ):
@@ -169,6 +171,8 @@ class TestObjectApi(ClusterTestBase):
                 assert copies == 2, "Expected 2 copies"
 
     @allure.title("Validate get object native API")
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/519")
+    @pytest.mark.nspcc_dev__neofs_testcases__issue_519
     def test_get_object_api(
         self, request: FixtureRequest, storage_objects: list[StorageObjectInfo]
     ):
@@ -190,6 +194,8 @@ class TestObjectApi(ClusterTestBase):
                 assert storage_object.file_hash == file_hash
 
     @allure.title("Validate head object native API")
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/519")
+    @pytest.mark.nspcc_dev__neofs_testcases__issue_519
     def test_head_object_api(
         self, request: FixtureRequest, storage_objects: list[StorageObjectInfo]
     ):
@@ -219,6 +225,8 @@ class TestObjectApi(ClusterTestBase):
             self.check_header_is_presented(head_info, storage_object_2.attributes)
 
     @allure.title("Validate object search by native API")
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/519")
+    @pytest.mark.nspcc_dev__neofs_testcases__issue_519
     def test_search_object_api(
         self, request: FixtureRequest, storage_objects: list[StorageObjectInfo]
     ):
@@ -338,6 +346,8 @@ class TestObjectApi(ClusterTestBase):
     @allure.title("Validate native object API get_range_hash")
     @pytest.mark.sanity
     @pytest.mark.grpc_api
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/519")
+    @pytest.mark.nspcc_dev__neofs_testcases__issue_519
     def test_object_get_range_hash(
         self, request: FixtureRequest, storage_objects: list[StorageObjectInfo], max_object_size
     ):
@@ -377,6 +387,8 @@ class TestObjectApi(ClusterTestBase):
     @allure.title("Validate native object API get_range")
     @pytest.mark.sanity
     @pytest.mark.grpc_api
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/519")
+    @pytest.mark.nspcc_dev__neofs_testcases__issue_519
     def test_object_get_range(
         self, request: FixtureRequest, storage_objects: list[StorageObjectInfo], max_object_size
     ):
@@ -417,6 +429,8 @@ class TestObjectApi(ClusterTestBase):
     @allure.title("Validate native object API get_range negative cases")
     @pytest.mark.sanity
     @pytest.mark.grpc_api
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/519")
+    @pytest.mark.nspcc_dev__neofs_testcases__issue_519
     def test_object_get_range_negatives(
         self,
         request: FixtureRequest,
@@ -472,6 +486,8 @@ class TestObjectApi(ClusterTestBase):
                         )
 
     @allure.title("Validate native object API get_range_hash negative cases")
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/519")
+    @pytest.mark.nspcc_dev__neofs_testcases__issue_519
     def test_object_get_range_hash_negatives(
         self,
         request: FixtureRequest,

--- a/pytest_tests/testsuites/object/test_object_lock.py
+++ b/pytest_tests/testsuites/object/test_object_lock.py
@@ -152,6 +152,8 @@ class TestObjectLockWithGrpc(ClusterTestBase):
         ids=["simple object", "complex object"],
         indirect=True,
     )
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/519")
+    @pytest.mark.nspcc_dev__neofs_testcases__issue_519
     def test_locked_object_cannot_be_deleted(
         self,
         request: FixtureRequest,
@@ -397,6 +399,8 @@ class TestObjectLockWithGrpc(ClusterTestBase):
         [pytest.lazy_fixture("simple_object_size"), pytest.lazy_fixture("complex_object_size")],
         ids=["simple object", "complex object"],
     )
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/519")
+    @pytest.mark.nspcc_dev__neofs_testcases__issue_519
     def test_already_outdated_lock_should_not_be_applied(
         self,
         request: FixtureRequest,
@@ -437,6 +441,8 @@ class TestObjectLockWithGrpc(ClusterTestBase):
         ids=["simple object", "complex object"],
     )
     @expect_not_raises()
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/519")
+    @pytest.mark.nspcc_dev__neofs_testcases__issue_519
     def test_after_lock_expiration_with_lifetime_user_should_be_able_to_delete_object(
         self,
         request: FixtureRequest,
@@ -479,6 +485,8 @@ class TestObjectLockWithGrpc(ClusterTestBase):
         ids=["simple object", "complex object"],
     )
     @expect_not_raises()
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/519")
+    @pytest.mark.nspcc_dev__neofs_testcases__issue_519
     def test_after_lock_expiration_with_expire_at_user_should_be_able_to_delete_object(
         self,
         request: FixtureRequest,
@@ -553,6 +561,8 @@ class TestObjectLockWithGrpc(ClusterTestBase):
         [pytest.lazy_fixture("complex_object_size")],
         indirect=True,
     )
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/519")
+    @pytest.mark.nspcc_dev__neofs_testcases__issue_519
     def test_link_object_of_locked_complex_object_can_be_dropped(
         self, new_locked_storage_object: StorageObjectInfo
     ):
@@ -583,6 +593,8 @@ class TestObjectLockWithGrpc(ClusterTestBase):
         [pytest.lazy_fixture("complex_object_size")],
         indirect=True,
     )
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/519")
+    @pytest.mark.nspcc_dev__neofs_testcases__issue_519
     def test_chunks_of_locked_complex_object_can_be_dropped(
         self, new_locked_storage_object: StorageObjectInfo
     ):
@@ -609,6 +621,8 @@ class TestObjectLockWithGrpc(ClusterTestBase):
         ids=["simple object", "complex object"],
         indirect=True,
     )
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/519")
+    @pytest.mark.nspcc_dev__neofs_testcases__issue_519
     def test_locked_object_can_be_dropped(
         self, new_locked_storage_object: StorageObjectInfo, request: FixtureRequest
     ):


### PR DESCRIPTION
Tests that fall with the error "Timed out after 90 seconds" are marked as skip.
These tests are also marked as nspcc_dev__neofs_testcases__issue_519.
See https://github.com/nspcc-dev/neofs-testcases/issues/519 for details.