### PR TITLE
Add put object delay for some tests

### DIFF
--- a/pytest_tests/tests/s3/test_s3.py
+++ b/pytest_tests/tests/s3/test_s3.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import time
 from random import choice, choices
 
 import allure
@@ -166,6 +167,7 @@ class TestS3(TestNeofsS3Base):
 
         with allure.step("Put several versions of object into bucket"):
             version_id_1 = s3_object.put_object_s3(self.s3_client, bucket, file_name_simple)
+            time.sleep(1)
             generate_file_with_content(simple_object_size, file_path=file_name_simple, content=version_2_content)
             version_id_2 = s3_object.put_object_s3(self.s3_client, bucket, file_name_simple)
 

--- a/pytest_tests/tests/s3/test_s3_locking.py
+++ b/pytest_tests/tests/s3/test_s3_locking.py
@@ -32,8 +32,10 @@ class TestS3Locking(TestNeofsS3Base):
 
         with allure.step("Put several versions of object into bucket"):
             s3_object.put_object_s3(self.s3_client, bucket, file_path)
+            time.sleep(1)
             file_name_1 = generate_file_with_content(simple_object_size, file_path=file_path)
             version_id_2 = s3_object.put_object_s3(self.s3_client, bucket, file_name_1)
+            time.sleep(1)
             check_objects_in_bucket(self.s3_client, bucket, [file_name])
             if version_id:
                 version_id = version_id_2
@@ -45,10 +47,12 @@ class TestS3Locking(TestNeofsS3Base):
                 "RetainUntilDate": date_obj,
             }
             s3_object.put_object_retention(self.s3_client, bucket, file_name, retention, version_id)
+            time.sleep(1)
             assert_object_lock_mode(self.s3_client, bucket, file_name, "COMPLIANCE", date_obj, "OFF")
 
         with allure.step(f"Put legal hold to object {file_name}"):
             s3_object.put_object_legal_hold(self.s3_client, bucket, file_name, "ON", version_id)
+            time.sleep(1)
             assert_object_lock_mode(self.s3_client, bucket, file_name, "COMPLIANCE", date_obj, "ON")
 
         with allure.step("Fail with deleting object with legal hold and retention period"):
@@ -59,9 +63,11 @@ class TestS3Locking(TestNeofsS3Base):
 
         with allure.step("Check retention period is no longer set on the uploaded object"):
             time.sleep((retention_period + 1) * 60)
+            time.sleep(1)
             assert_object_lock_mode(self.s3_client, bucket, file_name, "COMPLIANCE", date_obj, "ON")
 
         with allure.step("Fail with deleting object with legal hold and retention period"):
+            time.sleep(1)
             if version_id:
                 with pytest.raises(Exception):
                     # An error occurred (AccessDenied) when calling the DeleteObject operation (reached max retries: 0): Access Denied.

--- a/pytest_tests/tests/s3/test_s3_object.py
+++ b/pytest_tests/tests/s3/test_s3_object.py
@@ -1,5 +1,6 @@
 import os
 import string
+import time
 import uuid
 from datetime import UTC, datetime, timedelta
 from random import choices, sample
@@ -90,17 +91,20 @@ class TestS3Object(TestNeofsS3Base):
 
         with allure.step("Put object into bucket"):
             s3_object.put_object_s3(self.s3_client, bucket_1, file_name_simple)
+            time.sleep(1)
             bucket_1_objects = [obj_key]
             check_objects_in_bucket(self.s3_client, bucket_1, [obj_key])
 
         with allure.step("Copy one object into the same bucket"):
             copy_obj_path = s3_object.copy_object_s3(self.s3_client, bucket_1, obj_key)
+            time.sleep(1)
             bucket_1_objects.append(copy_obj_path)
             check_objects_in_bucket(self.s3_client, bucket_1, bucket_1_objects)
 
         set_bucket_versioning(self.s3_client, bucket_2, s3_bucket.VersioningStatus.ENABLED)
         with allure.step("Copy object from first bucket into second"):
             copy_obj_path_b2 = s3_object.copy_object_s3(self.s3_client, bucket_1, obj_key, bucket_dst=bucket_2)
+            time.sleep(1)
             check_objects_in_bucket(self.s3_client, bucket_1, expected_objects=bucket_1_objects)
             check_objects_in_bucket(self.s3_client, bucket_2, expected_objects=[copy_obj_path_b2])
 
@@ -111,6 +115,7 @@ class TestS3Object(TestNeofsS3Base):
 
         with allure.step("Copy one object into the same bucket"):
             with pytest.raises(Exception):
+                time.sleep(1)
                 s3_object.copy_object_s3(self.s3_client, bucket_1, obj_key)
 
     @allure.title("Test S3: Checking copy with acl")
@@ -123,6 +128,7 @@ class TestS3Object(TestNeofsS3Base):
 
         with allure.step("Put several versions of object into bucket"):
             s3_object.put_object_s3(self.s3_client, bucket, file_name_simple)
+            time.sleep(1)
             check_objects_in_bucket(self.s3_client, bucket, [obj_key])
 
         with allure.step("Copy object and check acl attribute"):
@@ -142,11 +148,13 @@ class TestS3Object(TestNeofsS3Base):
 
         with allure.step("Put object into bucket"):
             s3_object.put_object_s3(self.s3_client, bucket, file_path, Metadata=object_metadata)
+            time.sleep(1)
             bucket_1_objects = [file_name]
             check_objects_in_bucket(self.s3_client, bucket, bucket_1_objects)
 
         with allure.step("Copy one object"):
             copy_obj_path = s3_object.copy_object_s3(self.s3_client, bucket, file_name)
+            time.sleep(1)
             bucket_1_objects.append(copy_obj_path)
             check_objects_in_bucket(self.s3_client, bucket, bucket_1_objects)
             obj_head = s3_object.head_object_s3(self.s3_client, bucket, copy_obj_path)
@@ -154,6 +162,7 @@ class TestS3Object(TestNeofsS3Base):
 
         with allure.step("Copy one object with metadata"):
             copy_obj_path = s3_object.copy_object_s3(self.s3_client, bucket, file_name, metadata_directive="COPY")
+            time.sleep(1)
             bucket_1_objects.append(copy_obj_path)
             obj_head = s3_object.head_object_s3(self.s3_client, bucket, copy_obj_path)
             assert obj_head.get("Metadata") == object_metadata, f"Metadata must be {object_metadata}"
@@ -167,6 +176,7 @@ class TestS3Object(TestNeofsS3Base):
                 metadata_directive="REPLACE",
                 metadata=object_metadata_1,
             )
+            time.sleep(1)
             bucket_1_objects.append(copy_obj_path)
             obj_head = s3_object.head_object_s3(self.s3_client, bucket, copy_obj_path)
             assert obj_head.get("Metadata") == object_metadata_1, f"Metadata must be {object_metadata_1}"
@@ -182,12 +192,15 @@ class TestS3Object(TestNeofsS3Base):
 
         with allure.step("Put several versions of object into bucket"):
             s3_object.put_object_s3(self.s3_client, bucket, file_path)
+            time.sleep(1)
             s3_object.put_object_tagging(self.s3_client, bucket, file_name_simple, tags=object_tagging)
+            time.sleep(1)
             bucket_1_objects = [file_name_simple]
             check_objects_in_bucket(self.s3_client, bucket, bucket_1_objects)
 
         with allure.step("Copy one object without tag"):
             copy_obj_path = s3_object.copy_object_s3(self.s3_client, bucket, file_name_simple)
+            time.sleep(1)
             got_tags = s3_object.get_object_tagging(self.s3_client, bucket, copy_obj_path)
             assert got_tags, f"Expected tags, got {got_tags}"
             expected_tags = [{"Key": key, "Value": value} for key, value in object_tagging]
@@ -198,6 +211,7 @@ class TestS3Object(TestNeofsS3Base):
             copy_obj_path_1 = s3_object.copy_object_s3(
                 self.s3_client, bucket, file_name_simple, tagging_directive="COPY"
             )
+            time.sleep(1)
             got_tags = s3_object.get_object_tagging(self.s3_client, bucket, copy_obj_path_1)
             assert got_tags, f"Expected tags, got {got_tags}"
             expected_tags = [{"Key": key, "Value": value} for key, value in object_tagging]
@@ -215,6 +229,7 @@ class TestS3Object(TestNeofsS3Base):
                 tagging_directive="REPLACE",
                 tagging=new_tag,
             )
+            time.sleep(1)
             got_tags = s3_object.get_object_tagging(self.s3_client, bucket, copy_obj_path)
             assert got_tags, f"Expected tags, got {got_tags}"
             expected_tags = [{"Key": tag_key, "Value": str(tag_value)}]
@@ -498,6 +513,7 @@ class TestS3Object(TestNeofsS3Base):
 
         with allure.step("Put first object into bucket"):
             s3_object.put_object_s3(self.s3_client, bucket, file_path_1, Metadata=object_1_metadata, Tagging=tag_1)
+            time.sleep(1)
             obj_head = s3_object.head_object_s3(self.s3_client, bucket, file_name)
             assert obj_head.get("Metadata") == object_1_metadata, "Matadata must be the same"
             got_tags = s3_object.get_object_tagging(self.s3_client, bucket, file_name)
@@ -507,6 +523,7 @@ class TestS3Object(TestNeofsS3Base):
         with allure.step("Rewrite file into bucket"):
             file_path_2 = generate_file_with_content(simple_object_size, file_path=file_path_1)
             s3_object.put_object_s3(self.s3_client, bucket, file_path_2, Metadata=object_2_metadata, Tagging=tag_2)
+            time.sleep(1)
             obj_head = s3_object.head_object_s3(self.s3_client, bucket, file_name)
             assert obj_head.get("Metadata") == object_2_metadata, "Matadata must be the same"
             got_tags_1 = s3_object.get_object_tagging(self.s3_client, bucket, file_name)
@@ -527,6 +544,7 @@ class TestS3Object(TestNeofsS3Base):
             version_id_1 = s3_object.put_object_s3(
                 self.s3_client, bucket, file_path_3, Metadata=object_3_metadata, Tagging=tag_3
             )
+            time.sleep(1)
             obj_head_3 = s3_object.head_object_s3(self.s3_client, bucket, file_name_3)
             assert obj_head_3.get("Metadata") == object_3_metadata, "Matadata must be the same"
             got_tags_3 = s3_object.get_object_tagging(self.s3_client, bucket, file_name_3)
@@ -536,6 +554,7 @@ class TestS3Object(TestNeofsS3Base):
         with allure.step("Put new version of file into bucket"):
             file_path_4 = generate_file_with_content(simple_object_size, file_path=file_path_3)
             version_id_2 = s3_object.put_object_s3(self.s3_client, bucket, file_path_4)
+            time.sleep(1)
             versions = s3_object.list_objects_versions_s3(self.s3_client, bucket)
             obj_versions = {version.get("VersionId") for version in versions if version.get("Key") == file_name_3}
             assert obj_versions == {

--- a/pytest_tests/tests/s3/test_s3_tagging.py
+++ b/pytest_tests/tests/s3/test_s3_tagging.py
@@ -1,6 +1,7 @@
 from random import choice
 from string import ascii_letters
 from typing import Tuple
+import time
 
 import allure
 import pytest
@@ -38,6 +39,7 @@ class TestS3Tagging(TestNeofsS3Base):
         with allure.step("Put with 3 tags object into bucket"):
             tag_1 = "Tag1=Value1"
             s3_object.put_object_s3(self.s3_client, bucket, file_path, Tagging=tag_1)
+            time.sleep(1)
             got_tags = s3_object.get_object_tagging(self.s3_client, bucket, file_name)
             assert got_tags, f"Expected tags, got {got_tags}"
             assert got_tags == [{"Key": "Tag1", "Value": "Value1"}], "Tags must be the same"
@@ -45,15 +47,18 @@ class TestS3Tagging(TestNeofsS3Base):
         with allure.step("Put 10 new tags for object"):
             tags_2 = self.create_tags(10)
             s3_object.put_object_tagging(self.s3_client, bucket, file_name, tags=tags_2)
+            time.sleep(1)
             check_tags_by_object(self.s3_client, bucket, file_name, tags_2, [("Tag1", "Value1")])
 
         with allure.step("Put 10 extra new tags for object"):
             tags_3 = self.create_tags(10)
             s3_object.put_object_tagging(self.s3_client, bucket, file_name, tags=tags_3)
+            time.sleep(1)
             check_tags_by_object(self.s3_client, bucket, file_name, tags_3, tags_2)
 
         with allure.step("Copy one object with tag"):
             copy_obj_path_1 = s3_object.copy_object_s3(self.s3_client, bucket, file_name, tagging_directive="COPY")
+            time.sleep(1)
             check_tags_by_object(self.s3_client, bucket, copy_obj_path_1, tags_3, tags_2)
 
         with allure.step("Put 11 new tags to object and expect an error"):
@@ -65,15 +70,18 @@ class TestS3Tagging(TestNeofsS3Base):
         with allure.step("Put empty tag"):
             tags_5 = []
             s3_object.put_object_tagging(self.s3_client, bucket, file_name, tags=tags_5)
+            time.sleep(1)
             check_tags_by_object(self.s3_client, bucket, file_name, [])
 
         with allure.step("Put 10 object tags"):
             tags_6 = self.create_tags(10)
             s3_object.put_object_tagging(self.s3_client, bucket, file_name, tags=tags_6)
+            time.sleep(1)
             check_tags_by_object(self.s3_client, bucket, file_name, tags_6)
 
         with allure.step("Delete tags by delete-object-tagging"):
             s3_object.delete_object_tagging(self.s3_client, bucket, file_name)
+            time.sleep(1)
             check_tags_by_object(self.s3_client, bucket, file_name, [])
 
     @allure.title("Test S3: bucket tagging")


### PR DESCRIPTION
This delay is a temporary solution. It required to be able to get the right order of objects. There is some limitation to understand what object was first in the same second. See https://github.com/nspcc-dev/neofs-s3-gw/pull/1066.

There are two flaky tests

FAILED pytest_tests/tests/s3/test_s3.py::TestS3::test_s3_api_versioning[boto3] - Failed: DID NOT RAISE <class 'Exception'>
FAILED pytest_tests/tests/s3/test_s3.py::TestS3::test_s3_api_object_tagging[boto3] - AssertionError

Note, fails mostly boto3 version, aws-cli a bit more stable. These tests requires separate investigation