### PR TITLE
object: Unskip test_expired_object_should_be_deleted_after_locks_are_…

### DIFF
--- a/pytest_tests/testsuites/object/test_object_lock.py
+++ b/pytest_tests/testsuites/object/test_object_lock.py
@@ -283,7 +283,6 @@ class TestObjectLockWithGrpc(ClusterTestBase):
         [pytest.lazy_fixture("simple_object_size"), pytest.lazy_fixture("complex_object_size")],
         ids=["simple object", "complex object"],
     )
-    @pytest.mark.skip(reason="https://github.com/nspcc-dev/neofs-testcases/issues/537")
     @pytest.mark.nspcc_dev__neofs_testcases__issue_537
     def test_expired_object_should_be_deleted_after_locks_are_expired(
         self,


### PR DESCRIPTION
Unskiped test_expired_object_should_be_deleted_after_locks_are_expired, since the bug is fixed in commit https://github.com/nspcc-dev/neofs-node/pull/2535

Tests result:
https://http.t5.fs.neo.org/86C4P6uJC7gb5n3KkwEGpXRfdczubXyRNW5N9KeJRW73/360-1696606948/index.html