### PR TITLE
env/templates: drop IR's estimation managing config

### DIFF
--- a/neofs-testlib/neofs_testlib/env/templates/ir.yaml
+++ b/neofs-testlib/neofs_testlib/env/templates/ir.yaml
@@ -82,9 +82,6 @@ fee:
   main_chain: 0                 # Fixed8 value of extra GAS fee for mainchain contract invocation; ignore if notary is enabled in mainchain
 
 timers:
-  stop_estimation:
-    mul: 1 # Multiplier in x/y relation of when to stop basic income estimation within the epoch
-    div: 4 # Divider in x/y relation of when to stop basic income estimation within the epoch
   collect_basic_income:
     mul: 1 # Multiplier in x/y relation of when to start basic income asset collection within the epoch
     div: 2 # Divider in x/y relation of when to start basic income asset collecting within the epoch


### PR DESCRIPTION
Will not be used in future releases, fails tests for current master. Refs https://github.com/nspcc-dev/neofs-node/pull/3539.