### PR TITLE
http_gate: mark as skip test (#533)

### DIFF
--- a/pytest_tests/testsuites/services/http_gate/test_http_system_header.py
+++ b/pytest_tests/testsuites/services/http_gate/test_http_system_header.py
@@ -138,6 +138,10 @@ class Test_http_system_header(ClusterTestBase):
         return oid, head
 
     @allure.title("[negative] attempt to put object with expired epoch")
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-node/issues/2262")
+    @pytest.mark.nspcc_dev__neofs_node__issue_2262
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/533")
+    @pytest.mark.nspcc_dev__neofs_testcases__issue_533
     def test_unable_put_expired_epoch(self, user_container: str, simple_object_size: int):
         headers = attr_into_str_header_curl(
             {"Neofs-Expiration-Epoch": str(get_epoch(self.shell, self.cluster) - 1)}
@@ -155,6 +159,10 @@ class Test_http_system_header(ClusterTestBase):
             )
 
     @allure.title("[negative] attempt to put object with negative Neofs-Expiration-Duration")
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-node/issues/2262")
+    @pytest.mark.nspcc_dev__neofs_node__issue_2262
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/533")
+    @pytest.mark.nspcc_dev__neofs_testcases__issue_533
     def test_unable_put_negative_duration(self, user_container: str, simple_object_size: int):
         headers = attr_into_str_header_curl({"Neofs-Expiration-Duration": "-1h"})
         file_path = generate_file(simple_object_size)
@@ -172,6 +180,10 @@ class Test_http_system_header(ClusterTestBase):
     @allure.title(
         "[negative] attempt to put object with Neofs-Expiration-Timestamp value in the past"
     )
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-node/issues/2262")
+    @pytest.mark.nspcc_dev__neofs_node__issue_2262
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/533")
+    @pytest.mark.nspcc_dev__neofs_testcases__issue_533
     def test_unable_put_expired_timestamp(self, user_container: str, simple_object_size: int):
         headers = attr_into_str_header_curl({"Neofs-Expiration-Timestamp": "1635075727"})
         file_path = generate_file(simple_object_size)
@@ -189,6 +201,10 @@ class Test_http_system_header(ClusterTestBase):
     @allure.title(
         "[negative] Put object using HTTP with attribute Neofs-Expiration-RFC3339 where duration is in the past"
     )
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-node/issues/2262")
+    @pytest.mark.nspcc_dev__neofs_node__issue_2262
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/533")
+    @pytest.mark.nspcc_dev__neofs_testcases__issue_533
     def test_unable_put_expired_rfc(self, user_container: str, simple_object_size: int):
         headers = attr_into_str_header_curl({"Neofs-Expiration-RFC3339": "2021-11-22T09:55:49Z"})
         file_path = generate_file(simple_object_size)


### PR DESCRIPTION
Tests that fail with the division by zero are marked as skip. These tests are also marked as nspcc_dev__neofs_node__issue_2262 and nspcc_dev__neofs_testcases__issue_533.

See https://github.com/nspcc-dev/neofs-testcases/issues/533 and https://github.com/nspcc-dev/neofs-node/issues/2262 for details.