### PR TITLE
ir: drop netmap_cleaner configuration

### DIFF
--- a/neofs-testlib/neofs_testlib/env/templates/ir.yaml
+++ b/neofs-testlib/neofs_testlib/env/templates/ir.yaml
@@ -127,10 +127,6 @@ audit:
 indexer:
   cache_timeout: 15s # Duration between internal state update about current list of inner ring nodes
 
-netmap_cleaner:
-  enabled: true # Enable voting for removing stale storage nodes from network map
-  threshold: 3  # Number of NeoFS epoch without bootstrap request from storage node before it considered stale
-
 settlement:
   basic_income_rate: 0 # Optional: override basic income rate value from network config; applied only in debug mode
   audit_fee: 0         # Optional: override audit fee value from network config; applied only in debug mode


### PR DESCRIPTION
Adapt to https://github.com/nspcc-dev/neofs-node/pull/3304. Shouldn't affect old version since it has some defaults.