### PR TITLE
acl, container: Add negative tests

### DIFF
--- a/pytest_tests/helpers/grpc_responses.py
+++ b/pytest_tests/helpers/grpc_responses.py
@@ -27,8 +27,10 @@ INVALID_OFFSET_SPECIFIER = "invalid '{range}' range offset specifier"
 INVALID_LENGTH_SPECIFIER = "invalid '{range}' range length specifier"
 
 NOT_CONTAINER_OWNER = "provided account differs with the container owner"
+NOT_SESSION_CONTAINER_OWNER = "session issuer differs with the container owner"
 TIMED_OUT = "timed out after \\d+ seconds"
 CONTAINER_DELETION_TIMED_OUT = "container deletion: await timeout expired"
+EACL_TIMED_OUT = "eACL setting: await timeout expired"
 
 def error_matches_status(error: Exception, status_pattern: str) -> bool:
     """

--- a/pytest_tests/helpers/grpc_responses.py
+++ b/pytest_tests/helpers/grpc_responses.py
@@ -26,6 +26,9 @@ INVALID_RANGE_OVERFLOW = "invalid '{range}' range: uint64 overflow"
 INVALID_OFFSET_SPECIFIER = "invalid '{range}' range offset specifier"
 INVALID_LENGTH_SPECIFIER = "invalid '{range}' range length specifier"
 
+NOT_CONTAINER_OWNER = "provided account differs with the container owner"
+TIMED_OUT = "timed out after \\d+ seconds"
+CONTAINER_DELETION_TIMED_OUT = "container deletion: await timeout expired"
 
 def error_matches_status(error: Exception, status_pattern: str) -> bool:
     """

--- a/pytest_tests/testsuites/session_token/conftest.py
+++ b/pytest_tests/testsuites/session_token/conftest.py
@@ -24,3 +24,11 @@ def stranger_wallet(wallet_factory: WalletFactory) -> WalletFile:
     Returns stranger wallet which should fail to obtain data
     """
     return wallet_factory.create_wallet()
+
+
+@pytest.fixture(scope="module")
+def scammer_wallet(wallet_factory: WalletFactory) -> WalletFile:
+    """
+    Returns stranger wallet which should fail to obtain data
+    """
+    return wallet_factory.create_wallet()


### PR DESCRIPTION
Added two negative tests that verify that the container cannot be removed or set container EACL by anyone other than the owner (creator) or trusted trusted party proved by the container owner via session token.