### PR TITLE
Disable aws ec2 metadata

### DIFF
--- a/pytest_tests/helpers/aws_cli_client.py
+++ b/pytest_tests/helpers/aws_cli_client.py
@@ -21,6 +21,7 @@ class AwsCliClient:
 
     def __init__(self, s3gate_endpoint) -> None:
         self.s3gate_endpoint = s3gate_endpoint
+        os.environ['AWS_EC2_METADATA_DISABLED'] = 'true'
 
     def create_bucket(
         self,


### PR DESCRIPTION
Fixed bug nspcc-dev/neofs-s3-gw#798
This is a test environment error, not neofs-s3-gw: actions/runner-images#2791
aws/aws-cli#5623

Tests results:
https://github.com/vvarg229/neofs-node/actions/runs/5601200752/jobs/10244709153
https://http.t5.fs.neo.org/86C4P6uJC7gb5n3KkwEGpXRfdczubXyRNW5N9KeJRW73/216-1689781099/index.html#