### PR TITLE
Fix logs for payments tests

### DIFF
--- a/pytest_tests/tests/conftest.py
+++ b/pytest_tests/tests/conftest.py
@@ -1,3 +1,4 @@
+import datetime
 import logging
 import os
 import shutil
@@ -211,7 +212,8 @@ def neofs_env_with_mainchain(request):
             neofs_env.kill()
 
     if request.session.testsfailed:
-        logs_path = os.path.join(os.getcwd(), ASSETS_DIR, "neofs_env_with_mainchain_logs")
+        logs_id = datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%d-%H-%M-%S")
+        logs_path = os.path.join(os.getcwd(), ASSETS_DIR, f"neofs_env_with_mainchain_logs_{logs_id}")
         os.makedirs(logs_path, exist_ok=True)
 
         shutil.copyfile(neofs_env.main_chain.stderr, f"{logs_path}/main_chain_log.txt")
@@ -222,7 +224,7 @@ def neofs_env_with_mainchain(request):
         for idx, sn in enumerate(neofs_env.storage_nodes):
             shutil.copyfile(sn.stderr, f"{logs_path}/sn_{idx}_log.txt")
 
-        logs_zip_file_path = shutil.make_archive("neofs_env_with_mainchain_logs", "zip", logs_path)
+        logs_zip_file_path = shutil.make_archive(f"neofs_env_with_mainchain_logs_{logs_id}", "zip", logs_path)
         allure.attach.file(logs_zip_file_path, name="neofs env with main chain files", extension="zip")
     logger.info(f"Cleaning up dir {neofs_env}")
     shutil.rmtree(os.path.join(os.getcwd(), neofs_env._env_dir), ignore_errors=True)


### PR DESCRIPTION
if more than one payment test failed, logs were saved only from the first failure