### PR TITLE
pyproject: drop neofs-keywords

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.isort]
 profile = "black"
-src_paths = ["neofs-keywords", "pytest_tests", "robot"]
+src_paths = ["pytest_tests", "robot"]
 line_length = 100
 
 [tool.black]


### PR DESCRIPTION
It doesn't seem to be used, but I'm not sure what's gonna happen if we merge it. Opinions?