### PR TITLE
fix/venv activation

### DIFF
--- a/build_assets/activate.patch
+++ b/build_assets/activate.patch
@@ -1,31 +1,32 @@
-diff -urN bin.orig/activate bin/activate
---- bin.orig/activate  2018-12-27 14:55:13.916461020 +0900
-+++ bin/activate       2018-12-27 20:38:35.223248728 +0900
-@@ -30,6 +30,15 @@
+--- activate.orig	2023-11-01 16:36:41.273318317 +0000
++++ activate	2023-11-01 16:29:45.610264478 +0000
+@@ -27,6 +27,17 @@
          unset _OLD_VIRTUAL_PS1
      fi
-
+ 
 +    # Unset exported dev-env variables
-+    pushd ${DEVENV_PATH} > /dev/null
-+    unset `make env | awk -F= '{print $1}'`
-+    popd > /dev/null
++    if [ ! -z "${DEVENV_PATH}" ] ; then
++        pushd ${DEVENV_PATH} > /dev/null
++        unset `make env | awk -F= '{print $1}'`
++        popd > /dev/null
++    fi
 +
 +    # Unset external env variables
 +    declare -f env_deactivate > /dev/null && env_deactivate
 +    declare -f venv_deactivate > /dev/null && venv_deactivate
 +
      unset VIRTUAL_ENV
-     if [ ! "${1-}" = "nondestructive" ] ; then
-     # Self destruct!
-@@ -47,6 +56,11 @@
+     unset VIRTUAL_ENV_PROMPT
+     if [ ! "${1:-}" = "nondestructive" ] ; then
+@@ -45,6 +56,11 @@
  PATH="$VIRTUAL_ENV/bin:$PATH"
  export PATH
-
+ 
 +# Set external variables
 +if [ -f ${VIRTUAL_ENV}/bin/environment.sh ] ; then
 +    . ${VIRTUAL_ENV}/bin/environment.sh
 +fi
 +
  # unset PYTHONHOME if set
- if ! [ -z "${PYTHONHOME+_}" ] ; then
-     _OLD_VIRTUAL_PYTHONHOME="$PYTHONHOME"
+ # this will fail if PYTHONHOME is set to the empty string (which is bad anyway)
+ # could use `if (set -u; : $PYTHONHOME) ;` in bash

--- a/venv_template.mk
+++ b/venv_template.mk
@@ -9,8 +9,7 @@ venv.$(1)/bin/activate:
 	pip3.10 install -U setuptools==56.0.0 && \
 	pip3.10 install -Ur requirements.txt
 	@echo "Applying activate script patch"
-	patch -R --dry-run -p1 -s -f -d venv.$(1)/bin/ < build_assets/activate.patch || \
-	patch -p1 -d venv.$(1)/bin/ < build_assets/activate.patch
+	patch -b -d venv.$(1)/bin/ < build_assets/activate.patch
 
 venv.$(1)/bin/environment.sh: | venv/$(1)/environment.sh
 	ln -s ../../venv/$(1)/environment.sh venv.$(1)/bin/environment.sh


### PR DESCRIPTION
I have been looking at errors like
```
patch -R --dry-run -p1 -s -f -d venv.local-pytest/bin/ < build_assets/activate.patch || patch -p1 -d venv.local-pytest/bin/ < build_assets/activate.patch
2 out of 2 hunks FAILED
```
and 
```
make: *** No rule to make target 'env'.  Stop.
deactivate:unset:28: not enough arguments
(venv.local-pytest)
```
for years already. Double check, please. The whole approach looks strange to me but fixing smth is never bad.