### PR TITLE
session_token: change xfail mark to skip in test_static_session_search

### DIFF
--- a/pytest_tests/testsuites/session_token/test_static_object_session_token.py
+++ b/pytest_tests/testsuites/session_token/test_static_object_session_token.py
@@ -228,8 +228,8 @@ class TestObjectStaticSession(ClusterTestBase):
 
     @allure.title("Validate static session with search operation")
     @pytest.mark.static_session
-    @pytest.mark.xfail
-    # (see https://github.com/nspcc-dev/neofs-node/issues/2030)
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-node/issues/2030")
+    @pytest.mark.nspcc_dev__neofs_node__issue_2030
     def test_static_session_search(
         self,
         user_wallet: WalletFile,


### PR DESCRIPTION
Skip the falling test and mark it as nspcc_dev__neofs_node__issue_2030. See https://github.com/nspcc-dev/neofs-node/issues/2030 for details.