### PR TITLE
tests: adjust error messages for deleted object parts

### DIFF
--- a/pytest_tests/tests/object/test_object_api.py
+++ b/pytest_tests/tests/object/test_object_api.py
@@ -948,7 +948,7 @@ class TestObjectApi(TestNeofsBase):
 
         with allure.step("Try to get object parts"):
             for part in parts:
-                with pytest.raises(Exception, match=OBJECT_ALREADY_REMOVED):
+                with pytest.raises(Exception, match=f"({OBJECT_ALREADY_REMOVED}|{OBJECT_NOT_FOUND})"):
                     get_object(
                         default_wallet.path,
                         container,
@@ -997,7 +997,7 @@ class TestObjectApi(TestNeofsBase):
 
         with allure.step("Try to get object parts"):
             for part in parts:
-                with pytest.raises(Exception, match=OBJECT_NOT_FOUND):
+                with pytest.raises(Exception, match=f"({OBJECT_ALREADY_REMOVED}|{OBJECT_NOT_FOUND})"):
                     get_object(
                         default_wallet.path,
                         container,


### PR DESCRIPTION
Object parts can be deleted by GC and they have weak links to the deleted parent, so 2049 is also acceptable here, the main point of the test is that these objects are gone and they are.

closes #1245