### PR TITLE
tests: add missing timeouts

### DIFF
--- a/neofs-testlib/neofs_testlib/env/env.py
+++ b/neofs-testlib/neofs_testlib/env/env.py
@@ -31,6 +31,8 @@ from helpers.common import (
     ALLOCATED_PORTS_FILE,
     ALLOCATED_PORTS_LOCK_FILE,
     BINARY_DOWNLOADS_LOCK_FILE,
+    DEFAULT_OBJECT_OPERATION_TIMEOUT,
+    DEFAULT_REST_OPERATION_TIMEOUT,
     get_assets_dir_path,
 )
 
@@ -593,7 +595,7 @@ class NeoFSEnv:
     @staticmethod
     def download_binary(repo: str, version: str, file: str, target: str):
         download_url = f"https://github.com/{repo}/releases/download/{version}/{file}"
-        resp = requests.get(download_url)
+        resp = requests.get(download_url, timeout=DEFAULT_OBJECT_OPERATION_TIMEOUT)
         if not resp.ok:
             raise AssertionError(
                 f"Can not download binary from url: {download_url}: {resp.status_code}/{resp.reason}/{resp.json()}"
@@ -1128,7 +1130,7 @@ class S3_GW:
     @retry(wait=wait_fixed(10), stop=stop_after_attempt(10), reraise=True)
     def _wait_until_ready(self):
         endpoint = f"https://{self.address}" if self.tls_enabled else f"http://{self.address}"
-        resp = requests.get(endpoint, verify=False)
+        resp = requests.get(endpoint, verify=False, timeout=DEFAULT_REST_OPERATION_TIMEOUT)
         assert resp.status_code == 200
 
     def _generate_config(self):

--- a/neofs-testlib/neofs_testlib_tests/pytest/test_env.py
+++ b/neofs-testlib/neofs_testlib_tests/pytest/test_env.py
@@ -9,7 +9,7 @@ import pexpect
 import pytest
 import requests
 from botocore.config import Config
-
+from helpers.common import DEFAULT_OBJECT_OPERATION_TIMEOUT, DEFAULT_REST_OPERATION_TIMEOUT
 from neofs_testlib.env.env import NeoFSEnv, NodeWallet
 from neofs_testlib.utils.wallet import get_last_public_key_from_wallet, init_wallet
 
@@ -171,7 +171,7 @@ def test_gateways_put_get(neofs_env: NeoFSEnv, wallet: NodeWallet, zero_fee, gw_
         request = f"http://{neofs_env.rest_gw.address}/v1/upload/{cid}"
     files = {"upload_file": open(filename, "rb")}
     body = {"filename": filename}
-    resp = requests.post(request, files=files, data=body)
+    resp = requests.post(request, files=files, data=body, timeout=DEFAULT_OBJECT_OPERATION_TIMEOUT)
 
     if not resp.ok:
         raise Exception(
@@ -189,7 +189,7 @@ def test_gateways_put_get(neofs_env: NeoFSEnv, wallet: NodeWallet, zero_fee, gw_
     else:
         request = f"http://{neofs_env.rest_gw.address}/v1/get/{cid}/{oid}{download_attribute}"
 
-    resp = requests.get(request, stream=True)
+    resp = requests.get(request, stream=True, timeout=DEFAULT_OBJECT_OPERATION_TIMEOUT)
 
     if not resp.ok:
         raise Exception(

--- a/pytest_tests/lib/helpers/common.py
+++ b/pytest_tests/lib/helpers/common.py
@@ -63,6 +63,9 @@ ALLOCATED_PORTS_LOCK_FILE = "/tmp/allocated_ports.lock"
 ALLOCATED_PORTS_FILE = "/tmp/allocated_ports.txt"
 BINARY_DOWNLOADS_LOCK_FILE = "/tmp/binary_downloads.lock"
 
+DEFAULT_OBJECT_OPERATION_TIMEOUT = 600
+DEFAULT_REST_OPERATION_TIMEOUT = 10
+
 # Generate wallet configs
 # TODO: we should move all info about wallet configs to fixtures
 WALLET_CONFIG = os.path.join(os.getcwd(), "wallet_config.yml")

--- a/pytest_tests/lib/helpers/rest_gate.py
+++ b/pytest_tests/lib/helpers/rest_gate.py
@@ -12,7 +12,12 @@ import allure
 import requests
 from helpers.aws_cli_client import LONG_TIMEOUT
 from helpers.cli_helpers import _cmd_run
-from helpers.common import SIMPLE_OBJECT_SIZE, get_assets_dir_path
+from helpers.common import (
+    DEFAULT_OBJECT_OPERATION_TIMEOUT,
+    DEFAULT_REST_OPERATION_TIMEOUT,
+    SIMPLE_OBJECT_SIZE,
+    get_assets_dir_path,
+)
 from helpers.complex_object_actions import get_nodes_without_object
 from helpers.file_helper import get_file_hash
 from helpers.neofs_verbs import get_object
@@ -51,7 +56,7 @@ def get_via_rest_gate(
 
     if not skip_options_verify:
         verify_options_request(request)
-    resp = requests.get(request, stream=True)
+    resp = requests.get(request, stream=True, timeout=DEFAULT_OBJECT_OPERATION_TIMEOUT)
 
     if not resp.ok:
         raise Exception(
@@ -81,7 +86,7 @@ def get_via_zip_http_gate(cid: str, prefix: str, endpoint: str):
     endpoint: http gate endpoint
     """
     request = f"{endpoint}/zip/{cid}/{prefix}"
-    resp = requests.get(request, stream=True)
+    resp = requests.get(request, stream=True, timeout=DEFAULT_OBJECT_OPERATION_TIMEOUT)
 
     if not resp.ok:
         raise Exception(
@@ -125,7 +130,7 @@ def get_via_rest_gate_by_attribute(
 
     if not skip_options_verify:
         verify_options_request(request)
-    resp = requests.get(request, stream=True)
+    resp = requests.get(request, stream=True, timeout=DEFAULT_OBJECT_OPERATION_TIMEOUT)
 
     if not resp.ok:
         raise Exception(
@@ -169,7 +174,9 @@ def upload_via_rest_gate(
         files = {"upload_file": (path, open(path, "rb"), file_content_type)}
     body = {"filename": path}
     verify_options_request(request)
-    resp = requests.post(request, files=files, data=body, headers=headers, cookies=cookies)
+    resp = requests.post(
+        request, files=files, data=body, headers=headers, cookies=cookies, timeout=DEFAULT_OBJECT_OPERATION_TIMEOUT
+    )
 
     if not resp.ok:
         if error_pattern:
@@ -394,7 +401,9 @@ def new_upload_via_rest_gate(
         headers["Content-Type"] = file_content_type
 
     verify_options_request(request)
-    resp = requests.post(request, data=file_content, headers=headers, cookies=cookies)
+    resp = requests.post(
+        request, data=file_content, headers=headers, cookies=cookies, timeout=DEFAULT_OBJECT_OPERATION_TIMEOUT
+    )
 
     if not resp.ok:
         if error_pattern:
@@ -431,7 +440,7 @@ def get_epoch_duration_via_rest_gate(endpoint: str) -> int:
     request = f"{endpoint}/network-info"
 
     verify_options_request(request)
-    resp = requests.get(request, stream=True)
+    resp = requests.get(request, stream=True, timeout=DEFAULT_OBJECT_OPERATION_TIMEOUT)
 
     if not resp.ok:
         raise Exception(
@@ -449,7 +458,7 @@ def get_epoch_duration_via_rest_gate(endpoint: str) -> int:
 
 
 def verify_options_request(request):
-    options_resp = requests.options(request)
+    options_resp = requests.options(request, timeout=DEFAULT_REST_OPERATION_TIMEOUT)
     assert options_resp.status_code == 200, "Invalid status code for OPTIONS request"
     for cors_header in ("Access-Control-Allow-Headers", "Access-Control-Allow-Methods", "Access-Control-Allow-Origin"):
         assert cors_header in options_resp.headers, f"Not CORS header {cors_header} in OPTIONS response"

--- a/pytest_tests/tests/services/rest_gate/test_rest_streaming.py
+++ b/pytest_tests/tests/services/rest_gate/test_rest_streaming.py
@@ -3,6 +3,7 @@ import logging
 import allure
 import pytest
 import requests
+from helpers.common import DEFAULT_OBJECT_OPERATION_TIMEOUT
 from helpers.container import create_container
 from helpers.file_helper import generate_file
 from helpers.wellknown_acl import PUBLIC_ACL
@@ -56,7 +57,9 @@ class Test_rest_streaming(NeofsEnvTestBase):
         with allure.step("Put objects and Get object and verify hashes [ get/$CID/$OID ]"):
             # https://docs.python-requests.org/en/latest/user/advanced/#streaming-uploads
             with open(file_path, "rb") as file:
-                resp = requests.post(f"{gw_endpoint}/objects/{cid}", data=file)
+                resp = requests.post(
+                    f"{gw_endpoint}/objects/{cid}", data=file, timeout=DEFAULT_OBJECT_OPERATION_TIMEOUT
+                )
 
             if not resp.ok:
                 raise Exception(


### PR DESCRIPTION
Sometimes tests can hang unexpectedly, need to eliminate all blocking calls.