### PR TITLE
network, object, payment, services, session_token: mark as skip tests…

### DIFF
--- a/pytest_tests/testsuites/network/test_node_management.py
+++ b/pytest_tests/testsuites/network/test_node_management.py
@@ -46,6 +46,8 @@ check_nodes: list[StorageNode] = []
 @allure.title("Add one node to cluster")
 @pytest.mark.add_nodes
 @pytest.mark.node_mgmt
+@pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/542")
+@pytest.mark.nspcc_dev__neofs_testcases__issue_542
 class TestNodeManagement(ClusterTestBase):
     @pytest.fixture
     @allure.title("Create container and pick the node with data")

--- a/pytest_tests/testsuites/object/test_object_api_bearer.py
+++ b/pytest_tests/testsuites/object/test_object_api_bearer.py
@@ -142,6 +142,8 @@ class TestObjectApiWithBearerToken(ClusterTestBase):
         [pytest.lazy_fixture("simple_object_size"), pytest.lazy_fixture("complex_object_size")],
         ids=["simple object", "complex object"],
     )
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/542")
+    @pytest.mark.nspcc_dev__neofs_testcases__issue_542
     def test_get_object_with_s3_wallet_bearer_from_all_nodes(
         self,
         user_container: StorageContainer,

--- a/pytest_tests/testsuites/object/test_object_lifetime.py
+++ b/pytest_tests/testsuites/object/test_object_lifetime.py
@@ -24,6 +24,8 @@ class TestObjectApiLifetime(ClusterTestBase):
         [pytest.lazy_fixture("simple_object_size"), pytest.lazy_fixture("complex_object_size")],
         ids=["simple object", "complex object"],
     )
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/542")
+    @pytest.mark.nspcc_dev__neofs_testcases__issue_542
     def test_object_api_lifetime(
         self, default_wallet: str, request: FixtureRequest, object_size: int
     ):

--- a/pytest_tests/testsuites/object/test_object_lock.py
+++ b/pytest_tests/testsuites/object/test_object_lock.py
@@ -180,6 +180,8 @@ class TestObjectLockWithGrpc(ClusterTestBase):
     @pytest.mark.parametrize(
         "locked_storage_object", [pytest.lazy_fixture("simple_object_size")], indirect=True
     )
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/542")
+    @pytest.mark.nspcc_dev__neofs_testcases__issue_542
     def test_lock_object_itself_cannot_be_deleted(
         self,
         locked_storage_object: StorageObjectInfo,
@@ -205,6 +207,8 @@ class TestObjectLockWithGrpc(ClusterTestBase):
     @pytest.mark.parametrize(
         "locked_storage_object", [pytest.lazy_fixture("simple_object_size")], indirect=True
     )
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/542")
+    @pytest.mark.nspcc_dev__neofs_testcases__issue_542
     def test_lock_object_cannot_be_locked(
         self,
         locked_storage_object: StorageObjectInfo,
@@ -242,6 +246,8 @@ class TestObjectLockWithGrpc(ClusterTestBase):
             (None, -1, 'invalid argument "-1" for "-e, --expire-at" flag'),
         ],
     )
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/542")
+    @pytest.mark.nspcc_dev__neofs_testcases__issue_542
     def test_cannot_lock_object_without_lifetime(
         self,
         locked_storage_object: StorageObjectInfo,

--- a/pytest_tests/testsuites/payment/test_balance.py
+++ b/pytest_tests/testsuites/payment/test_balance.py
@@ -59,6 +59,8 @@ class TestBalanceAccounting(ClusterTestBase):
         return api_config_file
 
     @allure.title("Test balance request with wallet and address")
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/542")
+    @pytest.mark.nspcc_dev__neofs_testcases__issue_542
     def test_balance_wallet_address(self, main_wallet: WalletFile, cli: NeofsCli):
         result = cli.accounting.balance(
             wallet=main_wallet.path,
@@ -69,6 +71,8 @@ class TestBalanceAccounting(ClusterTestBase):
         self.check_amount(result)
 
     @allure.title("Test balance request with wallet only")
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/542")
+    @pytest.mark.nspcc_dev__neofs_testcases__issue_542
     def test_balance_wallet(self, main_wallet: WalletFile, cli: NeofsCli):
         result = cli.accounting.balance(
             wallet=main_wallet.path, rpc_endpoint=self.cluster.default_rpc_endpoint
@@ -87,6 +91,8 @@ class TestBalanceAccounting(ClusterTestBase):
             )
 
     @allure.title("Test balance request with config file")
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/542")
+    @pytest.mark.nspcc_dev__neofs_testcases__issue_542
     def test_balance_api(self, temp_directory: str, main_wallet: WalletFile, client_shell: Shell):
         config_file = self.write_api_config(
             config_dir=temp_directory,

--- a/pytest_tests/testsuites/services/http_gate/test_http_gate.py
+++ b/pytest_tests/testsuites/services/http_gate/test_http_gate.py
@@ -46,6 +46,8 @@ class TestHttpGate(ClusterTestBase):
         TestHttpGate.wallet = default_wallet
 
     @allure.title("Test Put over gRPC, Get over HTTP")
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/542")
+    @pytest.mark.nspcc_dev__neofs_testcases__issue_542
     def test_put_grpc_get_http(self, complex_object_size, simple_object_size):
         """
         Test that object can be put using gRPC interface and get using HTTP.

--- a/pytest_tests/testsuites/services/http_gate/test_http_object.py
+++ b/pytest_tests/testsuites/services/http_gate/test_http_object.py
@@ -34,6 +34,8 @@ class Test_http_object(ClusterTestBase):
         [pytest.lazy_fixture("simple_object_size"), pytest.lazy_fixture("complex_object_size")],
         ids=["simple object", "complex object"],
     )
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/542")
+    @pytest.mark.nspcc_dev__neofs_testcases__issue_542
     def test_object_put_get_attributes(self, object_size: int):
         """
         Test that object can be put using gRPC interface and get using HTTP.

--- a/pytest_tests/testsuites/session_token/test_static_object_session_token.py
+++ b/pytest_tests/testsuites/session_token/test_static_object_session_token.py
@@ -345,6 +345,8 @@ class TestObjectStaticSession(ClusterTestBase):
 
     @allure.title("Validate static session with container id not in session")
     @pytest.mark.static_session
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/542")
+    @pytest.mark.nspcc_dev__neofs_testcases__issue_542
     def test_static_session_unrelated_container(
         self,
         user_wallet: WalletFile,

--- a/pytest_tests/testsuites/session_token/test_static_session_token_container.py
+++ b/pytest_tests/testsuites/session_token/test_static_session_token_container.py
@@ -45,6 +45,8 @@ class TestSessionTokenContainer(ClusterTestBase):
             for verb in ContainerVerb
         }
 
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/542")
+    @pytest.mark.nspcc_dev__neofs_testcases__issue_542
     def test_static_session_token_container_create(
         self,
         owner_wallet: WalletFile,
@@ -112,6 +114,8 @@ class TestSessionTokenContainer(ClusterTestBase):
                     wait_for_creation=False,
                 )
 
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/542")
+    @pytest.mark.nspcc_dev__neofs_testcases__issue_542
     def test_static_session_token_container_delete(
         self,
         owner_wallet: WalletFile,
@@ -142,6 +146,8 @@ class TestSessionTokenContainer(ClusterTestBase):
             owner_wallet.path, shell=self.shell, endpoint=self.cluster.default_rpc_endpoint
         )
 
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/542")
+    @pytest.mark.nspcc_dev__neofs_testcases__issue_542
     def test_static_session_token_container_set_eacl(
         self,
         owner_wallet: WalletFile,


### PR DESCRIPTION
… (#542)

Many tests failed with an error "context deadline exceeded" and they are marked as skip.
These tests are also marked as nspcc_dev__neofs_testcases__issue_542. See https://github.com/nspcc-dev/neofs-testcases/issues/542 for details.