### PR TITLE
dyn_env: adapt failovers and load tests

### DIFF
--- a/dynamic_env_pytest_tests/tests/failovers/test_failover_network.py
+++ b/dynamic_env_pytest_tests/tests/failovers/test_failover_network.py
@@ -1,0 +1,222 @@
+import logging
+import subprocess
+from random import choices
+from time import sleep
+
+import allure
+import pytest
+from cluster import StorageNode
+from file_helper import generate_file, get_file_hash
+from iptables_helper import IpTablesHelper
+from neofs_env.neofs_env_test_base import NeofsEnvTestBase
+from python_keywords.container import create_container
+from python_keywords.neofs_verbs import get_netmap_netinfo, get_object, put_object_to_random_node
+from python_keywords.node_management import storage_node_healthcheck
+from wellknown_acl import PUBLIC_ACL
+
+from helpers.complex_object_actions import wait_object_replication
+from helpers.node_management import wait_all_storage_nodes_returned
+
+logger = logging.getLogger("NeoLogger")
+blocked_nodes: list[StorageNode] = []
+
+
+@pytest.mark.failover
+@pytest.mark.failover_network
+@pytest.mark.skip(reason="These tests require multiple hosts/inner rings to run")
+class TestFailoverNetwork(NeofsEnvTestBase):
+    @pytest.fixture(autouse=True)
+    @allure.step("Restore network")
+    def restore_network(self):
+        yield
+
+        not_empty = len(blocked_nodes) != 0
+        for node in list(blocked_nodes):
+            with allure.step(f"Restore network at host for {node}"):
+                IpTablesHelper.restore_input_traffic_to_port(
+                    self.shell, [node.endpoint.split(":")[1]]
+                )
+            blocked_nodes.remove(node)
+        if not_empty:
+            wait_all_storage_nodes_returned(self.neofs_env)
+
+    @allure.title("Block Storage node traffic")
+    def test_block_storage_node_traffic(self, default_wallet, simple_object_size):
+        """
+        Block storage nodes traffic using iptables and wait for replication for objects.
+        """
+        wallet = default_wallet
+        placement_rule = "REP 2 IN X CBF 2 SELECT 2 FROM * AS X"
+        wakeup_node_timeout = 10  # timeout to let nodes detect that traffic has blocked
+        nodes_to_block_count = 2
+
+        source_file_path = generate_file(simple_object_size)
+        cid = create_container(
+            wallet.path,
+            shell=self.shell,
+            endpoint=self.neofs_env.sn_rpc,
+            rule=placement_rule,
+            basic_acl=PUBLIC_ACL,
+        )
+        oid = put_object_to_random_node(
+            wallet.path, source_file_path, cid, shell=self.shell, neofs_env=self.neofs_env
+        )
+
+        nodes = wait_object_replication(
+            cid, oid, 2, shell=self.shell, nodes=self.neofs_env.storage_nodes
+        )
+
+        logger.info(f"Nodes are {nodes}")
+        nodes_to_block = nodes
+        if nodes_to_block_count > len(nodes):
+            # TODO: the intent of this logic is not clear, need to revisit
+            nodes_to_block = choices(nodes, k=2)
+
+        excluded_nodes = []
+        for node in nodes_to_block:
+            with allure.step(
+                f"Block incoming traffic at node {node} on port {[node.endpoint.split(':')[1]]}"
+            ):
+                blocked_nodes.append(node)
+                excluded_nodes.append(node)
+                IpTablesHelper.drop_input_traffic_to_port(self.shell, [node.endpoint.split(":")[1]])
+                sleep(wakeup_node_timeout)
+
+            with allure.step(f"Check object is not stored on node {node}"):
+                new_nodes = wait_object_replication(
+                    cid,
+                    oid,
+                    2,
+                    shell=self.shell,
+                    nodes=list(set(self.neofs_env.storage_nodes) - set(excluded_nodes)),
+                )
+                assert node not in new_nodes
+
+            with allure.step(f"Check object data is not corrupted"):
+                got_file_path = get_object(
+                    wallet, cid, oid, endpoint=new_nodes[0].endpoint, shell=self.shell
+                )
+                assert get_file_hash(source_file_path) == get_file_hash(got_file_path)
+
+        for node in nodes_to_block:
+            with allure.step(
+                f"Unblock incoming traffic at host {node} on port {[node.endpoint.split(':')[1]]}"
+            ):
+                IpTablesHelper.restore_input_traffic_to_port(
+                    self.shell, [node.endpoint.split(":")[1]]
+                )
+                blocked_nodes.remove(node)
+                sleep(wakeup_node_timeout)
+
+        with allure.step(f"Check object data is not corrupted"):
+            new_nodes = wait_object_replication(
+                cid, oid, 2, shell=self.shell, nodes=self.neofs_env.storage_nodes
+            )
+
+            got_file_path = get_object(
+                wallet, cid, oid, shell=self.shell, endpoint=new_nodes[0].endpoint
+            )
+            assert get_file_hash(source_file_path) == get_file_hash(got_file_path)
+
+    @pytest.mark.sanity
+    @allure.title("RPC reconnection test")
+    def test_rpc_reconnection(self, default_wallet):
+        """
+        When RPC connection fails (and it can), storage node reconnects to some other node and continues to operate.
+        """
+        dport_repeat = 10  # Constant for the number of the disconnect should be repeated
+
+        required_keys = [
+            "epoch",
+            "time_per_block",
+            "audit_fee",
+            "storage_price",
+            "container_fee",
+            "eigentrust_alpha",
+            "number_of_eigentrust_iterations",
+            "epoch_duration",
+            "inner_ring_candidate_fee",
+            "maximum_object_size",
+            "withdrawal_fee",
+            "systemdns",
+            "homomorphic_hashing_disabled",
+            "maintenance_mode_allowed",
+        ]
+
+        for storage_node in self.neofs_env.storage_nodes:
+            pid = storage_node.process.pid
+
+            morph_chain_addr = self.neofs_env.inner_ring_nodes[0].rpc_address.split(":")[0]
+            morph_chain_port = self.neofs_env.inner_ring_nodes[0].rpc_address.split(":")[1]
+
+            with allure.step(
+                f"Disconnecting storage node {storage_node.name} "
+                f"from {morph_chain_addr} {dport_repeat} times"
+            ):
+                for repeat in range(dport_repeat):
+                    with allure.step(f"Disconnect number {repeat}"):
+                        try:
+                            """
+                            Of course, it would be cleaner to use such code:
+                            with Namespace(pid, 'net'):
+                                subprocess.check_output(['ss', '-K', 'dst', addr, 'dport', port])
+                            But it would be required to run the tests from root, which is bad practice.
+                            But we face the limitations of the ubuntu-latest runner:
+                            And using setfacl is not possible due to GitHub ubuntu-latest runner limitations.
+                            """
+                            command = f"ss -K dst {morph_chain_addr} dport {morph_chain_port}"
+                            sudo_command = f"sudo nsenter -t {pid} -n {command}"
+                            output = subprocess.check_output(sudo_command, shell=True)
+                            logger.info(f"Output of the command {sudo_command}: {output}")
+                        except subprocess.CalledProcessError as e:
+                            logger.error(
+                                f"Error occurred while running command: {sudo_command}. Error message: {str(e)}"
+                            )
+                            raise
+                        finally:
+                            # Delay between shutdown attempts, emulates a real disconnection
+                            sleep(1)
+                    logger.info(
+                        f"Disconnected storage node {storage_node.name} "
+                        f"from {morph_chain_addr} {dport_repeat} times"
+                    )
+
+            for node in self.neofs_env.storage_nodes:
+
+                with allure.step(f"Checking if node {node} is alive"):
+                    try:
+                        health_check = storage_node_healthcheck(node)
+                        assert (
+                            health_check.health_status == "READY"
+                            and health_check.network_status == "ONLINE"
+                        )
+                    except Exception as err:
+                        logger.warning(f"Node {node} is not online:\n{err}")
+                        raise AssertionError(
+                            f"After the RPC connection failed, the storage node {node} DID NOT reconnect "
+                            f"to any other node and FAILED to continue operating. "
+                        )
+
+                with allure.step(f"Checking netinfo for node {node}"):
+                    try:
+                        net_info = get_netmap_netinfo(
+                            wallet=default_wallet.path,
+                            endpoint=self.neofs_env.sn_rpc,
+                            shell=self.shell,
+                        )
+                        missing_keys = [key for key in required_keys if key not in net_info]
+                        if missing_keys:
+                            raise AssertionError(
+                                f"Error occurred while checking netinfo for node {node} - "
+                                f"missing keys in the output: {missing_keys}."
+                                f"Netmap netinfo: {net_info}"
+                            )
+                    except Exception as err:
+                        logger.warning(
+                            f"Error occurred while checking netinfo for node {node}. Error message: {str(err)}"
+                        )
+                        raise Exception(
+                            f"After the RPC connection failed, the storage node {node} cannot get netmap netinfo"
+                        )
+
+            logger.info(f"Node {node} is alive and online")

--- a/dynamic_env_pytest_tests/tests/failovers/test_failover_part.py
+++ b/dynamic_env_pytest_tests/tests/failovers/test_failover_part.py
@@ -1,0 +1,91 @@
+import logging
+
+import allure
+import pytest
+from container import create_container
+from grpc_responses import OBJECT_NOT_FOUND
+from neofs_env.neofs_env_test_base import NeofsEnvTestBase
+from neofs_testlib.env.env import NeoFSEnv, NodeWallet
+from neofs_testlib.shell import Shell
+from neofs_verbs import get_object
+from test_control import expect_not_raises
+
+from helpers.node_management import (
+    delete_node_metadata,
+    start_storage_nodes,
+    wait_all_storage_nodes_returned,
+)
+from helpers.storage_container import StorageContainer, StorageContainerInfo
+
+logger = logging.getLogger("NeoLogger")
+
+
+@pytest.fixture(
+    scope="function",
+)
+def user_container(user_wallet: NodeWallet, client_shell: Shell, neofs_env: NeoFSEnv):
+    container_id = create_container(user_wallet.path, shell=client_shell, endpoint=neofs_env.sn_rpc)
+    return StorageContainer(
+        StorageContainerInfo(container_id, user_wallet), client_shell, neofs_env
+    )
+
+
+@pytest.mark.failover_part
+@pytest.mark.skip(reason="Processes restarts currently affects other tests")
+class TestFailoverNodePart(NeofsEnvTestBase):
+    @allure.title("Enable resync metabase, delete metadata and get object")
+    @pytest.mark.delete_metadata
+    def test_enable_resync_metabase_delete_metadata(
+        self,
+        enable_metabase_resync_on_start,
+        user_container: StorageContainer,
+        simple_object_size: int,
+    ):
+        storage_object = user_container.generate_object(simple_object_size)
+
+        with allure.step("Delete metabase files from storage nodes"):
+            for node in self.neofs_env.storage_nodes:
+                delete_node_metadata(node)
+
+        with allure.step("Start nodes after metabase deletion"):
+            start_storage_nodes(self.neofs_env.storage_nodes)
+            wait_all_storage_nodes_returned(self.neofs_env)
+
+        with allure.step("Try to fetch object from each storage node"):
+            for node in self.neofs_env.storage_nodes:
+                with expect_not_raises():
+                    get_object(
+                        storage_object.wallet_file_path,
+                        storage_object.cid,
+                        storage_object.oid,
+                        self.shell,
+                        endpoint=node.endpoint,
+                        wallet_config=user_container.get_wallet_config_path(),
+                    )
+
+    @allure.title(
+        "Delete metadata without resync metabase enabling, delete metadata try to get object"
+    )
+    @pytest.mark.delete_metadata
+    def test_delete_metadata(self, user_container: StorageContainer, simple_object_size: int):
+        storage_object = user_container.generate_object(simple_object_size)
+
+        with allure.step("Delete metabase files from storage nodes"):
+            for node in self.neofs_env.storage_nodes:
+                delete_node_metadata(node)
+
+        with allure.step("Start nodes after metabase deletion"):
+            start_storage_nodes(self.neofs_env.storage_nodes)
+            wait_all_storage_nodes_returned(self.neofs_env)
+
+        with allure.step("Try to fetch object from each storage node"):
+            for node in self.neofs_env.storage_nodes:
+                with pytest.raises(Exception, match=OBJECT_NOT_FOUND):
+                    get_object(
+                        storage_object.wallet_file_path,
+                        storage_object.cid,
+                        storage_object.oid,
+                        self.shell,
+                        endpoint=node.endpoint,
+                        wallet_config=user_container.get_wallet_config_path(),
+                    )

--- a/dynamic_env_pytest_tests/tests/failovers/test_failover_storage.py
+++ b/dynamic_env_pytest_tests/tests/failovers/test_failover_storage.py
@@ -1,0 +1,169 @@
+import logging
+
+import allure
+import pytest
+from file_helper import generate_file, get_file_hash
+from neofs_env.neofs_env_test_base import NeofsEnvTestBase
+from neofs_testlib.env.env import NeoFSEnv, StorageNode
+from neofs_testlib.shell import CommandOptions
+from python_keywords.container import create_container
+from python_keywords.neofs_verbs import get_object, put_object_to_random_node
+from wellknown_acl import PUBLIC_ACL
+
+from helpers.complex_object_actions import wait_object_replication
+from helpers.node_management import wait_all_storage_nodes_returned
+
+logger = logging.getLogger("NeoLogger")
+stopped_nodes: list[StorageNode] = []
+
+
+@pytest.fixture(scope="function", autouse=True)
+@allure.step("Return all stopped hosts")
+def after_run_return_all_stopped_hosts(neofs_env: NeoFSEnv):
+    yield
+    return_stopped_hosts(neofs_env)
+
+
+def panic_reboot_host(neofs_env: NeoFSEnv) -> None:
+    shell = neofs_env.shell
+    shell.exec('sudo sh -c "echo 1 > /proc/sys/kernel/sysrq"')
+
+    options = CommandOptions(close_stdin=True, timeout=1, check=False)
+    shell.exec('sudo sh -c "echo b > /proc/sysrq-trigger"', options)
+
+
+def return_stopped_hosts(neofs_env: NeoFSEnv) -> None:
+    for node in list(stopped_nodes):
+        with allure.step(f"Start host {node}"):
+            node.host.start_host()
+        stopped_nodes.remove(node)
+
+    wait_all_storage_nodes_returned(neofs_env)
+
+
+@pytest.mark.failover
+@pytest.mark.skip(reason="These tests require multiple hosts to run")
+class TestFailoverStorage(NeofsEnvTestBase):
+    @allure.title("Lose and return storage node's host")
+    @pytest.mark.parametrize("hard_reboot", [True, False])
+    @pytest.mark.failover_reboot
+    def test_lose_storage_node_host(self, default_wallet, hard_reboot: bool, simple_object_size):
+        wallet = default_wallet
+        placement_rule = "REP 2 IN X CBF 2 SELECT 2 FROM * AS X"
+        source_file_path = generate_file(simple_object_size)
+        cid = create_container(
+            wallet.path,
+            shell=self.shell,
+            endpoint=self.neofs_env.sn_rpc,
+            rule=placement_rule,
+            basic_acl=PUBLIC_ACL,
+        )
+        oid = put_object_to_random_node(
+            wallet.path, source_file_path, cid, shell=self.shell, neofs_env=self.neofs_env
+        )
+        nodes = wait_object_replication(
+            cid, oid, 2, shell=self.shell, nodes=self.neofs_env.storage_nodes
+        )
+
+        for node in nodes:
+            stopped_nodes.append(node)
+
+            with allure.step(f"Stop host {node}"):
+                node.host.stop_host("hard" if hard_reboot else "soft")
+
+            new_nodes = wait_object_replication(
+                cid,
+                oid,
+                2,
+                shell=self.shell,
+                nodes=list(set(self.neofs_env.storage_nodes) - {node}),
+            )
+        assert all(old_node not in new_nodes for old_node in nodes)
+
+        with allure.step("Check object data is not corrupted"):
+            got_file_path = get_object(
+                wallet, cid, oid, endpoint=new_nodes[0].get_rpc_endpoint(), shell=self.shell
+            )
+            assert get_file_hash(source_file_path) == get_file_hash(got_file_path)
+
+        with allure.step("Return all hosts"):
+            return_stopped_hosts(self.neofs_env)
+
+        with allure.step("Check object data is not corrupted"):
+            new_nodes = wait_object_replication(
+                cid, oid, 2, shell=self.shell, nodes=self.neofs_env.storage_nodes
+            )
+            got_file_path = get_object(
+                wallet.path, cid, oid, shell=self.shell, endpoint=new_nodes[0].endpoint
+            )
+            assert get_file_hash(source_file_path) == get_file_hash(got_file_path)
+
+    @allure.title("Panic storage node's host")
+    @pytest.mark.parametrize("sequence", [True, False])
+    @pytest.mark.failover_panic
+    def test_panic_storage_node_host(self, default_wallet, sequence: bool, simple_object_size):
+        wallet = default_wallet
+        placement_rule = "REP 2 IN X CBF 2 SELECT 2 FROM * AS X"
+        source_file_path = generate_file(simple_object_size)
+        cid = create_container(
+            wallet.path,
+            shell=self.shell,
+            endpoint=self.neofs_env.sn_rpc,
+            rule=placement_rule,
+            basic_acl=PUBLIC_ACL,
+        )
+        oid = put_object_to_random_node(
+            wallet.path, source_file_path, cid, shell=self.shell, neofs_env=self.neofs_env
+        )
+
+        nodes = wait_object_replication(
+            cid, oid, 2, shell=self.shell, nodes=self.neofs_env.storage_nodes
+        )
+        allure.attach(
+            "\n".join([str(node) for node in nodes]),
+            "Current nodes with object",
+            allure.attachment_type.TEXT,
+        )
+
+        new_nodes: list[StorageNode] = []
+        for node in nodes:
+            with allure.step(f"Hard reboot host {node} via magic SysRq option"):
+                panic_reboot_host(node.host)
+                if sequence:
+                    try:
+                        new_nodes = wait_object_replication(
+                            cid,
+                            oid,
+                            2,
+                            shell=self.shell,
+                            nodes=list(set(self.neofs_env.storage_nodes) - {node}),
+                        )
+                    except AssertionError:
+                        new_nodes = wait_object_replication(
+                            cid,
+                            oid,
+                            2,
+                            shell=self.shell,
+                            nodes=self.neofs_env.storage_nodes,
+                        )
+
+                    allure.attach(
+                        "\n".join([str(new_node) for new_node in new_nodes]),
+                        f"Nodes with object after {node} fail",
+                        allure.attachment_type.TEXT,
+                    )
+
+        if not sequence:
+            new_nodes = wait_object_replication(
+                cid, oid, 2, shell=self.shell, nodes=self.neofs_env.storage_nodes
+            )
+            allure.attach(
+                "\n".join([str(new_node) for new_node in new_nodes]),
+                "Nodes with object after nodes fail",
+                allure.attachment_type.TEXT,
+            )
+
+        got_file_path = get_object(
+            wallet, cid, oid, shell=self.shell, endpoint=new_nodes[0].endpoint
+        )
+        assert get_file_hash(source_file_path) == get_file_hash(got_file_path)

--- a/dynamic_env_pytest_tests/tests/load/test_load.py
+++ b/dynamic_env_pytest_tests/tests/load/test_load.py
@@ -1,0 +1,82 @@
+import allure
+import pytest
+from k6 import LoadParams
+from load import multi_node_k6_run, prepare_k6_instances
+from load_params import (
+    CONTAINERS_COUNT,
+    DELETERS,
+    LOAD_NODE_SSH_PRIVATE_KEY_PATH,
+    LOAD_NODE_SSH_USER,
+    LOAD_NODES,
+    LOAD_NODES_COUNT,
+    LOAD_TIME,
+    LOAD_TYPE,
+    OBJ_COUNT,
+    OBJ_SIZE,
+    OUT_FILE,
+    READERS,
+    WRITERS,
+)
+from neofs_env.neofs_env_test_base import NeofsEnvTestBase
+
+
+@pytest.mark.load
+@pytest.mark.skip(reason="Need to clarify its purpose")
+@pytest.mark.nspcc_dev__neofs_testcases__issue_544
+class TestLoad(NeofsEnvTestBase):
+
+    @pytest.mark.parametrize("obj_size, out_file", list(zip(OBJ_SIZE, OUT_FILE)))
+    @pytest.mark.parametrize("writers, readers, deleters", list(zip(WRITERS, READERS, DELETERS)))
+    @pytest.mark.parametrize("load_time", LOAD_TIME)
+    @pytest.mark.parametrize("containers_count", CONTAINERS_COUNT)
+    @pytest.mark.parametrize("load_type", LOAD_TYPE)
+    @pytest.mark.parametrize("obj_count", OBJ_COUNT)
+    @pytest.mark.parametrize("load_nodes_count", LOAD_NODES_COUNT)
+    @pytest.mark.benchmark
+    @pytest.mark.grpc
+    @pytest.mark.nspcc_dev__neofs_testcases__issue_544
+    def test_custom_load(
+        self,
+        obj_size,
+        out_file,
+        writers,
+        readers,
+        deleters,
+        load_time,
+        obj_count,
+        load_type,
+        load_nodes_count,
+        containers_count,
+    ):
+        allure.dynamic.title(
+            f"Load test "
+            f"writers = {writers} readers = {readers}, "
+            f"deleters = {deleters}, obj_size = {obj_size}, "
+            f"load_time = {load_time}"
+        )
+        with allure.step("Get endpoints"):
+            endpoints = ",".join(
+                [node.control_grpc_endpoint for node in self.neofs_env.storage_nodes]
+            )
+        load_params = LoadParams(
+            endpoint=endpoints,
+            obj_size=obj_size,
+            containers_count=containers_count,
+            out_file=out_file,
+            obj_count=obj_count,
+            writers=writers,
+            readers=readers,
+            deleters=deleters,
+            load_time=load_time,
+            load_type=load_type,
+        )
+        load_nodes_list = LOAD_NODES[:load_nodes_count]
+        k6_load_instances = prepare_k6_instances(
+            load_nodes=load_nodes_list,
+            login=LOAD_NODE_SSH_USER,
+            pkey=LOAD_NODE_SSH_PRIVATE_KEY_PATH,
+            load_params=load_params,
+            ssh_port=2222,
+        )
+        with allure.step("Run load"):
+            multi_node_k6_run(k6_load_instances)


### PR DESCRIPTION
Failover and load tests need some clarification on their purpose and what/how we want to deal with them.

1. Most of the failover tests require a setup with different hosts (physical servers/VMs) and check something strange with strange approaches. There are currently these scenarios:

-  "Block storage nodes traffic using iptables". As I understood we want to check replication logic there. It doesn't really work in its current version and should be rewritten. What I suggest - stop one of the storage node processes and ensure the object is replicated.
- "RPC reconnection". It is very strange to me as well. But as I understood - it wants to check the case when one of the inner ring nodes goes down and that storage nodes start using another inner ring node that is alive.
- "Storage nodes panic" - I'm not sure what is the difference from the case where we just stop the storage node process. 

To sum up, I would suggest to have these new failover tests instead of old ones:
1. Kill storage node processes - ensure objects are replicated. Check different replication policies
2. Multiple inner ring nodes - try to kill one and see that we still can put/read objects
3. tbd
---
2. Load test seems to be very irrelevant to current tests. And current test does not really check anything. We just run k6 and check RC, no results are parsed. As I understood @MaxGelbakhiani runs load tests somewhere else and doesn't rely on this particular test. I would suggest to remove it from current tests, since it doesn't really check anything.  Or we need to figure out what we want from this test. Maybe we can reimplement it and use like a benchmark to see a performance degradation on the pull requests and stop such pull requests where we see such a degradation.