### PR TITLE
Fixes application/zip attachments upload with process-allure-reports.py

### DIFF
--- a/tools/src/process-allure-reports.py
+++ b/tools/src/process-allure-reports.py
@@ -49,7 +49,7 @@ def put_combine_result_as_static_page(directory: str, neofs_domain: str, wallet:
                 # We save the logs archives as separate objects in order to make a static page small size.
                 # Without this, its size will be hundreds of megabytes.
                 object_cmd = (
-                    f'{base_cmd_with_file}{FILE_PATH}={run_id}/data/{current_dir_name}/{filename} '
+                    f'{base_cmd_with_file}{FILE_PATH}={run_id}/data/{current_dir_name}/{filename},'
                     f'ContentType=application/zip'
                 )
             else:


### PR DESCRIPTION
Faced the following problem with running neofs-testcases on neofs-s3-gw repo fork:
```
Exception: Command failed: NEOFS_CLI_PASSWORD=*** neofs-cli --rpc-endpoint st1.t5.fs.neo.org:8080 --wallet wallet.json  object put --cid 9GX3Bvpb5RFapar5g11zwwoBGDdxcSs35764xchZTVUF --timeout 600s --expire-at 9607 --file /home/runner/work/neofs-s3-gw/neofs-s3-gw/allure-report/data/attachments/700b2dbd13ff3e47.zip --attributes RunNumber=12-1695225472,FilePath=12-1695225472/data/attachments/700b2dbd13ff3e47.zip ContentType=application/zip
[41](https://github.com/MaxGelbakhiani/neofs-s3-gw/actions/runs/6251114048/job/16971515668#step:28:42)
Error code: 1

Stderr: Error: unknown command "ContentType=application/zip" for "neofs-cli object put"
[103](https://github.com/MaxGelbakhiani/neofs-s3-gw/actions/runs/6251114048/job/16971515668#step:28:104)
unknown command "ContentType=application/zip" for "neofs-cli object put"
```

https://github.com/MaxGelbakhiani/neofs-s3-gw/actions/runs/6251114048/job/16971515668#step:28:104

Adding a single comma sign fixes that error.