### PR TITLE
Change activate.patch

### DIFF
--- a/build_assets/activate.patch
+++ b/build_assets/activate.patch
@@ -1,16 +1,9 @@
 --- activate.orig	2023-11-01 16:36:41.273318317 +0000
 +++ activate	2023-11-01 16:29:45.610264478 +0000
-@@ -27,6 +27,17 @@
+@@ -27,6 +27,10 @@
          unset _OLD_VIRTUAL_PS1
      fi
- 
-+    # Unset exported dev-env variables
-+    if [ ! -z "${DEVENV_PATH}" ] ; then
-+        pushd ${DEVENV_PATH} > /dev/null
-+        unset `make env | awk -F= '{print $1}'`
-+        popd > /dev/null
-+    fi
-+
+
 +    # Unset external env variables
 +    declare -f env_deactivate > /dev/null && env_deactivate
 +    declare -f venv_deactivate > /dev/null && venv_deactivate


### PR DESCRIPTION
Remove unset exported dev-env variables

This patch was added in the issue
https://github.com/nspcc-dev/neofs-testcases/issues/111

https://github.com/nspcc-dev/neofs-testcases/issues/676 It seems that since we require more recent versions of neo-mamba and python, we can remove this patch.
But this requires reworking the assembly, so we'll do it later in the issue:
https://github.com/nspcc-dev/neofs-testcases/issues/676

Closes https://github.com/nspcc-dev/neofs-testcases/issues/675