### PR TITLE
env: use the latest and greatest NeoGo

### DIFF
--- a/neofs-testlib/neofs_testlib/env/templates/neofs_env_config.yaml
+++ b/neofs-testlib/neofs_testlib/env/templates/neofs_env_config.yaml
@@ -41,7 +41,7 @@ binaries:
 
     neo_go:
         repo: 'nspcc-dev/neo-go'
-        version: 'v0.106.3'
+        version: 'v0.107.0'
         file: 'neo-go-{{ arch }}'
 
     neofs_contract:


### PR DESCRIPTION
0.107.0 defines Echidna, so it's important to have it.