### PR TITLE
storage_group: Remove system eACL changing

### DIFF
--- a/pytest_tests/testsuites/acl/storage_group/test_storagegroup.py
+++ b/pytest_tests/testsuites/acl/storage_group/test_storagegroup.py
@@ -203,6 +203,7 @@ class TestStorageGroup(ClusterTestBase):
             EACLRule(access=EACLAccess.DENY, role=role, operation=op)
             for op in EACLOperation
             for role in EACLRole
+            if role != EACLRole.SYSTEM
         ]
         set_eacl(
             self.main_wallet,


### PR DESCRIPTION
Removed system eACL changing from the test_storagegroup_bearer_allow test.