### PR TITLE
object: mark as skip test (#537)

### DIFF
--- a/pytest_tests/testsuites/object/test_object_lock.py
+++ b/pytest_tests/testsuites/object/test_object_lock.py
@@ -276,6 +276,9 @@ class TestObjectLockWithGrpc(ClusterTestBase):
         [pytest.lazy_fixture("simple_object_size"), pytest.lazy_fixture("complex_object_size")],
         ids=["simple object", "complex object"],
     )
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/537")
+    @pytest.mark.nspcc_dev__neofs_testcases__issue_537
+    @pytest.mark.nspcc_dev__neofs_testcases__issue_519
     def test_expired_object_should_be_deleted_after_locks_are_expired(
         self,
         request: FixtureRequest,


### PR DESCRIPTION
Test test_expired_object_should_be_deleted_after_locks_are_expired that fail with the error "object not found" are marked as skip. Test are also marked as nspcc_dev__neofs_testcases__issue_537 and nspcc_dev__neofs_testcases__issue_519.
See https://github.com/nspcc-dev/neofs-testcases/issues/537 for details.