### PR TITLE
workflows: use xk6-neofs 0.2.1

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -144,7 +144,7 @@ jobs:
             uses: actions/checkout@v4
             with:
               repository: nspcc-dev/xk6-neofs
-              ref: 'v0.2.0'
+              ref: 'v0.2.1'
               fetch-depth: 0
               fetch-tags: true
               path: xk6-neofs
@@ -153,7 +153,7 @@ jobs:
             uses: dsaltares/fetch-gh-release-asset@1.1.2
             with:
               repo: 'nspcc-dev/xk6-neofs'
-              version: 'tags/v0.2.0'
+              version: 'tags/v0.2.1'
               file: 'xk6-neofs-${{ matrix.binary }}'
               target: 'xk6-neofs/xk6-neofs'
 


### PR DESCRIPTION
Compatible with node 0.51.0.