### PR TITLE
tests: fix test run cleanup logic

### DIFF
--- a/neofs-testlib/neofs_testlib/env/env.py
+++ b/neofs-testlib/neofs_testlib/env/env.py
@@ -213,8 +213,10 @@ class NeoFSEnv:
             except Exception as e:
                 for ir_node_idx, ir_node in enumerate(self.inner_ring_nodes):
                     temp_logs_dir = self._generate_temp_dir(prefix=f"ir{ir_node_idx}_logs")
-                    shutil.copy(ir_node.stderr, os.path.join(temp_logs_dir, f"ir{ir_node_idx}_stderr.log"))
-                    shutil.copy(ir_node.stdout, os.path.join(temp_logs_dir, f"ir{ir_node_idx}_stdout.log"))
+                    if os.path.isfile(ir_node.stderr):
+                        shutil.copy(ir_node.stderr, os.path.join(temp_logs_dir, f"ir{ir_node_idx}_stderr.log"))
+                    if os.path.isfile(ir_node.stdout):
+                        shutil.copy(ir_node.stdout, os.path.join(temp_logs_dir, f"ir{ir_node_idx}_stdout.log"))
                     zip_path = shutil.make_archive(
                         os.path.join(os.path.dirname(ir_node.stderr), f"ir{ir_node_idx}_logs"), "zip", temp_logs_dir
                     )

--- a/pytest_tests/lib/helpers/common.py
+++ b/pytest_tests/lib/helpers/common.py
@@ -77,4 +77,5 @@ with open(WALLET_CONFIG, "w") as file:
 
 @lru_cache(maxsize=1)
 def get_assets_dir_path() -> str:
-    return os.path.join(os.getcwd(), TEST_RUN_DIR)
+    worker_id = os.getenv("PYTEST_XDIST_WORKER", "master")
+    return os.path.join(os.getcwd(), f"{TEST_RUN_DIR}-{worker_id}-{os.getpid()}")

--- a/pytest_tests/tests/conftest.py
+++ b/pytest_tests/tests/conftest.py
@@ -296,7 +296,7 @@ def artifacts_directory(request, temp_directory: str) -> None:
     if not request.config.getoption("--persist-env") and not request.config.getoption("--load-env"):
         for dir_name in dirs:
             with allure.step(f"Remove {dir_name} directory"):
-                remove_dir(full_path)
+                remove_dir(os.path.join(temp_directory, dir_name))
 
 
 @pytest.fixture(scope="module")
@@ -354,7 +354,6 @@ def file_path(artifacts_directory):
 
 def create_dir(dir_path: str) -> None:
     with allure.step("Create directory"):
-        remove_dir(dir_path)
         Path(dir_path).mkdir(parents=True, exist_ok=True)
 
 


### PR DESCRIPTION
Two test processes managed to start on the same microsecond. This resulted in a non unique test run directory that was cleaned up and caused tests from the second process to fail.