### PR TITLE
Use python3.10 -m venv for environment creation

### DIFF
--- a/venv_template.mk
+++ b/venv_template.mk
@@ -3,8 +3,9 @@ venv.$(1): venv.$(1)/bin/activate venv.$(1)/bin/environment.sh
 
 venv.$(1)/bin/activate:
 	@echo "Creating $(1) venv in $$@ from $$<"
-	virtualenv --python=python3.10 --prompt="($(1))" venv.$(1)
+	python3.10 -m venv venv.$(1)
 	. venv.$(1)/bin/activate && \
+	pip3.10 install --upgrade pip && \
 	pip3.10 install -U setuptools==56.0.0 && \
 	pip3.10 install -Ur requirements.txt
 	@echo "Applying activate script patch"


### PR DESCRIPTION
This commit changes the method of creating the virtual environment from using virtualenv to the standard Python venv module, invoking "python3.10 -m venv". Additionally, it adds a step to upgrade pip before installing dependencies.

It's provides a more universal approach and ensures compatibility with Debian 11 and other platforms that might have issues with using virtualenv.