### PR TITLE
rest: skip Filename test case

### DIFF
--- a/pytest_tests/tests/services/rest_gate/test_rest_gate.py
+++ b/pytest_tests/tests/services/rest_gate/test_rest_gate.py
@@ -335,13 +335,18 @@ class TestRestGate(NeofsEnvTestBase):
     @pytest.mark.parametrize(
         "attributes",
         [
-            {"Filename": "simple_obj_filename"},
             {"File-Name": "simple obj filename"},
             {"FileName": "simple obj filename"},
             pytest.param(
                 {"cat%jpeg": "cat%jpeg"},
                 marks=pytest.mark.skip(
                     reason="https://github.com/nspcc-dev/neofs-rest-gw/issues/195"
+                ),
+            ),
+            pytest.param(
+                {"Filename": "simple_obj_filename"},
+                marks=pytest.mark.skip(
+                    reason="https://github.com/nspcc-dev/neofs-rest-gw/issues/168"
                 ),
             ),
         ],


### PR DESCRIPTION
It gets converted to FileName by the current REST gateway logic and is documented to do so, therefore this test can't work the way it's intended to.