### PR TITLE
refactor env usage and fix known issues

### DIFF
--- a/neofs-testlib/neofs_testlib_tests/pytest/test_env.py
+++ b/neofs-testlib/neofs_testlib_tests/pytest/test_env.py
@@ -29,7 +29,7 @@ def neofs_env(request):
     if request.config.getoption("--load-env"):
         neofs_env = NeoFSEnv.load(request.config.getoption("--load-env"))
     else:
-        neofs_env = NeoFSEnv.simple()
+        neofs_env = NeoFSEnv.deploy()
 
     yield neofs_env
 

--- a/pytest_tests/tests/conftest.py
+++ b/pytest_tests/tests/conftest.py
@@ -97,6 +97,13 @@ def neofs_env(temp_directory, artifacts_directory, request):
     neofs_env_finalizer(neofs_env, request)
 
 
+@pytest.fixture(scope="function")
+def neofs_env_function_scope(temp_directory, artifacts_directory, request):
+    neofs_env = get_or_create_neofs_env(request)
+    yield neofs_env
+    neofs_env_finalizer(neofs_env, request)
+
+
 @pytest.fixture()
 def neofs_env_with_writecache(temp_directory, artifacts_directory, request):
     neofs_env = get_or_create_neofs_env(request, writecache=True, with_s3_gw=False, with_rest_gw=False)

--- a/pytest_tests/tests/failovers/test_failover_network.py
+++ b/pytest_tests/tests/failovers/test_failover_network.py
@@ -13,18 +13,20 @@ from helpers.iptables_helper import IpTablesHelper
 from helpers.neofs_verbs import get_netmap_netinfo, get_object, put_object_to_random_node
 from helpers.node_management import storage_node_healthcheck, wait_all_storage_nodes_returned
 from helpers.wellknown_acl import PUBLIC_ACL
-from neofs_env.neofs_env_test_base import NeofsEnvTestBase
-from neofs_testlib.env.env import StorageNode
+from neofs_testlib.env.env import NeoFSEnv, StorageNode
 
 logger = logging.getLogger("NeoLogger")
 blocked_nodes: list[StorageNode] = []
 
 
 @pytest.mark.skipif(sys.platform == "darwin", reason="not supported on macos runners")
-class TestFailoverNetwork(NeofsEnvTestBase):
+class TestFailoverNetwork:
     @allure.step("Restore network")
     @pytest.fixture
-    def restore_network(self):
+    def restore_network(self, neofs_env_function_scope: NeoFSEnv):
+        self.neofs_env = neofs_env_function_scope
+        self.shell = self.neofs_env.shell
+
         yield
 
         not_empty = len(blocked_nodes) != 0

--- a/pytest_tests/tests/network/test_ir_change.py
+++ b/pytest_tests/tests/network/test_ir_change.py
@@ -2,6 +2,7 @@ import json
 import logging
 
 import allure
+import pytest
 from helpers.test_control import wait_for_success
 from helpers.utility import parse_node_height
 from neofs_testlib.cli import NeoGo
@@ -46,6 +47,8 @@ def test_replace_ir_node_from_main_chain(clear_neofs_env: NeoFSEnv):
     neofs_env = clear_neofs_env
     with allure.step("Deploy neofs with 4 ir nodes and main chain"):
         neofs_env.download_binaries()
+        if neofs_env.get_binary_version(neofs_env.neofs_node_path) <= "0.44.2":
+            pytest.skip("Test requires fresh node version")
         neofs_env.deploy_inner_ring_nodes(count=4, with_main_chain=True)
         neofs_env.deploy_storage_nodes(
             count=1,

--- a/pytest_tests/tests/network/test_ir_change.py
+++ b/pytest_tests/tests/network/test_ir_change.py
@@ -43,38 +43,11 @@ def new_pub_key_in_alphabet_pub_keys(neofs_env: NeoFSEnv, neo_go: NeoGo, expecte
     assert expected_key in fschain_alpabet_keys, "new inner ring pub key not in alphabet keys in fschain"
 
 
-def test_replace_ir_node_from_main_chain(clear_neofs_env: NeoFSEnv):
-    neofs_env = clear_neofs_env
-    with allure.step("Deploy neofs with 4 ir nodes and main chain"):
-        neofs_env.download_binaries()
-        if neofs_env.get_binary_version(neofs_env.neofs_node_path) <= "0.44.2":
-            pytest.skip("Test requires fresh node version")
-        neofs_env.deploy_inner_ring_nodes(count=4, with_main_chain=True)
-        neofs_env.deploy_storage_nodes(
-            count=1,
-            node_attrs={
-                0: ["UN-LOCODE:RU MOW", "Price:22"],
-                1: ["UN-LOCODE:RU LED", "Price:33"],
-                2: ["UN-LOCODE:SE STO", "Price:11"],
-                3: ["UN-LOCODE:FI HEL", "Price:44"],
-            },
-        )
-        neofs_env.log_env_details_to_file()
-        neofs_env.log_versions_to_allure()
-
-        neofs_adm = neofs_env.neofs_adm()
-        for sn in neofs_env.storage_nodes:
-            neofs_adm.fschain.refill_gas(
-                rpc_endpoint=f"http://{neofs_env.fschain_rpc}",
-                alphabet_wallets=neofs_env.alphabet_wallets_dir,
-                storage_wallet=sn.wallet.path,
-                gas="10.0",
-            )
-        neofs_env.neofs_adm().fschain.set_config(
-            rpc_endpoint=f"http://{neofs_env.fschain_rpc}",
-            alphabet_wallets=neofs_env.alphabet_wallets_dir,
-            post_data="WithdrawFee=5",
-        )
+def test_replace_ir_node_from_main_chain(neofs_env_4_ir_with_mainchain: NeoFSEnv):
+    neofs_env = neofs_env_4_ir_with_mainchain
+    if neofs_env.get_binary_version(neofs_env.neofs_node_path) <= "0.44.2":
+        pytest.skip("Test requires fresh node version")
+    neofs_adm = neofs_env.neofs_adm()
 
     with allure.step("Deploy new inner ring node"):
         new_inner_ring_node = InnerRing(neofs_env)

--- a/pytest_tests/tests/network/test_ir_controls.py
+++ b/pytest_tests/tests/network/test_ir_controls.py
@@ -39,38 +39,10 @@ def wait_until_node_disappears_from_netmap_snapshot(
     assert offline_node_addr not in netmap_snapshot, f"Node {offline_node_addr} is still in network map"
 
 
-@pytest.fixture(scope="module")
-def multi_ir_neofs_env():
-    neofs_env = NeoFSEnv(neofs_env_config=NeoFSEnv._generate_default_neofs_env_config())
-    with allure.step("Deploy neofs with 4 ir nodes"):
-        neofs_env.download_binaries()
-        neofs_env.deploy_inner_ring_nodes(count=4)
-        neofs_env.deploy_storage_nodes(
-            count=4,
-            node_attrs={
-                0: ["UN-LOCODE:RU MOW", "Price:22"],
-                1: ["UN-LOCODE:RU LED", "Price:33"],
-                2: ["UN-LOCODE:SE STO", "Price:11"],
-                3: ["UN-LOCODE:FI HEL", "Price:44"],
-            },
-        )
-        neofs_env.log_env_details_to_file()
-        neofs_env.log_versions_to_allure()
-
-        neofs_env.neofs_adm().fschain.set_config(
-            rpc_endpoint=f"http://{neofs_env.fschain_rpc}",
-            alphabet_wallets=neofs_env.alphabet_wallets_dir,
-            post_data="ContainerFee=0 ContainerAliasFee=0 MaxObjectSize=524288",
-        )
-        time.sleep(30)
-    yield neofs_env
-    neofs_env.kill()
-
-
-def test_control_notary_request_new_epoch(multi_ir_neofs_env: NeoFSEnv):
-    if multi_ir_neofs_env.get_binary_version(multi_ir_neofs_env.neofs_node_path) <= "0.44.2":
+def test_control_notary_request_new_epoch(neofs_env_4_ir_4_sn: NeoFSEnv):
+    if neofs_env_4_ir_4_sn.get_binary_version(neofs_env_4_ir_4_sn.neofs_node_path) <= "0.44.2":
         pytest.skip("Test requires fresh node version")
-    neofs_env = multi_ir_neofs_env
+    neofs_env = neofs_env_4_ir_4_sn
 
     with allure.step("Create notary request to tick epoch"):
         current_epoch = neofs_epoch.ensure_fresh_epoch(neofs_env)
@@ -130,10 +102,10 @@ def test_control_notary_request_new_epoch(multi_ir_neofs_env: NeoFSEnv):
         ("MaintenanceModeAllowed", True),
     ],
 )
-def test_control_notary_request_new_config_value(multi_ir_neofs_env: NeoFSEnv, key: str, value: Union[str, int, bool]):
-    if multi_ir_neofs_env.get_binary_version(multi_ir_neofs_env.neofs_node_path) <= "0.44.2":
+def test_control_notary_request_new_config_value(neofs_env_4_ir_4_sn: NeoFSEnv, key: str, value: Union[str, int, bool]):
+    if neofs_env_4_ir_4_sn.get_binary_version(neofs_env_4_ir_4_sn.neofs_node_path) <= "0.44.2":
         pytest.skip("Test requires fresh node version")
-    neofs_env = multi_ir_neofs_env
+    neofs_env = neofs_env_4_ir_4_sn
 
     with allure.step("Create notary request to update config value"):
         ir_node = neofs_env.inner_ring_nodes[0]
@@ -175,10 +147,10 @@ def test_control_notary_request_new_config_value(multi_ir_neofs_env: NeoFSEnv, k
     wait_until_new_config_value(neofs_env, CONFIG_KEYS_MAPPING[key], value)
 
 
-def test_control_notary_request_node_removal(multi_ir_neofs_env: NeoFSEnv):
-    if multi_ir_neofs_env.get_binary_version(multi_ir_neofs_env.neofs_node_path) <= "0.44.2":
+def test_control_notary_request_node_removal(neofs_env_4_ir_4_sn: NeoFSEnv):
+    if neofs_env_4_ir_4_sn.get_binary_version(neofs_env_4_ir_4_sn.neofs_node_path) <= "0.44.2":
         pytest.skip("Test requires fresh node version")
-    neofs_env = multi_ir_neofs_env
+    neofs_env = neofs_env_4_ir_4_sn
 
     with allure.step("Create notary request to remove node"):
         ir_node = neofs_env.inner_ring_nodes[0]

--- a/pytest_tests/tests/system/test_sighup.py
+++ b/pytest_tests/tests/system/test_sighup.py
@@ -20,26 +20,8 @@ def is_port_in_use(host: str, port: str) -> bool:
             return False
 
 
-@pytest.fixture
-def clear_neofs_env():
-    neofs_env_config = yaml.safe_load(
-        files("neofs_testlib.env.templates").joinpath("neofs_env_config.yaml").read_text()
-    )
-    neofs_env = NeoFSEnv(neofs_env_config=neofs_env_config)
-    neofs_env.download_binaries()
-    neofs_env.deploy_inner_ring_nodes()
-    neofs_env.deploy_storage_nodes(
-        count=1,
-        node_attrs={
-            0: ["UN-LOCODE:RU MOW", "Price:22"],
-        },
-    )
-    yield neofs_env
-    neofs_env.kill()
-
-
-def test_sighup_fschain_endpoint_reload(clear_neofs_env: NeoFSEnv):
-    neofs_env = clear_neofs_env
+def test_sighup_fschain_endpoint_reload(neofs_env_single_sn: NeoFSEnv):
+    neofs_env = neofs_env_single_sn
 
     with allure.step("Update IR port"):
         ir_config_path = neofs_env.inner_ring_nodes[0].ir_node_config_path
@@ -62,8 +44,8 @@ def test_sighup_fschain_endpoint_reload(clear_neofs_env: NeoFSEnv):
         neofs_env.storage_nodes[0]._wait_until_ready()
 
 
-def test_sighup_node_attrs_update(clear_neofs_env: NeoFSEnv):
-    neofs_env = clear_neofs_env
+def test_sighup_node_attrs_update(neofs_env_single_sn: NeoFSEnv):
+    neofs_env = neofs_env_single_sn
 
     with allure.step("Get current node attributes"):
         node_info = (
@@ -98,8 +80,8 @@ def test_sighup_node_attrs_update(clear_neofs_env: NeoFSEnv):
         assert "UN-LOCODE=FI HEL" in node_info, "node info doesn't contain required attributes"
 
 
-def test_sighup_disable_metrics(clear_neofs_env: NeoFSEnv):
-    neofs_env = clear_neofs_env
+def test_sighup_disable_metrics(neofs_env_single_sn: NeoFSEnv):
+    neofs_env = neofs_env_single_sn
 
     with allure.step("Disable pprof and prometheus"):
         config_path = neofs_env.storage_nodes[0].storage_node_config_path


### PR DESCRIPTION
Move the module scoped vars to function scoped vars, since module scoped vars do not work correctly when running in multithreaded/multiprocessed environments. It caused other tests to fail in case of errors inside test_container_deletion_while_sn_down.