### PR TITLE
env: check meta legacy version based on an IR version, not SN

### DIFF
--- a/neofs-testlib/neofs_testlib/env/env.py
+++ b/neofs-testlib/neofs_testlib/env/env.py
@@ -1186,7 +1186,7 @@ class InnerRing(ResurrectableProcess):
             ]
 
         chain_meta_data_legacy_format = parse_version(
-            self.neofs_env.get_binary_version(self.neofs_env.neofs_node_path)
+            self.neofs_env.get_binary_version(self.neofs_env.neofs_ir_path)
         ) <= parse_version("0.52.0")
 
         if not os.getenv(f"IR{self.ir_number}_CONFIG_PATH", None):


### PR DESCRIPTION
Not a big deal for automated runs (versions are usually in sync), but took some time to understand why changing local neofs-ir binary with an old neofs-node binary still led to an outdated config generation.