### PR TITLE
session_token: mark as skip tests

### DIFF
--- a/pytest_tests/testsuites/session_token/test_static_object_session_token.py
+++ b/pytest_tests/testsuites/session_token/test_static_object_session_token.py
@@ -159,6 +159,8 @@ class TestObjectStaticSession(ClusterTestBase):
             (get_object, ObjectVerb.GET),
         ],
     )
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/519")
+    @pytest.mark.nspcc_dev__neofs_testcases__issue_519
     def test_static_session_read(
         self,
         user_wallet: WalletFile,
@@ -192,6 +194,8 @@ class TestObjectStaticSession(ClusterTestBase):
         "method_under_test,verb",
         [(get_range, ObjectVerb.RANGE), (get_range_hash, ObjectVerb.RANGEHASH)],
     )
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/519")
+    @pytest.mark.nspcc_dev__neofs_testcases__issue_519
     def test_static_session_range(
         self,
         user_wallet: WalletFile,
@@ -256,6 +260,8 @@ class TestObjectStaticSession(ClusterTestBase):
 
     @allure.title("Validate static session with object id not in session")
     @pytest.mark.static_session
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/519")
+    @pytest.mark.nspcc_dev__neofs_testcases__issue_519
     def test_static_session_unrelated_object(
         self,
         user_wallet: WalletFile,
@@ -281,6 +287,8 @@ class TestObjectStaticSession(ClusterTestBase):
 
     @allure.title("Validate static session with user id not in session")
     @pytest.mark.static_session
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/519")
+    @pytest.mark.nspcc_dev__neofs_testcases__issue_519
     def test_static_session_head_unrelated_user(
         self,
         stranger_wallet: WalletFile,
@@ -308,6 +316,8 @@ class TestObjectStaticSession(ClusterTestBase):
 
     @allure.title("Validate static session with wrong verb in session")
     @pytest.mark.static_session
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/519")
+    @pytest.mark.nspcc_dev__neofs_testcases__issue_519
     def test_static_session_head_wrong_verb(
         self,
         user_wallet: WalletFile,
@@ -363,6 +373,8 @@ class TestObjectStaticSession(ClusterTestBase):
 
     @allure.title("Validate static session which signed by another wallet")
     @pytest.mark.static_session
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/519")
+    @pytest.mark.nspcc_dev__neofs_testcases__issue_519
     def test_static_session_signed_by_other(
         self,
         owner_wallet: WalletFile,
@@ -402,6 +414,8 @@ class TestObjectStaticSession(ClusterTestBase):
 
     @allure.title("Validate static session which signed for another container")
     @pytest.mark.static_session
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/519")
+    @pytest.mark.nspcc_dev__neofs_testcases__issue_519
     def test_static_session_signed_for_other_container(
         self,
         owner_wallet: WalletFile,
@@ -441,6 +455,8 @@ class TestObjectStaticSession(ClusterTestBase):
 
     @allure.title("Validate static session which wasn't signed")
     @pytest.mark.static_session
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/519")
+    @pytest.mark.nspcc_dev__neofs_testcases__issue_519
     def test_static_session_without_sign(
         self,
         owner_wallet: WalletFile,
@@ -641,6 +657,8 @@ class TestObjectStaticSession(ClusterTestBase):
             )
 
     @allure.title("Delete verb should be restricted for static session")
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/519")
+    @pytest.mark.nspcc_dev__neofs_testcases__issue_519
     def test_static_session_delete_verb(
         self,
         user_wallet: WalletFile,
@@ -666,6 +684,8 @@ class TestObjectStaticSession(ClusterTestBase):
             )
 
     @allure.title("Put verb should be restricted for static session")
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/519")
+    @pytest.mark.nspcc_dev__neofs_testcases__issue_519
     def test_static_session_put_verb(
         self,
         user_wallet: WalletFile,
@@ -691,7 +711,9 @@ class TestObjectStaticSession(ClusterTestBase):
             )
 
     @allure.title("Validate static session which is issued in future epoch")
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/519")
     @pytest.mark.static_session
+    @pytest.mark.nspcc_dev__neofs_testcases__issue_519
     def test_static_session_invalid_issued_epoch(
         self,
         owner_wallet: WalletFile,


### PR DESCRIPTION
Tests that fail with the error "Timed out after 90 seconds" are marked as skip. These tests are also marked as nspcc_dev__neofs_testcases__issue_519. See https://github.com/nspcc-dev/neofs-testcases/issues/519 for details.