### PR TITLE
workflows: use the latest Go version for builds

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -116,7 +116,7 @@ jobs:
             uses: actions/setup-go@v5
             with:
               cache: true
-              go-version: '1.22'
+              go-version: 'stable'
           - run: go version
 
           - name: Set up Python


### PR DESCRIPTION
1.22 is _very_ old. Just changing the version will get us to the same problem in ~half a year. Using go-version-file with go.mod isn't an option since this worklow runs from testcases that doesn't have any go.mod. But actions/setup-go has a stable alias that should be reasonable for our builds.