### PR TITLE
load: mark as skip test_custom_load (#544)

### DIFF
--- a/pytest_tests/testsuites/load/test_load.py
+++ b/pytest_tests/testsuites/load/test_load.py
@@ -71,6 +71,8 @@ class TestLoad(ClusterTestBase):
     @pytest.mark.parametrize("load_nodes_count", LOAD_NODES_COUNT)
     @pytest.mark.benchmark
     @pytest.mark.grpc
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/544")
+    @pytest.mark.nspcc_dev__neofs_testcases__issue_544
     def test_custom_load(
         self,
         obj_size,


### PR DESCRIPTION
Test test_custom_load that fail with the "Permission denied" error are marked as skip.
Test is also marked as nspcc_dev__neofs_testcases__issue_544. See https://github.com/nspcc-dev/neofs-testcases/issues/544 for details.