### PR TITLE
http_gate: Fix test_object2_can_be_get_by_attr

### DIFF
--- a/pytest_tests/testsuites/services/http_gate/test_http_headers.py
+++ b/pytest_tests/testsuites/services/http_gate/test_http_headers.py
@@ -25,7 +25,6 @@ from wellknown_acl import PUBLIC_ACL
 from helpers.storage_object_info import StorageObjectInfo
 from steps.cluster_test_base import ClusterTestBase
 
-OBJECT_ALREADY_REMOVED_ERROR = "object already removed"
 logger = logging.getLogger("NeoLogger")
 
 
@@ -146,10 +145,11 @@ class Test_http_headers(ClusterTestBase):
                 shell=self.shell,
                 endpoint=self.cluster.default_rpc_endpoint,
             )
+            error_pattern = "404 Not Found"
             try_to_get_object_and_expect_error(
                 cid=storage_object_2.cid,
                 oid=storage_object_2.oid,
-                error_pattern=OBJECT_ALREADY_REMOVED_ERROR,
+                error_pattern=error_pattern,
                 endpoint=self.cluster.default_http_gate_endpoint,
             )
             storage_objects_with_attributes.remove(storage_object_2)


### PR DESCRIPTION
Test modified to be consistent with the http-gw change: https://github.com/nspcc-dev/neofs-http-gw/commit/e6e794105f9264761166d6b6fedfc46fef399d16

Changed the expected error from "object already removed" to "404 Not Found" when trying to get a previously removed object.

This is the allure report before the fix:
[dddd.zip](https://github.com/nspcc-dev/neofs-testcases/files/11799168/dddd.zip)


This is the allure report after the fix:
[dddd_fix.zip](https://github.com/nspcc-dev/neofs-testcases/files/11799171/dddd_fix.zip)

