### PR TITLE
tests: unskip test_session_token_expiration_flags, closes #629

### DIFF
--- a/pytest_tests/testsuites/session_token/test_object_session_token.py
+++ b/pytest_tests/testsuites/session_token/test_object_session_token.py
@@ -147,8 +147,6 @@ class TestDynamicObjectSession(ClusterTestBase):
                 )
 
     @allure.title("Verify session token expiration flags")
-    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-node/issues/2539")
-    @pytest.mark.nspcc_dev__neofs_node__issue_2539
     @pytest.mark.parametrize("expiration_flag", ["lifetime", "expire_at"])
     def test_session_token_expiration_flags(
         self, default_wallet, simple_object_size, expiration_flag, cluster


### PR DESCRIPTION
test passes, allure: [allure-11.tar.gz](https://github.com/nspcc-dev/neofs-testcases/files/12652723/allure-11.tar.gz)
