### PR TITLE
env: handle process termination more gracefully

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -346,7 +346,7 @@ jobs:
             env:
               ALLURE_RESULTS_DIR: ${{ env.ALLURE_RESULTS_DIR }}
             run: |
-              source venv.pytest/bin/activate && pytest --timeout=720 -n ${{ inputs.tests_parallel_level }} --show-capture=no -m "${{ inputs.marks }}" --alluredir=${GITHUB_WORKSPACE}/allure-results ${{ inputs.tests_path }}
+              source venv.pytest/bin/activate && pytest --timeout=900 -n ${{ inputs.tests_parallel_level }} --show-capture=no -m "${{ inputs.marks }}" --alluredir=${GITHUB_WORKSPACE}/allure-results ${{ inputs.tests_path }}
             working-directory: neofs-testcases
 
           - name: Publish to NeoFS


### PR DESCRIPTION
Sometimes subprocesses are not terminated by the terminate call. Add timeout for this case and use kill instead.

Also on the latest node - storage nodes fail to stop gracefully, latest messages in the log:

```
info	policer/process.go:15	routine stopped	{"component": "Object Policer"}
info	event/listener.go:221	stop event listener by context	{"reason": "context canceled"}
debug	neofs-node/main.go:101	shutting down pprof service
info	neofs-node/main.go:157	pprof service started successfully
debug	neofs-node/main.go:110	pprof service has been stopped
info	neofs-node/grpc.go:138	stopping gRPC server...	{"name": "NeoFS Control API"}
info	neofs-node/grpc.go:154	gRPC server stopped successfully	{"name": "NeoFS Control API"}
info	neofs-node/storage.go:65	closing components of the storage engine...
debug	blobstor/control.go:44	closing...	{"shard_id": "Zhk5nFGfiWGBLfEe8vGXH"}
info	shard/gc.go:165	waiting for GC workers to stop...
debug	shard/gc.go:151	GC is stopped
warn	shard/gc.go:105	stop event listener by closed channel
debug	blobstor/control.go:44	closing...	{"shard_id": "Nn74icc68kj8hkUqRFUKGP"}
info	shard/gc.go:165	waiting for GC workers to stop...
debug	shard/gc.go:151	GC is stopped
warn	shard/gc.go:105	stop event listener by closed channel
info	neofs-node/storage.go:73	all components of the storage engine closed successfully
info	neofs-node/grpc.go:138	stopping gRPC server...	{"name": "NeoFS Public API"}
info	neofs-node/grpc.go:154	gRPC server stopped successfully	{"name": "NeoFS Public API"}
info	neofs-node/grpc.go:117	stop listening gRPC endpoint	{"endpoint": "127.0.0.1:55649"}
debug	neofs-node/main.go:192	waiting for all processes to stop
```