### PR TITLE
pytest_tests: Reduce log verbosity

### DIFF
--- a/pytest_tests/pytest.ini
+++ b/pytest_tests/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 log_cli = 1
-log_cli_level = DEBUG
+log_cli_level = ERROR
 log_cli_format = %(asctime)s [%(levelname)4s] %(message)s
 log_format = %(asctime)s [%(levelname)4s] %(message)s
 log_cli_date_format = %Y-%m-%d %H:%M:%S


### PR DESCRIPTION
This commit reduces log verbosity during testing by changing the log level from DEBUG to ERROR in pytest.ini. This offers several benefits:

1. Readability: Test results are easier to read with less log output.

2. Speed: Deploying test results to GitHub Pages' allure-report is faster, as there is less data to process and transfer.

3. Disk space: Less output saves space on the GitHub-hosted runners, which have limited storage.

In conclusion, this commit improves the efficiency and usability of the testing process.