### PR TITLE
Revert aiohttp to 3.7.4.post0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiodns==3.0.0
-aiohttp==3.8.5
+aiohttp==3.7.4.post0
 aioresponses==0.7.2
 allure-pytest==2.9.45
 allure-python-commons==2.9.45


### PR DESCRIPTION
Because the aiohttp version was changed, dependency errors occurred: The conflict is caused by:
    The user requested async-timeout==3.0.1
    aiohttp 3.8.5 depends on async-timeout<5.0 and >=4.0.0a3
    The user requested aiohttp==3.8.5
    aioresponses 0.7.2 depends on aiohttp<4.0.0 and >=2.0.0
    neo-mamba 1.0.0 depends on aiohttp==3.7.4.post0

To fix it, we need to do some work to update Python and neo-mamba.