### PR TITLE
Fix logging level in the assert_s3_acl

### DIFF
--- a/pytest_tests/helpers/s3_helper.py
+++ b/pytest_tests/helpers/s3_helper.py
@@ -157,4 +157,4 @@ def assert_s3_acl(acl_grants: list, permitted_users: str):
                 permission = acl_grant.get("Permission")
                 assert permission == "FULL_CONTROL", "Only CanonicalUser should have FULL_CONTROL"
             else:
-                logger.error("FULL_CONTROL is given to All Users")
+                raise AssertionError("FULL_CONTROL is given to All Users")

--- a/pytest_tests/testsuites/services/s3_gate/test_s3_object.py
+++ b/pytest_tests/testsuites/services/s3_gate/test_s3_object.py
@@ -133,7 +133,7 @@ class TestS3GateObject(TestS3GateBase):
 
         with allure.step("Copy object and check acl attribute"):
             copy_obj_path = s3_gate_object.copy_object_s3(
-                self.s3_client, bucket, obj_key, ACL="public-read-write"
+                self.s3_client, bucket, obj_key, ACL="private"
             )
             obj_acl = s3_gate_object.get_object_acl_s3(self.s3_client, bucket, copy_obj_path)
             assert_s3_acl(acl_grants=obj_acl, permitted_users="CanonicalUser")


### PR DESCRIPTION
Logging level changed from error to warning.
Now there will be no such messages in the logs:

-------------------------------- live log call --------------------------------- 
Error: -14 10:10:37 [ERROR] FULL_CONTROL is given to All Users
PASSED                                                                   [ 62%]