### PR TITLE
Update session token expiration checks to match the current node behavior

### DIFF
--- a/pytest_tests/testsuites/session_token/test_static_object_session_token.py
+++ b/pytest_tests/testsuites/session_token/test_static_object_session_token.py
@@ -519,7 +519,7 @@ class TestObjectStaticSession(ClusterTestBase):
             session=token_expire_at_next_epoch,
         )
 
-        self.tick_epoch()
+        self.tick_epochs(2)
 
         with pytest.raises(Exception, match=EXPIRED_SESSION_TOKEN):
             head_object(
@@ -585,7 +585,7 @@ class TestObjectStaticSession(ClusterTestBase):
             session=token_start_at_next_epoch,
         )
 
-        self.tick_epoch()
+        self.tick_epochs(2)
         with pytest.raises(Exception, match=EXPIRED_SESSION_TOKEN):
             head_object(
                 user_wallet.path,


### PR DESCRIPTION
Fixes - https://github.com/nspcc-dev/neofs-testcases/issues/602
tests run - https://github.com/evgeniiz321/neofs-node/actions/runs/5906826616/job/16023612260

```
pytest_tests/testsuites/session_token/test_static_object_session_token.py::TestObjectStaticSession::test_static_session_start_at_next[simple object] PASSED
pytest_tests/testsuites/session_token/test_static_object_session_token.py::TestObjectStaticSession::test_static_session_start_at_next[complex object] PASSED
pytest_tests/testsuites/session_token/test_static_object_session_token.py::TestObjectStaticSession::test_static_session_expiration_at_next[simple object] PASSED
pytest_tests/testsuites/session_token/test_static_object_session_token.py::TestObjectStaticSession::test_static_session_expiration_at_next[complex object] PASSED

```