### PR TITLE
tests: remove post-drop access check for ec recovery test

### DIFF
--- a/pytest_tests/tests/container/test_ec_container.py
+++ b/pytest_tests/tests/container/test_ec_container.py
@@ -889,9 +889,6 @@ def test_ec_recovery(
         )
         node_to_drop_object_from = random.choice(nodes_with_object)
         drop_object(node_to_drop_object_from, cid, object_to_recover["id"])
-        object_is_not_accessible(
-            default_wallet.path, cid, object_to_recover["id"], neofs_env, node_to_drop_object_from.endpoint
-        )
 
     with allure.step("Verify main object is still accessible after dropping one part"):
         head_object(


### PR DESCRIPTION
The check is to verify that the drop actually works. But the test actually verifies the ec recovery behavior. We have other tests to verify that the drop functionality works. Otherwise, we would need to have a separate env with a custom policer and we will need to restart all SNs after an object drop to update the policer settings.