### PR TITLE
http_gate: mark as skip tests (#523)

### DIFF
--- a/pytest_tests/testsuites/services/http_gate/test_http_bearer.py
+++ b/pytest_tests/testsuites/services/http_gate/test_http_bearer.py
@@ -26,6 +26,8 @@ logger = logging.getLogger("NeoLogger")
 
 @pytest.mark.sanity
 @pytest.mark.http_gate
+@pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/523")
+@pytest.mark.nspcc_dev__neofs_testcases__issue_523
 class Test_http_bearer(ClusterTestBase):
     PLACEMENT_RULE = "REP 2 IN X CBF 1 SELECT 2 FROM * AS X"
 

--- a/pytest_tests/testsuites/services/http_gate/test_http_gate.py
+++ b/pytest_tests/testsuites/services/http_gate/test_http_gate.py
@@ -34,6 +34,8 @@ OBJECT_NOT_FOUND_ERROR = "not found"
 @allure.link("https://github.com/nspcc-dev/neofs-http-gw#downloading", name="downloading")
 @pytest.mark.sanity
 @pytest.mark.http_gate
+@pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/523")
+@pytest.mark.nspcc_dev__neofs_testcases__issue_523
 class TestHttpGate(ClusterTestBase):
     PLACEMENT_RULE_1 = "REP 1 IN X CBF 1 SELECT 1 FROM * AS X"
     PLACEMENT_RULE_2 = "REP 2 IN X CBF 2 SELECT 2 FROM * AS X"

--- a/pytest_tests/testsuites/services/http_gate/test_http_headers.py
+++ b/pytest_tests/testsuites/services/http_gate/test_http_headers.py
@@ -31,6 +31,8 @@ logger = logging.getLogger("NeoLogger")
 
 @pytest.mark.sanity
 @pytest.mark.http_gate
+@pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/523")
+@pytest.mark.nspcc_dev__neofs_testcases__issue_523
 class Test_http_headers(ClusterTestBase):
     PLACEMENT_RULE = "REP 2 IN X CBF 1 SELECT 4 FROM * AS X"
     obj1_keys = ["Writer", "Chapter1", "Chapter2"]


### PR DESCRIPTION
All tests in test_http_bearer, test_http_gate and test_http_headers suites fail with errors "Failed to connect to http.neofs.devenv port 80" or "Failed to establish a new connection", so they are marked as skip. These tests are also marked as nspcc_dev__neofs_testcases__issue_523. See https://github.com/nspcc-dev/neofs-testcases/issues/523 for details.