### PR TITLE
Add checks for lifetime, expire_at flags

### DIFF
--- a/pytest_tests/steps/session_token.py
+++ b/pytest_tests/steps/session_token.py
@@ -236,6 +236,8 @@ def create_session_token(
     wallet_path: str,
     wallet_password: str,
     rpc_endpoint: str,
+    lifetime: Optional[int] = None,
+    expire_at: Optional[int] = None
 ) -> str:
     """
     Create session token for an object.
@@ -256,6 +258,8 @@ def create_session_token(
         wallet=wallet_path,
         wallet_password=wallet_password,
         out=session_token,
+        lifetime=lifetime,
+        expire_at=expire_at
     )
     return session_token
 

--- a/pytest_tests/testsuites/acl/test_bearer.py
+++ b/pytest_tests/testsuites/acl/test_bearer.py
@@ -1,14 +1,22 @@
+import os
+import uuid
+
 import allure
 import pytest
 from cluster_test_base import ClusterTestBase
+from common import ASSETS_DIR, TEST_FILES_DIR, WALLET_PASS
+from epoch import get_epoch
+from neofs_testlib.utils.wallet import get_last_address_from_wallet
 from python_keywords.acl import (
     EACLAccess,
     EACLOperation,
     EACLRole,
     EACLRule,
+    create_bearer_token,
     create_eacl,
     form_bearertoken_file,
     set_eacl,
+    sign_bearer,
     wait_for_cache_expired,
 )
 from python_keywords.container_access import (
@@ -226,6 +234,79 @@ class TestACLBearer(ClusterTestBase):
                 deny_operations=deny_map_with_bearer[EACLRole.OTHERS],
                 bearer=bearer_other,
                 wallet_config=other_wallet.config_path,
+                shell=self.shell,
+                cluster=self.cluster,
+            )
+
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-api/issues/273")
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-node/issues/2538")
+    @pytest.mark.nspcc_dev__neofs_api__issue_273
+    @pytest.mark.nspcc_dev__neofs_node__issue_2538
+    @pytest.mark.parametrize("expiration_flag", ["lifetime", "expire_at"])
+    def test_bearer_token_expiration(self, wallets, eacl_container_with_objects, expiration_flag):
+        current_epoch = get_epoch(self.shell, self.cluster)
+        self.tick_epochs(1)
+        cid, objects_oids, file_path = eacl_container_with_objects
+        user_wallet = wallets.get_wallet()
+
+        with allure.step("Create and sign bearer token via cli"):
+            eacl = [
+                EACLRule(access=EACLAccess.ALLOW, role=EACLRole.USER, operation=op)
+                for op in EACLOperation
+            ]
+
+            path_to_bearer = os.path.join(
+                os.getcwd(), ASSETS_DIR, TEST_FILES_DIR, f"bearer_token_{str(uuid.uuid4())}"
+            )
+
+            create_bearer_token(
+                self.shell,
+                issued_at=1,
+                not_valid_before=1,
+                owner=get_last_address_from_wallet(user_wallet.wallet_path, WALLET_PASS),
+                out=path_to_bearer,
+                rpc_endpoint=self.cluster.default_rpc_endpoint,
+                eacl=create_eacl(cid, eacl, shell=self.shell),
+                lifetime=1 if expiration_flag == "lifetime" else None,
+                expire_at=current_epoch + 2 if expiration_flag == "expire_at" else None,
+            )
+
+            sign_bearer(
+                shell=self.shell,
+                wallet_path=user_wallet.wallet_path,
+                eacl_rules_file_from=path_to_bearer,
+                eacl_rules_file_to=path_to_bearer,
+                json=True,
+            )
+
+        self.tick_epochs(1)
+
+        with allure.step(
+            f"Check {EACLRole.USER.value} with token has access to all operations with container"
+        ):
+            check_full_access_to_container(
+                user_wallet.wallet_path,
+                cid,
+                objects_oids.pop(),
+                file_path,
+                bearer=path_to_bearer,
+                wallet_config=user_wallet.config_path,
+                shell=self.shell,
+                cluster=self.cluster,
+            )
+
+        self.tick_epochs(1)
+
+        with allure.step(
+            f"Check {EACLRole.USER.value} has no access to all operations with container"
+        ):
+            check_no_access_to_container(
+                user_wallet.wallet_path,
+                cid,
+                objects_oids.pop(),
+                file_path,
+                bearer=path_to_bearer,
+                wallet_config=user_wallet.config_path,
                 shell=self.shell,
                 cluster=self.cluster,
             )

--- a/pytest_tests/testsuites/session_token/test_object_session_token.py
+++ b/pytest_tests/testsuites/session_token/test_object_session_token.py
@@ -4,8 +4,9 @@ import allure
 import pytest
 from cluster_test_base import ClusterTestBase
 from common import WALLET_PASS
+from epoch import get_epoch
 from file_helper import generate_file
-from grpc_responses import SESSION_NOT_FOUND
+from grpc_responses import EXPIRED_SESSION_TOKEN, SESSION_NOT_FOUND
 from neofs_testlib.utils.wallet import get_last_address_from_wallet
 from python_keywords.container import create_container
 from python_keywords.neofs_verbs import delete_object, put_object, put_object_to_random_node
@@ -142,5 +143,75 @@ class TestDynamicObjectSession(ClusterTestBase):
                     oid=oid,
                     shell=self.shell,
                     endpoint=non_container_node.get_rpc_endpoint(),
+                    session=session_token,
+                )
+
+    @allure.title("Verify session token expiration flags")
+    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-node/issues/2539")
+    @pytest.mark.nspcc_dev__neofs_node__issue_2539
+    @pytest.mark.parametrize("expiration_flag", ["lifetime", "expire_at"])
+    def test_session_token_expiration_flags(
+        self, default_wallet, simple_object_size, expiration_flag, cluster
+    ):
+        rpc_endpoint = self.cluster.storage_nodes[0].get_rpc_endpoint()
+
+        with allure.step("Create Session Token with Lifetime param"):
+            current_epoch = get_epoch(self.shell, cluster)
+
+            session_token = create_session_token(
+                shell=self.shell,
+                owner=get_last_address_from_wallet(default_wallet, ""),
+                wallet_path=default_wallet,
+                wallet_password=WALLET_PASS,
+                rpc_endpoint=rpc_endpoint,
+                lifetime=1 if expiration_flag == "lifetime" else None,
+                expire_at=current_epoch + 1 if expiration_flag == "expire_at" else None,
+            )
+
+        with allure.step("Create Private Container"):
+            un_locode = self.cluster.storage_nodes[0].get_un_locode()
+            locode = "SPB" if un_locode == "RU LED" else un_locode.split()[1]
+            placement_policy = (
+                f"REP 1 IN LOC_{locode}_PLACE CBF 1 SELECT 1 FROM LOC_{locode} "
+                f'AS LOC_{locode}_PLACE FILTER "UN-LOCODE" '
+                f'EQ "{un_locode}" AS LOC_{locode}'
+            )
+            cid = create_container(
+                default_wallet,
+                shell=self.shell,
+                endpoint=self.cluster.default_rpc_endpoint,
+                rule=placement_policy,
+            )
+
+        with allure.step("Verify object operations with created session token are allowed"):
+            file_path = generate_file(simple_object_size)
+            oid = put_object(
+                wallet=default_wallet,
+                path=file_path,
+                cid=cid,
+                shell=self.shell,
+                endpoint=rpc_endpoint,
+                session=session_token,
+            )
+            delete_object(
+                wallet=default_wallet,
+                cid=cid,
+                oid=oid,
+                shell=self.shell,
+                endpoint=rpc_endpoint,
+                session=session_token,
+            )
+
+        self.tick_epochs(2)
+
+        with allure.step("Verify object operations with created session token are not allowed"):
+            file_path = generate_file(simple_object_size)
+            with pytest.raises(RuntimeError, match=EXPIRED_SESSION_TOKEN):
+                oid = put_object(
+                    wallet=default_wallet,
+                    path=file_path,
+                    cid=cid,
+                    shell=self.shell,
+                    endpoint=rpc_endpoint,
                     session=session_token,
                 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ mmh3==3.0.0
 multidict==6.0.2
 mypy==0.950
 mypy-extensions==0.4.3
-neofs-testlib==1.1.8
+neofs-testlib==1.1.10
 netaddr==0.8.0
 packaging==21.3
 paramiko==2.10.3

--- a/robot/resources/lib/python_keywords/acl.py
+++ b/robot/resources/lib/python_keywords/acl.py
@@ -276,3 +276,30 @@ def bearer_token_base64_from_file(
     with open(bearer_path, "rb") as file:
         signed = file.read()
     return base64.b64encode(signed).decode("utf-8")
+
+
+@allure.step("Create bearer token")
+def create_bearer_token(
+    shell,
+    issued_at: int,
+    not_valid_before: int,
+    owner: str,
+    out: str,
+    rpc_endpoint: str,
+    json: Optional[bool] = False,
+    eacl: Optional[str] = None,
+    lifetime: Optional[int] = None,
+    expire_at: Optional[int] = None,
+) -> str:
+    neofscli = NeofsCli(shell=shell, neofs_cli_exec_path=NEOFS_CLI_EXEC, config_file=WALLET_CONFIG)
+    neofscli.bearer.create(
+        issued_at=issued_at,
+        not_valid_before=not_valid_before,
+        owner=owner,
+        out=out,
+        rpc_endpoint=rpc_endpoint,
+        json=json,
+        eacl=eacl,
+        lifetime=lifetime,
+        expire_at=expire_at,
+    )

--- a/robot/resources/lib/python_keywords/neofs_verbs.py
+++ b/robot/resources/lib/python_keywords/neofs_verbs.py
@@ -174,6 +174,7 @@ def put_object_to_random_node(
     attributes: Optional[dict] = None,
     xhdr: Optional[dict] = None,
     wallet_config: Optional[str] = None,
+    lifetime: Optional[int] = None,
     expire_at: Optional[int] = None,
     no_progress: bool = True,
     session: Optional[str] = None,
@@ -192,7 +193,8 @@ def put_object_to_random_node(
         cluster: cluster under test
         wallet_config: path to the wallet config
         no_progress: do not show progress bar
-        expire_at: Last epoch in the life of the object
+        lifetime: Lock lifetime - relative to the current epoch.
+        expire_at: Last epoch in the life of the object - absolute value.
         xhdr: Request X-Headers in form of Key=Value
         session: path to a JSON-encoded container session token
     Returns:
@@ -213,6 +215,7 @@ def put_object_to_random_node(
         expire_at,
         no_progress,
         session,
+        lifetime
     )
 
 
@@ -230,6 +233,7 @@ def put_object(
     expire_at: Optional[int] = None,
     no_progress: bool = True,
     session: Optional[str] = None,
+    lifetime: Optional[int] = None,
 ):
     """
     PUT of given file.
@@ -247,6 +251,7 @@ def put_object(
         expire_at: Last epoch in the life of the object
         xhdr: Request X-Headers in form of Key=Value
         session: path to a JSON-encoded container session token
+        lifetime: Lock lifetime - relative to the current epoch.
     Returns:
         (str): ID of uploaded Object
     """
@@ -259,6 +264,7 @@ def put_object(
         cid=cid,
         attributes=attributes,
         bearer=bearer,
+        lifetime=lifetime,
         expire_at=expire_at,
         no_progress=no_progress,
         xhdr=xhdr,

--- a/robot/resources/lib/python_keywords/storage_group.py
+++ b/robot/resources/lib/python_keywords/storage_group.py
@@ -26,6 +26,7 @@ def put_storagegroup(
     bearer: Optional[str] = None,
     wallet_config: str = WALLET_CONFIG,
     lifetime: int = 10,
+    expire_at: Optional[int] = None,
 ) -> str:
     """
     Wrapper for `neofs-cli storagegroup put`. Before the SG is created,
@@ -36,6 +37,7 @@ def put_storagegroup(
         wallet: Path to wallet on whose behalf the SG is created.
         cid: ID of Container to put SG to.
         lifetime: Storage group lifetime in epochs.
+        expire_at: The last active epoch of the storage group.
         objects: List of Object IDs to include into the SG.
         bearer: Path to Bearer token file.
         wallet_config: Path to neofs-cli config file.
@@ -47,6 +49,7 @@ def put_storagegroup(
         wallet=wallet,
         cid=cid,
         lifetime=lifetime,
+        expire_at=expire_at,
         members=objects,
         bearer=bearer,
         rpc_endpoint=endpoint,


### PR DESCRIPTION
Currently there are multiple problems here (allure with logs is attached):

1. New test **test_bearer_token_expiration** (previously bearer token was not created by cli command but was created manually, now I use 'bearer create' command). 'get range hash' command doesn't work with the generated token, it fails like this:

```
COMMAND: neofs-cli --config /home/runner/work/neofs-node/neofs-node/neofs-testcases/wallet_config.yml object hash --rpc-endpoint 's01.neofs.devenv:8080' --wallet '/home/runner/work/neofs-node/neofs-node/neofs-testcases/TemporaryDir/e768c827-812f-4a8c-9090-c52a3b7047ed.json' --cid 'HMVBh53JLaPF38Ztca3TQKfgjPwvFhBto1bSeREjfyiy' --oid '27wMEkckZ2VUAEtu3bLWymTabDn7Rw6BANvKss5jwt2r' --bearer '/home/runner/work/neofs-node/neofs-node/neofs-testcases/TemporaryDir/TestFilesDir/bearer_token_e95282b4-3ab9-4db3-8f86-1dd8a64694d6' --range '0:10'
RETCODE: 1

STDOUT:
rpc error: read payload hashes via client: status: code = 2049 message = object not found

STDERR:

Start / End / Elapsed	 20:52:08.234392 / 20:52:08.751591 / 0:00:00.517199
```

In the logs there are the following entries:

```
2023-08-30T20:51:54.306Z	debug	get/get.go:87	serving request...	{"component": "Object.Get service", "request": "GET_RANGE", "address": "AT95KqvYRw3AC1cCmPJdxwYAcXDJGFLv89rZaZKsmJk3/CdrUYtHAuDDzFF8iw4mAgN2qqb8SDKPo8Gpyg12Ree2k", "raw": false, "local": false, "with session": false, "with bearer": true}
2023-08-30T20:51:54.306Z	debug	get/local.go:25	local get failed	{"component": "Object.Get service", "request": "GET_RANGE", "address": "AT95KqvYRw3AC1cCmPJdxwYAcXDJGFLv89rZaZKsmJk3/CdrUYtHAuDDzFF8iw4mAgN2qqb8SDKPo8Gpyg12Ree2k", "raw": false, "local": false, "with session": false, "with bearer": true, "error": "status: code = 2049 message = object not found"}
2023-08-30T20:51:54.306Z	debug	get/get.go:108	operation finished with error	{"component": "Object.Get service", "request": "GET_RANGE", "address": "AT95KqvYRw3AC1cCmPJdxwYAcXDJGFLv89rZaZKsmJk3/CdrUYtHAuDDzFF8iw4mAgN2qqb8SDKPo8Gpyg12Ree2k", "raw": false, "local": false, "with session": false, "with bearer": true, "error": "status: code = 2049 message = object not found"}
2023-08-30T20:51:54.306Z	debug	get/container.go:18	trying to execute in container...	{"component": "Object.Get service", "request": "GET_RANGE", "address": "AT95KqvYRw3AC1cCmPJdxwYAcXDJGFLv89rZaZKsmJk3/CdrUYtHAuDDzFF8iw4mAgN2qqb8SDKPo8Gpyg12Ree2k", "raw": false, "local": false, "with session": false, "with bearer": true, "netmap lookup depth": 0}
2023-08-30T20:51:54.306Z	debug	get/container.go:46	process epoch	{"component": "Object.Get service", "request": "GET_RANGE", "address": "AT95KqvYRw3AC1cCmPJdxwYAcXDJGFLv89rZaZKsmJk3/CdrUYtHAuDDzFF8iw4mAgN2qqb8SDKPo8Gpyg12Ree2k", "raw": false, "local": false, "with session": false, "with bearer": true, "number": 7}
2023-08-30T20:51:54.306Z	debug	get/remote.go:13	processing node...	{"component": "Object.Get service", "request": "GET_RANGE", "address": "AT95KqvYRw3AC1cCmPJdxwYAcXDJGFLv89rZaZKsmJk3/CdrUYtHAuDDzFF8iw4mAgN2qqb8SDKPo8Gpyg12Ree2k", "raw": false, "local": false, "with session": false, "with bearer": true}
2023-08-30T20:51:54.311Z	debug	get/container.go:87	completing the operation	{"component": "Object.Get service", "request": "GET_RANGE", "address": "AT95KqvYRw3AC1cCmPJdxwYAcXDJGFLv89rZaZKsmJk3/CdrUYtHAuDDzFF8iw4mAgN2qqb8SDKPo8Gpyg12Ree2k", "raw": false, "local": false, "with session": false, "with bearer": true}
2023-08-30T20:51:54.311Z	debug	get/get.go:99	operation finished successfully	{"component": "Object.Get service", "request": "GET_RANGE", "address": "AT95KqvYRw3AC1cCmPJdxwYAcXDJGFLv89rZaZKsmJk3/CdrUYtHAuDDzFF8iw4mAgN2qqb8SDKPo8Gpyg12Ree2k", "raw": false, "local": false, "with session": false, "with bearer": true}
2023-08-30T20:51:54.787Z	debug	get/get.go:87	serving request...	{"component": "Object.Get service", "request": "GET_RANGE", "address": "AT95KqvYRw3AC1cCmPJdxwYAcXDJGFLv89rZaZKsmJk3/CdrUYtHAuDDzFF8iw4mAgN2qqb8SDKPo8Gpyg12Ree2k", "raw": false, "local": false, "with session": false, "with bearer": true}
2023-08-30T20:51:54.787Z	debug	get/local.go:25	local get failed	{"component": "Object.Get service", "request": "GET_RANGE", "address": "AT95KqvYRw3AC1cCmPJdxwYAcXDJGFLv89rZaZKsmJk3/CdrUYtHAuDDzFF8iw4mAgN2qqb8SDKPo8Gpyg12Ree2k", "raw": false, "local": false, "with session": false, "with bearer": true, "error": "status: code = 2049 message = object not found"}
2023-08-30T20:51:54.787Z	debug	get/get.go:108	operation finished with error	{"component": "Object.Get service", "request": "GET_RANGE", "address": "AT95KqvYRw3AC1cCmPJdxwYAcXDJGFLv89rZaZKsmJk3/CdrUYtHAuDDzFF8iw4mAgN2qqb8SDKPo8Gpyg12Ree2k", "raw": false, "local": false, "with session": false, "with bearer": true, "error": "status: code = 2049 message = object not found"}
2023-08-30T20:51:54.787Z	debug	get/container.go:18	trying to execute in container...	{"component": "Object.Get service", "request": "GET_RANGE", "address": "AT95KqvYRw3AC1cCmPJdxwYAcXDJGFLv89rZaZKsmJk3/CdrUYtHAuDDzFF8iw4mAgN2qqb8SDKPo8Gpyg12Ree2k", "raw": false, "local": false, "with session": false, "with bearer": true, "netmap lookup depth": 0}
2023-08-30T20:51:54.787Z	debug	get/container.go:46	process epoch	{"component": "Object.Get service", "request": "GET_RANGE", "address": "AT95KqvYRw3AC1cCmPJdxwYAcXDJGFLv89rZaZKsmJk3/CdrUYtHAuDDzFF8iw4mAgN2qqb8SDKPo8Gpyg12Ree2k", "raw": false, "local": false, "with session": false, "with bearer": true, "number": 7}
2023-08-30T20:51:54.787Z	debug	get/remote.go:13	processing node...	{"component": "Object.Get service", "request": "GET_RANGE", "address": "AT95KqvYRw3AC1cCmPJdxwYAcXDJGFLv89rZaZKsmJk3/CdrUYtHAuDDzFF8iw4mAgN2qqb8SDKPo8Gpyg12Ree2k", "raw": false, "local": false, "with session": false, "with bearer": true}
2023-08-30T20:51:54.792Z	debug	get/remote.go:29	remote call failed	{"component": "Object.Get service", "request": "GET_RANGE", "address": "AT95KqvYRw3AC1cCmPJdxwYAcXDJGFLv89rZaZKsmJk3/CdrUYtHAuDDzFF8iw4mAgN2qqb8SDKPo8Gpyg12Ree2k", "raw": false, "local": false, "with session": false, "with bearer": true, "error": "init object reading: header: status: code = 2048 message = access to object operation denied"}
2023-08-30T20:51:54.792Z	debug	get/remote.go:13	processing node...	{"component": "Object.Get service", "request": "GET_RANGE", "address": "AT95KqvYRw3AC1cCmPJdxwYAcXDJGFLv89rZaZKsmJk3/CdrUYtHAuDDzFF8iw4mAgN2qqb8SDKPo8Gpyg12Ree2k", "raw": false, "local": false, "with session": false, "with bearer": true}
2023-08-30T20:51:54.826Z	debug	get/remote.go:29	remote call failed	{"component": "Object.Get service", "request": "GET_RANGE", "address": "AT95KqvYRw3AC1cCmPJdxwYAcXDJGFLv89rZaZKsmJk3/CdrUYtHAuDDzFF8iw4mAgN2qqb8SDKPo8Gpyg12Ree2k", "raw": false, "local": false, "with session": false, "with bearer": true, "error": "init object reading: header: status: code = 2048 message = access to object operation denied"}
2023-08-30T20:51:54.826Z	debug	get/remote.go:13	processing node...	{"component": "Object.Get service", "request": "GET_RANGE", "address": "AT95KqvYRw3AC1cCmPJdxwYAcXDJGFLv89rZaZKsmJk3/CdrUYtHAuDDzFF8iw4mAgN2qqb8SDKPo8Gpyg12Ree2k", "raw": false, "local": false, "with session": false, "with bearer": true}
2023-08-30T20:51:54.836Z	debug	get/remote.go:29	remote call failed	{"component": "Object.Get service", "request": "GET_RANGE", "address": "AT95KqvYRw3AC1cCmPJdxwYAcXDJGFLv89rZaZKsmJk3/CdrUYtHAuDDzFF8iw4mAgN2qqb8SDKPo8Gpyg12Ree2k", "raw": false, "local": false, "with session": false, "with bearer": true, "error": "init object reading: header: status: code = 2048 message = access to object operation denied"}
2023-08-30T20:51:54.836Z	debug	get/container.go:63	no more nodes, abort placement iteration	{"component": "Object.Get service", "request": "GET_RANGE", "address": "AT95KqvYRw3AC1cCmPJdxwYAcXDJGFLv89rZaZKsmJk3/CdrUYtHAuDDzFF8iw4mAgN2qqb8SDKPo8Gpyg12Ree2k", "raw": false, "local": false, "with session": false, "with bearer": true}
2023-08-30T20:51:54.836Z	debug	get/get.go:108	operation finished with error	{"component": "Object.Get service", "request": "GET_RANGE", "address": "AT95KqvYRw3AC1cCmPJdxwYAcXDJGFLv89rZaZKsmJk3/CdrUYtHAuDDzFF8iw4mAgN2qqb8SDKPo8Gpyg12Ree2k", "raw": false, "local": false, "with session": false, "with bearer": true, "error": "status: code = 2049 message = object not found"}
```
All other commands work as expected. It only happens on get range hash

2. Same test **test_bearer_token_expiration**, I set lifetime=1 and expire_at=current_epoch + 1 and I expect that the token will expire after 2 epoch ticks. In other scenarios it works ok. But here, I have to set expire_at=current_epoch + 2 during the token creation to have the same behavior as with lifetime=1. It seems strange. 

3. Another new test - **test_session_token_expiration_flags**, seems like expire-at param for a session token doesn't have any effect. Lifetime works ok. 


All failures are in the attached allure - [allure.tar.gz](https://github.com/nspcc-dev/neofs-testcases/files/12480246/allure.tar.gz) or here - https://github.com/evgeniiz321/neofs-node/suites/15662779232/artifacts/894066888
