### PR TITLE
s3_gate: mark as skip tests

### DIFF
--- a/pytest_tests/testsuites/services/s3_gate/test_s3_ACL.py
+++ b/pytest_tests/testsuites/services/s3_gate/test_s3_ACL.py
@@ -17,6 +17,7 @@ def pytest_generate_tests(metafunc):
 class TestS3GateACL(TestS3GateBase):
     @pytest.mark.sanity
     @allure.title("Test S3: Object ACL")
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-s3-gw/issues/784")
     def test_s3_object_ACL(self, bucket, simple_object_size):
         file_path = generate_file(simple_object_size)
         file_name = object_key_from_file_path(file_path)

--- a/pytest_tests/testsuites/services/s3_gate/test_s3_bucket.py
+++ b/pytest_tests/testsuites/services/s3_gate/test_s3_bucket.py
@@ -24,6 +24,7 @@ def pytest_generate_tests(metafunc):
 class TestS3GateBucket(TestS3GateBase):
     @pytest.mark.sanity
     @allure.title("Test S3: Create Bucket with different ACL")
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-s3-gw/issues/784")
     def test_s3_create_bucket_with_ACL(self):
 
         with allure.step("Create bucket with ACL private"):


### PR DESCRIPTION
The tests "Test S3: Object ACL" and "Test S3: Create Bucket with different ACL" are marked as skipped, because the issue is opening: https://github.com/nspcc-dev/neofs-s3-gw/issues/784