### PR TITLE
s3_gate: Remove PutBucketTagging before PutObjectTagging

### DIFF
--- a/dynamic_env_pytest_tests/tests/services/s3_gate/test_s3_gate.py
+++ b/dynamic_env_pytest_tests/tests/services/s3_gate/test_s3_gate.py
@@ -336,8 +336,6 @@ class TestS3Gate(TestNeofsS3GateBase):
         file_name_simple = generate_file(simple_object_size)
         obj_key = self.object_key_from_file_path(file_name_simple)
 
-        s3_gate_bucket.put_bucket_tagging(self.s3_client, bucket, key_value_pair_bucket)
-
         s3_gate_object.put_object_s3(self.s3_client, bucket, file_name_simple)
 
         for tags in (key_value_pair_obj, key_value_pair_obj_new):


### PR DESCRIPTION
In the discussion
https://github.com/nspcc-dev/neofs-testcases/pull/699#discussion_r1438602718 it was noted that we don't have to use `PutBucketTagging` before `PutObjectTagging`.

This commit removes PutBucketTagging in the test_s3_api_object_tagging test.