### PR TITLE
s3_gate: mark as skip tests (#521)

### DIFF
--- a/pytest_tests/testsuites/services/s3_gate/test_s3_ACL.py
+++ b/pytest_tests/testsuites/services/s3_gate/test_s3_ACL.py
@@ -15,6 +15,8 @@ def pytest_generate_tests(metafunc):
 @pytest.mark.sanity
 @pytest.mark.acl
 @pytest.mark.s3_gate
+@pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/521")
+@pytest.mark.nspcc_dev__neofs_testcases__issue_521
 class TestS3GateACL(TestS3GateBase):
     @allure.title("Test S3: Object ACL")
     def test_s3_object_ACL(self, bucket, simple_object_size):

--- a/pytest_tests/testsuites/services/s3_gate/test_s3_bucket.py
+++ b/pytest_tests/testsuites/services/s3_gate/test_s3_bucket.py
@@ -22,6 +22,8 @@ def pytest_generate_tests(metafunc):
 @pytest.mark.sanity
 @pytest.mark.s3_gate
 @pytest.mark.s3_gate_bucket
+@pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/521")
+@pytest.mark.nspcc_dev__neofs_testcases__issue_521
 class TestS3GateBucket(TestS3GateBase):
     @allure.title("Test S3: Create Bucket with different ACL")
     def test_s3_create_bucket_with_ACL(self):

--- a/pytest_tests/testsuites/services/s3_gate/test_s3_gate.py
+++ b/pytest_tests/testsuites/services/s3_gate/test_s3_gate.py
@@ -37,6 +37,8 @@ def pytest_generate_tests(metafunc):
 @pytest.mark.sanity
 @pytest.mark.s3_gate
 @pytest.mark.s3_gate_base
+@pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/521")
+@pytest.mark.nspcc_dev__neofs_testcases__issue_521
 class TestS3Gate(TestS3GateBase):
     @allure.title("Test S3 Bucket API")
     def test_s3_buckets(self, simple_object_size):

--- a/pytest_tests/testsuites/services/s3_gate/test_s3_locking.py
+++ b/pytest_tests/testsuites/services/s3_gate/test_s3_locking.py
@@ -19,6 +19,8 @@ def pytest_generate_tests(metafunc):
 @pytest.mark.s3_gate
 @pytest.mark.s3_gate_locking
 @pytest.mark.parametrize("version_id", [None, "second"])
+@pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/521")
+@pytest.mark.nspcc_dev__neofs_testcases__issue_521
 class TestS3GateLocking(TestS3GateBase):
     @allure.title("Test S3: Checking the operation of retention period & legal lock on the object")
     def test_s3_object_locking(self, version_id, simple_object_size):
@@ -203,6 +205,8 @@ class TestS3GateLocking(TestS3GateBase):
 
 
 @pytest.mark.s3_gate
+@pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/521")
+@pytest.mark.nspcc_dev__neofs_testcases__issue_521
 class TestS3GateLockingBucket(TestS3GateBase):
     @allure.title("Test S3: Bucket Lock")
     def test_s3_bucket_lock(self, simple_object_size):

--- a/pytest_tests/testsuites/services/s3_gate/test_s3_multipart.py
+++ b/pytest_tests/testsuites/services/s3_gate/test_s3_multipart.py
@@ -17,6 +17,8 @@ def pytest_generate_tests(metafunc):
 @pytest.mark.sanity
 @pytest.mark.s3_gate
 @pytest.mark.s3_gate_multipart
+@pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/521")
+@pytest.mark.nspcc_dev__neofs_testcases__issue_521
 class TestS3GateMultipart(TestS3GateBase):
     @allure.title("Test S3 Object Multipart API")
     def test_s3_object_multipart(self):

--- a/pytest_tests/testsuites/services/s3_gate/test_s3_object.py
+++ b/pytest_tests/testsuites/services/s3_gate/test_s3_object.py
@@ -31,6 +31,8 @@ def pytest_generate_tests(metafunc):
 @pytest.mark.sanity
 @pytest.mark.s3_gate
 @pytest.mark.s3_gate_object
+@pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/521")
+@pytest.mark.nspcc_dev__neofs_testcases__issue_521
 class TestS3GateObject(TestS3GateBase):
     @staticmethod
     def object_key_from_file_path(full_path: str) -> str:

--- a/pytest_tests/testsuites/services/s3_gate/test_s3_policy.py
+++ b/pytest_tests/testsuites/services/s3_gate/test_s3_policy.py
@@ -23,6 +23,8 @@ def pytest_generate_tests(metafunc):
 
 
 @pytest.mark.s3_gate
+@pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/521")
+@pytest.mark.nspcc_dev__neofs_testcases__issue_521
 class TestS3GatePolicy(TestS3GateBase):
     @allure.title("Test S3: Verify bucket creation with retention policy applied")
     def test_s3_bucket_location(self, simple_object_size):

--- a/pytest_tests/testsuites/services/s3_gate/test_s3_tagging.py
+++ b/pytest_tests/testsuites/services/s3_gate/test_s3_tagging.py
@@ -21,6 +21,8 @@ def pytest_generate_tests(metafunc):
 @pytest.mark.sanity
 @pytest.mark.s3_gate
 @pytest.mark.s3_gate_tagging
+@pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/521")
+@pytest.mark.nspcc_dev__neofs_testcases__issue_521
 class TestS3GateTagging(TestS3GateBase):
     @staticmethod
     def create_tags(count: int) -> Tuple[list, list]:

--- a/pytest_tests/testsuites/services/s3_gate/test_s3_versioning.py
+++ b/pytest_tests/testsuites/services/s3_gate/test_s3_versioning.py
@@ -17,6 +17,8 @@ def pytest_generate_tests(metafunc):
 @pytest.mark.sanity
 @pytest.mark.s3_gate
 @pytest.mark.s3_gate_versioning
+@pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/521")
+@pytest.mark.nspcc_dev__neofs_testcases__issue_521
 class TestS3GateVersioning(TestS3GateBase):
     @staticmethod
     def object_key_from_file_path(full_path: str) -> str:


### PR DESCRIPTION
Tests that fall with the error "SSL: WRONG_VERSION_NUMBER" are marked as skip. These tests are also marked as nspcc_dev__neofs_testcases__issue_521. See https://github.com/nspcc-dev/neofs-testcases/issues/521 for details.