### PR TITLE
service: mark as skip tests (#524)

### DIFF
--- a/pytest_tests/testsuites/services/http_gate/test_http_bearer.py
+++ b/pytest_tests/testsuites/services/http_gate/test_http_bearer.py
@@ -100,6 +100,8 @@ class Test_http_bearer(ClusterTestBase):
         [pytest.lazy_fixture("simple_object_size"), pytest.lazy_fixture("complex_object_size")],
         ids=["simple object", "complex object"],
     )
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/524")
+    @pytest.mark.nspcc_dev__neofs_testcases__issue_524
     def test_put_with_bearer_when_eacl_restrict(
         self,
         object_size: int,

--- a/pytest_tests/testsuites/services/http_gate/test_http_streaming.py
+++ b/pytest_tests/testsuites/services/http_gate/test_http_streaming.py
@@ -28,6 +28,8 @@ class Test_http_streaming(ClusterTestBase):
         [pytest.lazy_fixture("complex_object_size")],
         ids=["complex object"],
     )
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/524")
+    @pytest.mark.nspcc_dev__neofs_testcases__issue_524
     def test_object_can_be_put_get_by_streaming(self, object_size: int):
         """
         Test that object can be put using gRPC interface and get using HTTP.

--- a/pytest_tests/testsuites/services/http_gate/test_http_system_header.py
+++ b/pytest_tests/testsuites/services/http_gate/test_http_system_header.py
@@ -206,6 +206,8 @@ class Test_http_system_header(ClusterTestBase):
         [pytest.lazy_fixture("simple_object_size"), pytest.lazy_fixture("complex_object_size")],
         ids=["simple object", "complex object"],
     )
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/524")
+    @pytest.mark.nspcc_dev__neofs_testcases__issue_524
     def test_http_attr_priority_epoch_duration(
         self, user_container: str, object_size: int, epoch_duration: int
     ):
@@ -253,6 +255,8 @@ class Test_http_system_header(ClusterTestBase):
         [pytest.lazy_fixture("simple_object_size"), pytest.lazy_fixture("complex_object_size")],
         ids=["simple object", "complex object"],
     )
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/524")
+    @pytest.mark.nspcc_dev__neofs_testcases__issue_524
     def test_http_attr_priority_dur_timestamp(
         self, user_container: str, object_size: int, epoch_duration: int
     ):
@@ -307,6 +311,8 @@ class Test_http_system_header(ClusterTestBase):
         [pytest.lazy_fixture("simple_object_size"), pytest.lazy_fixture("complex_object_size")],
         ids=["simple object", "complex object"],
     )
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/524")
+    @pytest.mark.nspcc_dev__neofs_testcases__issue_524
     def test_http_attr_priority_timestamp_rfc(
         self, user_container: str, object_size: int, epoch_duration: int
     ):
@@ -359,6 +365,8 @@ class Test_http_system_header(ClusterTestBase):
         [pytest.lazy_fixture("simple_object_size"), pytest.lazy_fixture("complex_object_size")],
         ids=["simple object", "complex object"],
     )
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/524")
+    @pytest.mark.nspcc_dev__neofs_testcases__issue_524
     def test_http_rfc_object_unavailable_after_expir(
         self, user_container: str, object_size: int, epoch_duration: int
     ):


### PR DESCRIPTION
Tests that freeze and run indefinitely are marked as skip. These tests are also marked as nspcc_dev__neofs_testcases__issue_524. See https://github.com/nspcc-dev/neofs-testcases/issues/524 for details.